### PR TITLE
Subtitles on multiple rows

### DIFF
--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -3,6 +3,7 @@ BG:	Atanas Kumbarov <kumbarov@gmail.com>
     Georgi Georgiev <georgiev_1994@abv.bg>
 DE:	German Translator Team <celestia-deutsch@gmx.net>
         U. Dickmann / C. Lenz / S. Schreiber / A. Wagner
+        Olaf Senninger <olafsenninger@googlemail.com>
 EL:	Charis Kouzinopoulos <ckouz@uom.gr>
 ES:	Guillermo Abramson <abramson@cab.cnea.gov.ar>
 FR:	Christophe Teyssier <chris@teyssier.org>
@@ -23,13 +24,15 @@ PL:	Michał Trzebiatowski <hippie_1968@hotmail.com>
 PT:	José Raeiro <zeraeiro@gmail.com>
 PT_BR:	Luis Gabriel <lgabriel@brazilmail.com>
         Igor Borgo <igorborgo@gmail.com>
+        Pedro Garcia
 RO:	Oana Radu <oanaradu32@queeq.com>
 RU:	Sergey Leonov <leserg@ua.fm>
+        Askaniy Anpilogov <aaskaniy@gmail.com>
 SV:	Daniel Nylander <po@danielnylander.se>
         Anders Pamdal <anders@pamdal.se>
 UK:	Serhij Dubyk <dubyk@library.lviv.ua>
         Yuri Chornoivan <yurchor@ukr.net>
-ZH_CN:	Markerz Li <markerzli@gmail.com>
+ZH_CN:	Levin Li <lilinfeng303@outlook.com>
 ZH_TW:	An-Li Chen<alchen@tam.gov.tw>
         I-Yuan Chiang <iychiangg1809@gmail.com>
         Lung-Chin Hsieh<lungchin@gmail.com>

--- a/locale/demo_bg.cel
+++ b/locale/demo_bg.cel
@@ -18,9 +18,9 @@
 	wait { duration 1.0 }
 	follow {}
 
-	print { text "В момента се намираме на 12 500 км над Земята" row -3 duration 5 }
+	print { text "В момента се намираме на 12 500 км.\nнад Земята." row -3 duration 5 }
 	orbit { axis [ 0 1 0 ] rate 30 duration 10 }
-	print { text "Като добавим и облаците, Земята изглежда по позната." row -3}
+	print { text "Като добавим и облаците,\nЗемята изглежда по позната." row -3}
 	wait { duration 0.1 }
 	renderflags { set "cloudmaps" }
 	orbit { axis [ 0 1 0 ] rate 30 duration 6 }
@@ -29,17 +29,17 @@
 	select { object "Moon" }
 	goto { time 5 distance 4 upframe "equatorial" }
 	wait { duration 5.5 }
-	print { text "Оглеждайте се за Земята и Слънцето, докато се движим около Луната" row -3}
+	print { text "Оглеждайте се за Земята и Слънцето,\nдокато се движим около Луната." row -3}
 	orbit { axis [ 0 1 0 ] rate 30 duration 10 }
 	
 	print { text "Напред към Слънцето." row -3}
 	select { object "Sol" }
 	goto { time 8 distance 12 upframe "equatorial" up [ 0 1 0 ] }
 	wait { duration 8.5 }
-	print { text "От това разстояние могат да се видят тъмните слънчеви петна по повърхността му." row -3}
+	print { text "От това разстояние могат да се видят тъмните\nслънчеви петна по повърхността му." row -3}
 	orbit { axis [ 0 1 0 ] rate 20 duration 10 }
 
-	print { text "Нека да се отдалечим и разгледаме вътрешната част на Слънчевата система." row -3}
+	print { text "Нека да се отдалечим и разгледаме вътрешната част\nна Слънчевата система." row -3}
 	orbit { axis [ 1 0 0 ] rate 45 duration 2 }
 	renderflags { set "orbits" }
 	changedistance { duration 4.0 rate 1.0 }
@@ -47,10 +47,10 @@
 	print { text "Да включим имената на планетите . . ." row -3}
 	labels { set "planets" }
 	wait { duration 1.0 }
-	print { text "Можем да ускорим времето за да видим как планетите обикалят около Слънцето." row -3}
+	print { text "Можем да ускорим времето за да видим как\nпланетите обикалят около Слънцето." row -3}
 	timerate { rate 2592000 }
 	wait { duration 3.0 }
-	print { text "Всяка секунда в реално време е равна на един месец в симулацията." row -3}
+	print { text "Всяка секунда в реално време е равна на\nедин месец в симулацията." row -3}
 	wait { duration 12.0 }
 	timerate { rate 1 }
 	print { text "В момента, времето е спряно." row -3}
@@ -64,57 +64,57 @@
 	wait { duration 6.5 }
 	renderflags { clear "orbits" }
 	labels { clear "planets" }
-	print { text "Няколко от луните на Сатурн са видими като ярки точки" row -3 duration 3}
+	print { text "Няколко от луните на Сатурн са видими като\nярки точки." row -3 duration 3}
 	orbit { axis [ 0 1 0 ] rate 30 duration 12 }
 	
 	select { object "Mimas" }
 	goto { time 5 distance 4 upframe "equatorial" }
-	print { text "Най-интересната характеристика на Мимас е огромния кратер Хершел." row -3 duration 9 }
+	print { text "Най-интересната характеристика на Мимас е\nогромния кратер Хершел." row -3 duration 9 }
 	orbit { axis [ 0 1 0 ] rate 30 duration 12 }
 	changedistance { duration 6.0 rate 0.5 }
 
 	select { object "Sol" }
 	center { time 2 }
-	print { text "Вижте колко малко изглежда Слънцето от това разстояние." row -3 }
+	print { text "Вижте колко малко изглежда Слънцето\nот това разстояние." row -3 }
 	wait { duration 2 }
 
 	print { text "Нека да разгледаме и другите звезди." row -3 duration 2 }
 	wait { duration 2 }
 	select { object "Alpha UMa" }
 	center { time 2 }
-	print { text "Ако живеете в северното полукълбо, ще разпознаете Колата в съзвездието Голямата мечка." row -3 duration 3 }
+	print { text "Ако живеете в северното полукълбо, ще разпознаете\nКолата в съзвездието Голямата мечка." row -3 duration 3 }
 	wait { duration 4 }
 
 	select { object "Polaris" }
 	center { time 2 }
 	wait { duration 2 }
-	print { text "А това е Поларис, известна още като Северната звезда." row -3}
+	print { text "А това е Поларис, известна още като\nСеверната звезда." row -3}
 	wait { duration 1 }
 	labels { set "stars" }
 	wait { duration 2 }
 	print { text "Поларис е част от Малката мечка." row -3}
 	wait { duration 2 }
-	print { text "За по-добра ориентация в небето, Celestia може да активира диаграмите на съзвездията . . ." row -3}
+	print { text "За по-добра ориентация в небето, Celestia\nможе да активира диаграмите на съзвездията . . ." row -3}
 	renderflags { set "constellations" }
 	wait { duration 2 }
-	print { text ". . . и имената на съзвездията" row -3}
+	print { text ". . . и имената на съзвездията." row -3}
 	labels { set "constellations" }
 	wait { duration 2 }
 
 	select { object "Alnilam" }
 	center { time 4 }
 	wait { duration 2 }
-	print { text "Орион е едно от най-известните съзвездия в небето." row -3 duration 3 }
+	print { text "Орион е едно от най-известните съзвездия\nв небето." row -3 duration 3 }
 	wait { duration 4 }
 
 	select { object "Beta Cru" }
 	center { time 4 }
 	wait { duration 2 }
-	print { text "Ако живеете в южното полукълбо, ще разпознаете съзвездието Южен кръст." row -3 duration 4 }
+	print { text "Ако живеете в южното полукълбо,\nще разпознаете съзвездието Южен кръст." row -3 duration 4 }
 	wait { duration 4 }
 
 	rotate { axis [ 0.707 0.707 0 ] rate 20 duration 7 }
-	print { text "Нека да включим рендерирането на галактиките за да видим Млечния път" row -3 duration 4 }
+	print { text "Нека да включим рендерирането на галактиките\nза да видим Млечния път." row -3 duration 4 }
 	renderflags { set "galaxies" }
 	rotate { axis [ 0.707 0.707 0 ] rate 20 duration 14 }
 	rotate { axis [ 0.707 0.707 0 ] rate 20 duration 10 }
@@ -122,7 +122,7 @@
 	select { object "Antares" }
 	center { time 5 }
 	wait { duration 3 }
-	print { text "Сега ще пътуваме до Антарес, това е звезда червен гигант в съзвездието Скорпион." row -3 duration 5 }
+	print { text "Сега ще пътуваме до Антарес, това е звезда\nчервен гигант в съзвездието Скорпион." row -3 duration 5 }
 	wait { duration 2 }
 	renderflags { clear "constellations" }
 	labels { clear "constellations|stars" }
@@ -131,10 +131,10 @@
 	wait { duration 8.5 }
 	goto { time 5 distance 10 }
 	wait { duration 5.0 }
-	print { text "Въпреки че сме 10 пъти по-далече от Антарес\nотколкото Земята е от Слънцето, масивната звезда червен гигант изглежда застрашително голяма." row -3}
+	print { text "Въпреки че сме 10 пъти по-далече от Антарес\nотколкото Земята е от Слънцето,\nмасивната звезда червен гигант изглежда\n застрашително голяма." row -3}
 	wait { duration 4.0 }
 
-	print { text "Нека да се отдалечим за да видим как изглежда нашата галактика . . ." row -3}
+	print { text "Нека да се отдалечим за да видим\nкак изглежда нашата галактика . . ." row -3}
 	changedistance { duration 10.0 rate 2.0 }
 
 	select { object "Milky Way" }

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -27,12 +27,12 @@ msgstr "عطارد"
 msgid "Venus"
 msgstr "الزهرة"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "الأرض"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "قمر"
 
@@ -48,141 +48,141 @@ msgstr ""
 msgid "Deimos"
 msgstr ""
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "المشتري"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr ""
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "آيو"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "يوروبا"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "جنايميد"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "كاليستو"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "زحل"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "بروميثياس"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "باندورا"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "ايبيماثيوس"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "جينوس"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "ميميس"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr ""
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "تَثيز"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "دايون"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "ريَا"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "تيتان"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "هابريون"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "أيابوتس"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "فيبي"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "أورانس"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr ""
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "أريال"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "أمبيريال"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "تيتانيا"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "أوبيران"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "نبتون"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "لاريسّا"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "بروتياس"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "تراتون"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "نِريد"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 #, fuzzy
 msgid "Pluto-Charon"
 msgstr "بلوتو"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "بلوتو"
 
@@ -191,1034 +191,1293 @@ msgid "Charon"
 msgstr "كارن"
 
 #: ../data/data.cpp:42
-msgid "NORTH AMERICA"
-msgstr "أمريكا الشمالية"
+msgid "Styx"
+msgstr ""
 
 #: ../data/data.cpp:43
-msgid "SOUTH AMERICA"
-msgstr "أمريكا الجنوبية"
+msgid "Nix"
+msgstr ""
 
 #: ../data/data.cpp:44
-msgid "EURASIA"
-msgstr "أوراسيا"
+msgid "Kerberos"
+msgstr ""
 
 #: ../data/data.cpp:45
-msgid "AFRICA"
-msgstr "أفريقيا"
+msgid "Hydra"
+msgstr ""
 
 #: ../data/data.cpp:46
-msgid "AUSTRALIA"
-msgstr "أستراليا"
+msgid "Haumea"
+msgstr ""
 
 #: ../data/data.cpp:47
-msgid "ANTARCTICA"
-msgstr "أنتارتيكا"
+msgid "Namaka"
+msgstr ""
 
 #: ../data/data.cpp:48
-msgid "NORTH ATLANTIC OCEAN"
-msgstr "المحيط الأطلسي الشمالي"
+msgid "Hi'iaka"
+msgstr ""
 
 #: ../data/data.cpp:49
-msgid "SOUTH ATLANTIC OCEAN"
-msgstr "المحيط الأطلسي الجنوبي"
+msgid "Makemake"
+msgstr ""
 
 #: ../data/data.cpp:50
-msgid "NORTH PACIFIC OCEAN"
-msgstr "المحيط الهاديء الشمالي"
+msgid "S-2015 136472 I"
+msgstr ""
 
 #: ../data/data.cpp:51
-msgid "SOUTH PACIFIC OCEAN"
-msgstr "المحيط الهاديء الجنوبي"
+msgid "Eris"
+msgstr ""
 
 #: ../data/data.cpp:52
-msgid "INDIAN OCEAN"
-msgstr "المحيط الهندي"
+msgid "Dysnomia"
+msgstr ""
 
 #: ../data/data.cpp:53
-msgid "ARCTIC OCEAN"
-msgstr "المحيط القطب الشمالي"
+msgid "Metis"
+msgstr ""
 
 #: ../data/data.cpp:54
-msgid "Abu Dhabi"
+msgid "Adrastea"
 msgstr ""
 
 #: ../data/data.cpp:55
-msgid "Abuja"
+msgid "Amalthea"
 msgstr ""
 
 #: ../data/data.cpp:56
-msgid "Accra"
+msgid "Thebe"
 msgstr ""
 
 #: ../data/data.cpp:57
-msgid "Adamstown"
+msgid "Themisto"
 msgstr ""
 
 #: ../data/data.cpp:58
-msgid "Addis Ababa"
+msgid "Leda"
 msgstr ""
 
 #: ../data/data.cpp:59
-msgid "Algiers"
+msgid "Himalia"
 msgstr ""
 
 #: ../data/data.cpp:60
-msgid "Alofi"
+msgid "Lysithea"
 msgstr ""
 
 #: ../data/data.cpp:61
-msgid "Amman"
+msgid "Elara"
 msgstr ""
 
 #: ../data/data.cpp:62
-msgid "Amsterdam"
+msgid "Iocaste"
 msgstr ""
 
 #: ../data/data.cpp:63
-msgid "Andorra la Vella"
+msgid "Praxidike"
 msgstr ""
 
 #: ../data/data.cpp:64
-msgid "Ankara"
+msgid "Harpalyke"
 msgstr ""
 
 #: ../data/data.cpp:65
-msgid "Antananarivo"
+msgid "Ananke"
 msgstr ""
 
 #: ../data/data.cpp:66
-msgid "Apia"
+msgid "Isonoe"
 msgstr ""
 
 #: ../data/data.cpp:67
-msgid "Ashgabat"
+msgid "Erinome"
 msgstr ""
 
 #: ../data/data.cpp:68
-msgid "Asmara"
+msgid "Taygete"
 msgstr ""
 
 #: ../data/data.cpp:69
-msgid "Astana"
+msgid "Chaldene"
 msgstr ""
 
 #: ../data/data.cpp:70
-msgid "Asuncion"
+msgid "Carme"
 msgstr ""
 
 #: ../data/data.cpp:71
-msgid "Athens"
+msgid "Pasiphae"
 msgstr ""
 
 #: ../data/data.cpp:72
-msgid "Avarua"
+msgid "Kalyke"
 msgstr ""
 
 #: ../data/data.cpp:73
-msgid "Baghdad"
+msgid "Megaclite"
 msgstr ""
 
 #: ../data/data.cpp:74
-msgid "Baku"
+msgid "Sinope"
 msgstr ""
 
 #: ../data/data.cpp:75
-msgid "Bamako"
-msgstr ""
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "كاليستو"
 
 #: ../data/data.cpp:76
-msgid "Bandar Seri Begawan"
-msgstr ""
+#, fuzzy
+msgid "Pan"
+msgstr "جينوس"
 
 #: ../data/data.cpp:77
-msgid "Bangkok"
+msgid "Atlas"
 msgstr ""
 
 #: ../data/data.cpp:78
-msgid "Bangui"
-msgstr ""
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
 
 #: ../data/data.cpp:79
-msgid "Banjul"
+msgid "Calypso"
 msgstr ""
 
 #: ../data/data.cpp:80
-msgid "Basse-Terre"
+msgid "Helene"
 msgstr ""
 
 #: ../data/data.cpp:81
-msgid "Basseterre"
+msgid "Cordelia"
 msgstr ""
 
 #: ../data/data.cpp:82
-msgid "Beijing"
+msgid "Ophelia"
 msgstr ""
 
 #: ../data/data.cpp:83
-msgid "Beirut"
+msgid "Bianca"
 msgstr ""
 
 #: ../data/data.cpp:84
-msgid "Belgrade"
+msgid "Cressida"
 msgstr ""
 
 #: ../data/data.cpp:85
-msgid "Belmopan"
+msgid "Desdemona"
 msgstr ""
 
 #: ../data/data.cpp:86
-msgid "Berlin"
+msgid "Juliet"
 msgstr ""
 
 #: ../data/data.cpp:87
-msgid "Bern"
+msgid "Portia"
 msgstr ""
 
 #: ../data/data.cpp:88
-msgid "Bishkek"
+msgid "Rosalind"
 msgstr ""
 
 #: ../data/data.cpp:89
-msgid "Bissau"
+msgid "Belinda"
 msgstr ""
 
 #: ../data/data.cpp:90
-msgid "Bloemfontein"
+msgid "Puck"
 msgstr ""
 
 #: ../data/data.cpp:91
-msgid "Bogota"
+msgid "Caliban"
 msgstr ""
 
 #: ../data/data.cpp:92
-msgid "Brasilia"
+msgid "Stephano"
 msgstr ""
 
 #: ../data/data.cpp:93
-msgid "Bratislava"
+msgid "Sycorax"
 msgstr ""
 
 #: ../data/data.cpp:94
-msgid "Brazzaville"
+msgid "Prospero"
 msgstr ""
 
 #: ../data/data.cpp:95
-msgid "Bridgetown"
+msgid "Setebos"
 msgstr ""
 
 #: ../data/data.cpp:96
-msgid "Brussels"
+msgid "Naiad"
 msgstr ""
 
 #: ../data/data.cpp:97
-msgid "Bucharest"
+msgid "Thalassa"
 msgstr ""
 
 #: ../data/data.cpp:98
-msgid "Budapest"
+msgid "Despina"
 msgstr ""
 
 #: ../data/data.cpp:99
-msgid "Buenos Aires"
-msgstr ""
+#, fuzzy
+msgid "Galatea"
+msgstr "المجرّات"
 
 #: ../data/data.cpp:100
-msgid "Bujumbura"
-msgstr ""
+msgid "NORTH AMERICA"
+msgstr "أمريكا الشمالية"
 
 #: ../data/data.cpp:101
-msgid "Cairo"
-msgstr ""
+msgid "SOUTH AMERICA"
+msgstr "أمريكا الجنوبية"
 
 #: ../data/data.cpp:102
-msgid "Canberra"
-msgstr ""
+msgid "EURASIA"
+msgstr "أوراسيا"
 
 #: ../data/data.cpp:103
-msgid "Cape Town"
-msgstr ""
+msgid "AFRICA"
+msgstr "أفريقيا"
 
 #: ../data/data.cpp:104
-msgid "Caracas"
-msgstr ""
+msgid "AUSTRALIA"
+msgstr "أستراليا"
 
 #: ../data/data.cpp:105
-msgid "Castries"
-msgstr ""
+msgid "ANTARCTICA"
+msgstr "أنتارتيكا"
 
 #: ../data/data.cpp:106
-msgid "Cayenne"
-msgstr ""
+msgid "NORTH ATLANTIC OCEAN"
+msgstr "المحيط الأطلسي الشمالي"
 
 #: ../data/data.cpp:107
-msgid "Charlotte Amalie"
-msgstr ""
+msgid "SOUTH ATLANTIC OCEAN"
+msgstr "المحيط الأطلسي الجنوبي"
 
 #: ../data/data.cpp:108
-msgid "Chisinau"
-msgstr ""
+msgid "NORTH PACIFIC OCEAN"
+msgstr "المحيط الهاديء الشمالي"
 
 #: ../data/data.cpp:109
-msgid "Colombo"
-msgstr ""
+msgid "SOUTH PACIFIC OCEAN"
+msgstr "المحيط الهاديء الجنوبي"
 
 #: ../data/data.cpp:110
-msgid "Conakry"
-msgstr ""
+msgid "INDIAN OCEAN"
+msgstr "المحيط الهندي"
 
 #: ../data/data.cpp:111
-msgid "Copenhagen"
-msgstr ""
+msgid "ARCTIC OCEAN"
+msgstr "المحيط القطب الشمالي"
 
 #: ../data/data.cpp:112
-msgid "Cotonou"
+msgid "Abu Dhabi"
 msgstr ""
 
 #: ../data/data.cpp:113
-msgid "Dakar"
+msgid "Abuja"
 msgstr ""
 
 #: ../data/data.cpp:114
-msgid "Damascus"
+msgid "Accra"
 msgstr ""
 
 #: ../data/data.cpp:115
-msgid "Dar es Salaam"
+msgid "Adamstown"
 msgstr ""
 
 #: ../data/data.cpp:116
-msgid "Dhaka"
+msgid "Addis Ababa"
 msgstr ""
 
 #: ../data/data.cpp:117
-msgid "Dili"
+msgid "Algiers"
 msgstr ""
 
 #: ../data/data.cpp:118
-msgid "Djibouti"
+msgid "Alofi"
 msgstr ""
 
 #: ../data/data.cpp:119
-msgid "Doha"
+msgid "Amman"
 msgstr ""
 
 #: ../data/data.cpp:120
-msgid "Douglas"
+msgid "Amsterdam"
 msgstr ""
 
 #: ../data/data.cpp:121
-msgid "Dublin"
+msgid "Andorra la Vella"
 msgstr ""
 
 #: ../data/data.cpp:122
-msgid "Dushanbe"
+msgid "Ankara"
 msgstr ""
 
 #: ../data/data.cpp:123
-msgid "Fongafale"
+msgid "Antananarivo"
 msgstr ""
 
 #: ../data/data.cpp:124
-msgid "Fort-de-France"
+msgid "Apia"
 msgstr ""
 
 #: ../data/data.cpp:125
-msgid "Freetown"
+msgid "Ashgabat"
 msgstr ""
 
 #: ../data/data.cpp:126
-msgid "Gaborone"
+msgid "Asmara"
 msgstr ""
 
 #: ../data/data.cpp:127
-msgid "George Town"
+msgid "Astana"
 msgstr ""
 
 #: ../data/data.cpp:128
-msgid "Georgetown"
+msgid "Asuncion"
 msgstr ""
 
 #: ../data/data.cpp:129
-msgid "Gibraltar"
+msgid "Athens"
 msgstr ""
 
 #: ../data/data.cpp:130
-msgid "Grand Turk"
+msgid "Avarua"
 msgstr ""
 
 #: ../data/data.cpp:131
-msgid "Guatemala"
+msgid "Baghdad"
 msgstr ""
 
 #: ../data/data.cpp:132
-msgid "Hagatna"
+msgid "Baku"
 msgstr ""
 
 #: ../data/data.cpp:133
-msgid "The Hague"
+msgid "Bamako"
 msgstr ""
 
 #: ../data/data.cpp:134
-msgid "Hamilton"
+msgid "Bandar Seri Begawan"
 msgstr ""
 
 #: ../data/data.cpp:135
-msgid "Hanoi"
+msgid "Bangkok"
 msgstr ""
 
 #: ../data/data.cpp:136
-msgid "Harare"
+msgid "Bangui"
 msgstr ""
 
 #: ../data/data.cpp:137
-msgid "Havana"
+msgid "Banjul"
 msgstr ""
 
 #: ../data/data.cpp:138
-msgid "Helsinki"
+msgid "Basse-Terre"
 msgstr ""
 
 #: ../data/data.cpp:139
-msgid "Honiara"
+msgid "Basseterre"
 msgstr ""
 
 #: ../data/data.cpp:140
-msgid "Islamabad"
+msgid "Beijing"
 msgstr ""
 
 #: ../data/data.cpp:141
-msgid "Jakarta"
+msgid "Beirut"
 msgstr ""
 
 #: ../data/data.cpp:142
-msgid "Jamestown"
+msgid "Belgrade"
 msgstr ""
 
 #: ../data/data.cpp:143
-msgid "Jerusalem"
+msgid "Belmopan"
 msgstr ""
 
 #: ../data/data.cpp:144
-msgid "Kabul"
+msgid "Berlin"
 msgstr ""
 
 #: ../data/data.cpp:145
-msgid "Kampala"
+msgid "Bern"
 msgstr ""
 
 #: ../data/data.cpp:146
-msgid "Kathmandu"
+msgid "Bishkek"
 msgstr ""
 
 #: ../data/data.cpp:147
-msgid "Khartoum"
+msgid "Bissau"
 msgstr ""
 
 #: ../data/data.cpp:148
-msgid "Kiev"
+msgid "Bloemfontein"
 msgstr ""
 
 #: ../data/data.cpp:149
-msgid "Kigali"
+msgid "Bogota"
 msgstr ""
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
-msgid "Kingston"
+#: ../data/data.cpp:150
+msgid "Brasilia"
+msgstr ""
+
+#: ../data/data.cpp:151
+msgid "Bratislava"
 msgstr ""
 
 #: ../data/data.cpp:152
-msgid "Kingstown"
+msgid "Brazzaville"
 msgstr ""
 
 #: ../data/data.cpp:153
-msgid "Kinshasa"
+msgid "Bridgetown"
 msgstr ""
 
 #: ../data/data.cpp:154
-msgid "Koror"
+msgid "Brussels"
 msgstr ""
 
 #: ../data/data.cpp:155
-msgid "Kuala Lumpur"
+msgid "Bucharest"
 msgstr ""
 
 #: ../data/data.cpp:156
-msgid "Kuwait"
+msgid "Budapest"
 msgstr ""
 
 #: ../data/data.cpp:157
-msgid "La'youn"
+msgid "Buenos Aires"
 msgstr ""
 
 #: ../data/data.cpp:158
-msgid "La Paz"
+msgid "Bujumbura"
 msgstr ""
 
 #: ../data/data.cpp:159
-msgid "Libreville"
+msgid "Cairo"
 msgstr ""
 
 #: ../data/data.cpp:160
-msgid "Lilongwe"
+msgid "Canberra"
 msgstr ""
 
 #: ../data/data.cpp:161
-msgid "Lima"
+msgid "Cape Town"
 msgstr ""
 
 #: ../data/data.cpp:162
-msgid "Lisbon"
+msgid "Caracas"
 msgstr ""
 
 #: ../data/data.cpp:163
-msgid "Ljubljana"
+msgid "Castries"
 msgstr ""
 
 #: ../data/data.cpp:164
-msgid "Lobamba"
+msgid "Cayenne"
 msgstr ""
 
 #: ../data/data.cpp:165
-msgid "Lome"
+msgid "Charlotte Amalie"
 msgstr ""
 
 #: ../data/data.cpp:166
-msgid "London"
+msgid "Chisinau"
 msgstr ""
 
 #: ../data/data.cpp:167
-msgid "Longyearbyen"
+msgid "Colombo"
 msgstr ""
 
 #: ../data/data.cpp:168
-msgid "Luanda"
+msgid "Conakry"
 msgstr ""
 
 #: ../data/data.cpp:169
-msgid "Lusaka"
+msgid "Copenhagen"
 msgstr ""
 
 #: ../data/data.cpp:170
-msgid "Luxembourg"
+msgid "Cotonou"
 msgstr ""
 
 #: ../data/data.cpp:171
-msgid "Madrid"
+msgid "Dakar"
 msgstr ""
 
 #: ../data/data.cpp:172
-msgid "Majuro"
+msgid "Damascus"
 msgstr ""
 
 #: ../data/data.cpp:173
-msgid "Malabo"
+msgid "Dar es Salaam"
 msgstr ""
 
 #: ../data/data.cpp:174
-msgid "Male"
+msgid "Dhaka"
 msgstr ""
 
 #: ../data/data.cpp:175
-msgid "Mamoutzou"
+msgid "Dili"
 msgstr ""
 
 #: ../data/data.cpp:176
-msgid "Managua"
+msgid "Djibouti"
 msgstr ""
 
 #: ../data/data.cpp:177
-msgid "Manama"
+msgid "Doha"
 msgstr ""
 
 #: ../data/data.cpp:178
-msgid "Manila"
+msgid "Douglas"
 msgstr ""
 
 #: ../data/data.cpp:179
-msgid "Maputo"
+msgid "Dublin"
 msgstr ""
 
 #: ../data/data.cpp:180
-msgid "Maseru"
+msgid "Dushanbe"
 msgstr ""
 
 #: ../data/data.cpp:181
-msgid "Mata-Utu"
+msgid "Fongafale"
 msgstr ""
 
 #: ../data/data.cpp:182
-msgid "Mbabane"
+msgid "Fort-de-France"
 msgstr ""
 
 #: ../data/data.cpp:183
+msgid "Freetown"
+msgstr ""
+
+#: ../data/data.cpp:184
+msgid "Gaborone"
+msgstr ""
+
+#: ../data/data.cpp:185
+msgid "George Town"
+msgstr ""
+
+#: ../data/data.cpp:186
+msgid "Georgetown"
+msgstr ""
+
+#: ../data/data.cpp:187
+msgid "Gibraltar"
+msgstr ""
+
+#: ../data/data.cpp:188
+msgid "Grand Turk"
+msgstr ""
+
+#: ../data/data.cpp:189
+msgid "Guatemala"
+msgstr ""
+
+#: ../data/data.cpp:190
+msgid "Hagatna"
+msgstr ""
+
+#: ../data/data.cpp:191
+msgid "The Hague"
+msgstr ""
+
+#: ../data/data.cpp:192
+msgid "Hamilton"
+msgstr ""
+
+#: ../data/data.cpp:193
+msgid "Hanoi"
+msgstr ""
+
+#: ../data/data.cpp:194
+msgid "Harare"
+msgstr ""
+
+#: ../data/data.cpp:195
+msgid "Havana"
+msgstr ""
+
+#: ../data/data.cpp:196
+msgid "Helsinki"
+msgstr ""
+
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
+msgid "Honiara"
+msgstr ""
+
+#: ../data/data.cpp:198
+msgid "Islamabad"
+msgstr ""
+
+#: ../data/data.cpp:199
+msgid "Jakarta"
+msgstr ""
+
+#: ../data/data.cpp:200
+msgid "Jamestown"
+msgstr ""
+
+#: ../data/data.cpp:201
+msgid "Jerusalem"
+msgstr ""
+
+#: ../data/data.cpp:202
+msgid "Kabul"
+msgstr ""
+
+#: ../data/data.cpp:203
+msgid "Kampala"
+msgstr ""
+
+#: ../data/data.cpp:204
+msgid "Kathmandu"
+msgstr ""
+
+#: ../data/data.cpp:205
+msgid "Khartoum"
+msgstr ""
+
+#: ../data/data.cpp:206
+msgid "Kiev"
+msgstr ""
+
+#: ../data/data.cpp:207
+msgid "Kigali"
+msgstr ""
+
+#: ../data/data.cpp:208 ../data/data.cpp:209
+msgid "Kingston"
+msgstr ""
+
+#: ../data/data.cpp:210
+msgid "Kingstown"
+msgstr ""
+
+#: ../data/data.cpp:211
+msgid "Kinshasa"
+msgstr ""
+
+#: ../data/data.cpp:212
+msgid "Koror"
+msgstr ""
+
+#: ../data/data.cpp:213
+msgid "Kuala Lumpur"
+msgstr ""
+
+#: ../data/data.cpp:214
+msgid "Kuwait"
+msgstr ""
+
+#: ../data/data.cpp:215
+msgid "La'youn"
+msgstr ""
+
+#: ../data/data.cpp:216
+msgid "La Paz"
+msgstr ""
+
+#: ../data/data.cpp:217
+msgid "Libreville"
+msgstr ""
+
+#: ../data/data.cpp:218
+msgid "Lilongwe"
+msgstr ""
+
+#: ../data/data.cpp:219
+msgid "Lima"
+msgstr ""
+
+#: ../data/data.cpp:220
+msgid "Lisbon"
+msgstr ""
+
+#: ../data/data.cpp:221
+msgid "Ljubljana"
+msgstr ""
+
+#: ../data/data.cpp:222
+msgid "Lobamba"
+msgstr ""
+
+#: ../data/data.cpp:223
+msgid "Lome"
+msgstr ""
+
+#: ../data/data.cpp:224
+msgid "London"
+msgstr ""
+
+#: ../data/data.cpp:225
+msgid "Longyearbyen"
+msgstr ""
+
+#: ../data/data.cpp:226
+msgid "Luanda"
+msgstr ""
+
+#: ../data/data.cpp:227
+msgid "Lusaka"
+msgstr ""
+
+#: ../data/data.cpp:228
+msgid "Luxembourg"
+msgstr ""
+
+#: ../data/data.cpp:229
+msgid "Madrid"
+msgstr ""
+
+#: ../data/data.cpp:230
+msgid "Majuro"
+msgstr ""
+
+#: ../data/data.cpp:231
+msgid "Malabo"
+msgstr ""
+
+#: ../data/data.cpp:232
+msgid "Male"
+msgstr ""
+
+#: ../data/data.cpp:233
+msgid "Mamoutzou"
+msgstr ""
+
+#: ../data/data.cpp:234
+msgid "Managua"
+msgstr ""
+
+#: ../data/data.cpp:235
+msgid "Manama"
+msgstr ""
+
+#: ../data/data.cpp:236
+msgid "Manila"
+msgstr ""
+
+#: ../data/data.cpp:237
+msgid "Maputo"
+msgstr ""
+
+#: ../data/data.cpp:238
+msgid "Maseru"
+msgstr ""
+
+#: ../data/data.cpp:239
+msgid "Mata-Utu"
+msgstr ""
+
+#: ../data/data.cpp:240
+msgid "Mbabane"
+msgstr ""
+
+#: ../data/data.cpp:241
 #, fuzzy
 msgid "Mexico City"
 msgstr "إظهار مواقع المدن"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr ""
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr ""
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr ""
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr ""
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr ""
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr ""
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr ""
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr ""
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr ""
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr ""
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr ""
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 #, fuzzy
 msgid "New Delhi"
 msgstr "اسم جديد"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr ""
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr ""
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr ""
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr ""
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr ""
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr ""
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr ""
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr ""
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr ""
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr ""
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr ""
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr ""
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr ""
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr ""
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr ""
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr ""
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr ""
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr ""
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr ""
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr ""
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 #, fuzzy
 msgid "Port-au-Prince"
 msgstr "وحدة قياس فضائية"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr ""
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr ""
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr ""
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr ""
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr ""
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr ""
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr ""
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr ""
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr ""
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr ""
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr ""
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr ""
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr ""
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr ""
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr ""
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr ""
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr ""
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr ""
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr ""
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr ""
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr ""
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr ""
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr ""
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr ""
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr ""
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr ""
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr ""
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr ""
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr ""
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr ""
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr ""
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr ""
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr ""
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr ""
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr ""
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr ""
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr ""
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr ""
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr ""
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr ""
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr ""
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr ""
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr ""
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr ""
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr ""
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr ""
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr ""
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr ""
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr ""
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr ""
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr ""
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr ""
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr ""
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr ""
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr ""
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr ""
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr ""
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr ""
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr ""
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 #, fuzzy
 msgid "Vatican City"
 msgstr "إظهار مواقع المدن"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr ""
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr ""
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr ""
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr ""
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr ""
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr ""
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr ""
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 #, fuzzy
 msgid "West Island"
 msgstr "الغرب"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr ""
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr ""
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr ""
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr ""
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr ""
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr ""
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr ""
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr ""
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr ""
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr ""
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 #, fuzzy
 msgid "Solar System Barycenter"
 msgstr "نقطة منتصف نظام النجوم\n"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr ""
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr ""
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "خطأ في فتح الصورة "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "خطأ في قراءة ملف التركيبة"
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1228,87 +1487,58 @@ msgstr ""
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr "الفضاء\tالمتجمد"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "تشغيل جزئية برنامج  NV:"
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "خطأ في تشغيل جزئية برنامج NV:"
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "خطأ في برنامج القطعة "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "تشغيل جزئية برنامج NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "تم تحميل جميع جزئيات برامج NV بنجاح.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "تشغيل جزئية برنامج ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "مجرة (نوع Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "تحميل صورة من ملف "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr "نوع الصورة غير مدعوم أو غير معروف.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "خطأ في فتح الصورة "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "ليس ملف من نوع PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "خطأ في قراءة ملف من نوع PNG"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "تحميل نموذج : "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "خطأ في تحميل النموذج '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 #, fuzzy
 msgid "Nebula"
 msgstr "إظهار لوحات اسماء السديم"
@@ -1318,454 +1548,390 @@ msgstr "إظهار لوحات اسماء السديم"
 msgid "Open cluster"
 msgstr "إظهار أسماء المجموعات المفتوحة"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "خطأ في ملف من نوع .ssc (السطر"
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "تحذير، تعريف مكرر من "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "سطح بديل سيء"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "موقع سيء"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "عنوان رئسي سيء للفهرس المتقاطع\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "تشغيل الفهرس المتقاطع فشل في السجل "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr "النجوم في قاعدة البيانات الثنائية\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "إجمالي عدد النجوم: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "خطأ في ملف من نوع .stc (السطر"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "نجمة غير صحيحة : نوع الطيف سيء.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "نجمة غير صحيحة : نوع الطيف مفقود.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " غير موجود.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "نجمة غير صحيحة: المطلع المستقيم مفقود\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "نجمة غير صحيحة: البعد الزاوي مفقود\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "نجمة غير صحيحة: المسافة مفقودة\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "نجمة غير صحيحة: مقدار مفقود\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr ""
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "تشغيل برنامج القمة NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "خطأ في تشغيل برنامج القمة NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "خطأ في برنامج القمة "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "تشغير برنامج قمة ARB: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "خطأ في تشغيل برنامج قمة ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", السطر"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "تشغيل برنامج القمة NV ...\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "تم تشغيل جميع برامج المقة NV بنجاح.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "تشغيل برنامج القمة ARB . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "تم تشغيل جميع برامج المقة ARB بنجاح.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "خطأ في الفتح "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "خطأ في قراءة ملف من نوع PNG"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "خطأ في قراءة المفضلة."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "خطأ في فتح مستند."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "خطأ في فتح المستند '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "خطأ غير معروف في فتح المستند"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "خطأ في انشاء مستند برنامج جزئي"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "نوع الملف خاطئ"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "حد المقدار: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "تفعيل المعلّم"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "تبطيل المعلّم"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "ذهاب الى السطح"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 #, fuzzy
 msgid "Alt-azimuth mode enabled"
 msgstr "وضعية منظار Alt-azimuth"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 #, fuzzy
 msgid "Alt-azimuth mode disabled"
 msgstr "وضعية منظار Alt-azimuth"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "طراز النجمة: نقاط غير واضحة"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "طراز النجمة: نقاط"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "طراز النجمة: اسطوانات من القشرة الجافة"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "تفعيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "تبطيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "مسار التمثيل: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "تفعيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "تبطيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "المقدار الآلي مفعل"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "المقدار الآلي معطل"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "إلغاء الامر"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "تم إيقاف الوقت والمستند مؤقتا"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "تم إيقاف الوقت مؤقتا"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "استئناف"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "إجمالي عدد النجوم: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "إجمالي عدد النجوم: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "وقت انتقال الضوء %.4f سنة "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "وقت انتقال الضوء %d دقيقة %.1f ثانية"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "وقت انتقال الضوء %d ساعة %d دقيقة %.1f ثانية"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "تأخير وقت انتقال الضوء متضمن"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "تأخير وقت انتقال الضوء مغلق"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "وقت انتقال الضوء مهمل"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "استعمال قوام السطح الطبيعي."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "استعمال قوام سطح حد المعرفة."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "يتبع"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "الوقت: تقدم"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "الوقت: تراجع"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "معدل الإطار"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "&ضئيل"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "&متوسط"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "استعمال قوام سطح حد المعرفة."
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 #, fuzzy
 msgid "Sync Orbit"
 msgstr "مدار مصاحب"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "قفل"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "ملاحقة"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "حد المقدار: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "حد المقدار الآلي عند 45 درجة: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, fuzzy, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "&الضوء البيئي"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "إكساب الضوء"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 #, fuzzy
 msgid "Bloom enabled"
 msgstr "تفعيل المعلّم"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 #, fuzzy
 msgid "Bloom disabled"
 msgstr "تبطيل المعلّم"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "خطأ GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "العرض صغير جداً ليقسم"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "العرض المضاف"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 #, fuzzy
 msgid "ly"
@@ -1773,411 +1939,451 @@ msgstr "مجرة (نوع Hubble: %s)"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "وحدة قياس فضائية"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " الأيام"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " الساعات"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " الدقائق"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "ضبط الوقت..."
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr "مجرة (نوع Hubble: %s)"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr "وحدة قياس فضائية"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr "مجرة (نوع Hubble: %s)"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "السرعة: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "القطر الظاهر: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "المقدار الظاهر: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "القيمة المطلقة: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "المسافة: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "نقطة منتصف نظام النجوم\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (app) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "اللمعان: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "نجم نيوترون"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "فجوة سوداء"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "الفصل: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "حرارة السطح: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "تواجد كواكب مرافقه\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "المسافة من المركز: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "درجة الحرارة: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "الوقت الحقيقي"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-الوقت الحقيقي"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "تم ايقاف الوقت"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " أسرع"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " أبطأ"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (ايقاف موقت)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "الانتقال "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "الانتقال "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "تتبع "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "يتبع "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "مدار مصاحب"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "ملاحقة "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 #, fuzzy
 msgid "Sun"
 msgstr "رسومات\tCtrl+X"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "اسم الهدف: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " ايقاف مؤقت"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  تسجيل"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 بدأ/ايقاف مؤقت    F12 ايقاف"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "وضع التنسيق"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "تحميل دليل النظام الشمسي: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "تحميل دليل النظام الشمسي: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "خطأ في قراءة ملف التركيبة"
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 #, fuzzy
 msgid "Initialization of SPICE library failed."
 msgstr "خطأ في انشاء مستند برنامج جزئي"
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "لا يمكن قراءة قاعدة بيانات النجمة"
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "خطأ في تحميل دليل النظام الشمسي.\n"
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "لا يمكن قراءة قاعدة بيانات النجمة"
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "خطأ في تحميل دليل النظام الشمسي.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "خطأ في فتح ملف الشكل النجمي."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "خطأ في فتح ملف حدود الابراج."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "فشل في انشاء الممثل"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "خطأ في تحميل الخط; النص سيكون غير مرئي.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "خطأ في قراءة الفهرس المتقاطع "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "الفهرس المتقاطع محمل "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "خطأ في قراءة ملف اسماء النجوم\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "خطأ في الفتح "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "خطأ في قراءة ملف اسماء النجوم\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "خطأ في قراءة ملف النجوم\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "خطأ في فتح دليل النجوم "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "خطأ في فتح المستند '%s'"
+msgid "%s Version: %s\n"
+msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "خطأ غير معروف في فتح المستند"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "فشل في انشاء الممثل"
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "فشل في انشاء الممثل"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "استعمال قوام سطح حد المعرفة."
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2372,14 +2578,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, fuzzy, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "التقاط &فيديو...\tShift+F10"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 msgid "Internal Ogg library error.\n"
 msgstr ""
 
@@ -2395,46 +2601,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "المتصفح السماوي"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "المتصفح السماوي"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "نظام الخلية الشمسية"
 
@@ -2444,21 +2641,20 @@ msgstr "نظام الخلية الشمسية"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "النجوم"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "العناصر المعلّمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "كاشف الكسوف أو الخسوف"
@@ -2467,462 +2663,511 @@ msgstr "كاشف الكسوف أو الخسوف"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "وقت"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "مرشد الجولة"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "شاشة كاملة"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "التقاط &فيديو...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "خطأ في فتح ملف الشكل النجمي."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&إضافة مفضلة..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "انتزاع صورة"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "ليس ملف من نوع PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 #, fuzzy
 msgid "Capture Video"
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 msgid "Video (*.avi)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 msgid "Video (*.ogv)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "الدقة"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "معدل الإطار"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 #, fuzzy
 msgid "Copied URL"
 msgstr "ادخل الموقع"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "ابدأ وانتقل الى الموقع"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&فتح مستند..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "إنشاء مجلد مفضلة جديد في هذه القائمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "خطأ غير معروف في فتح المستند"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+msgid "supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+msgid "not supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "عن Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>لغة تظليل OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "فشل في انشاء الممثل"
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 غير ممتد</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "<b>مجمعات NVIDIA ، لا يوجد برامج قمة</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "استعمال قوام سطح حد المعرفة."
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "حجم المميزات الأقل"
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "حجم المميزات الأقل"
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "نصف القطر: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "معلومات عن OpenGL"
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "فشل في انشاء الممثل"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&ملف"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "انتزاع صورة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "التقاط &فيديو...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "نسخ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "نسخ"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "ادخل الموقع"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&فتح مستند..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "خيارات Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "خ&روج"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "رسومات\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&ملاحة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&اختيار"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&الاختيار المركزي\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "الاختيار: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "الذهاب إلى عنصر..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&وقت"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "ضبط الوقت..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "عرض"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "العناصر المعلّمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "إظهار ظل الكسوف أو الخسوف"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "طر&از النجمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "الدقة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&التحكم"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&المفضلة"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&عرض"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "عرض متعدد"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "تقسيم العرض عامودياً"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "تقسيم أفقي\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "تقسيم العرض أفقياً"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "تقسيم عامودي\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "عرض كامل"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "عرض وحيد"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&عرض وحيد"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "حذف العرض"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "حذف"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "الإطارات مرئية"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "الإطارات الفعّالة مرئية"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "تزامن الوقت"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&مساعدة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "خيارات Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "عن Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "معلومات عن OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&إضافة مفضلة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&تنظيم المفضلة..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "التحميل قائم "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 #, fuzzy
 msgid "Scripts"
 msgstr "&فتح مستند..."
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 msgid "Description"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&المفضلة"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "القائمة الأساسية"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "خطأ في قراءة المفضلة."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "المفضلة"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "ضبط وقت المحاكاة"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "ضبط وقت المحاكاة"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "وقت"
@@ -2931,76 +3176,74 @@ msgstr "وقت"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "مجلد جديد..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 msgid "Galactic coordinate grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr ", السطر"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 msgid "Horizontal coordinate grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr ", السطر"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 msgid "M"
 msgstr ""
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "المعلّم"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&الاختيار المركزي\tC"
@@ -3009,57 +3252,54 @@ msgstr "&الاختيار المركزي\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "برج فلكي"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>مجمعات NVIDIA ، لا يوجد برامج قمة</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "حدود البرج الفلكي"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "موافق"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "المسارات"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "الكواب"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #, fuzzy
 msgid "Dwarf Planets"
 msgstr "مع الكواكب"
@@ -3070,19 +3310,17 @@ msgstr "مع الكواكب"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "الأقمار"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #, fuzzy
 msgid "Minor Moons"
 msgstr "الأقمار"
@@ -3093,12 +3331,12 @@ msgstr "الأقمار"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "الكويكبات"
 
@@ -3108,12 +3346,12 @@ msgstr "الكويكبات"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "المذنبات"
 
@@ -3123,14 +3361,15 @@ msgstr "المذنبات"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "المركبات الفضائية"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "&أسرع بـ 10 أضعاف\tL"
@@ -3139,9 +3378,8 @@ msgstr "&أسرع بـ 10 أضعاف\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "أسماء"
 
@@ -3149,20 +3387,18 @@ msgstr "أسماء"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "المجرّات"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 #, fuzzy
 msgid "Globulars"
 msgstr "إظهار النجوم"
@@ -3171,7 +3407,7 @@ msgstr "إظهار النجوم"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3181,622 +3417,639 @@ msgstr "المجموعات المفتوحة"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "السديم"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "المواقع"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "المجموعات المفتوحة"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "سحب"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "أنوار الجانب المظلم"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "أذيال المذنبات"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "الغلاف الجوي"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "ظلال الحلقة"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "ظلال الكسوف أو الخسوف"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 #, fuzzy
 msgid "Cloud Shadows"
 msgstr "ظلال الحلقة"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 #, fuzzy
 msgid "Low"
 msgstr "&ضئيل"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 #, fuzzy
 msgid "Medium"
 msgstr "&متوسط"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "المقدار الآلي\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "نجوم مرئية أكثر\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "نجوم مرئية أقل\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&نقاط"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&نقاط غير واضحة"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "الأقراص الممدة"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "تأخير وقت انتقال الضوء مغلق"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "تفعيل ذيل المذنب"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "حد المقدار الآلي عند 45 درجة: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "حد المقدار: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "الاسم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 #, fuzzy
 msgid "Distance (ly)"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 #, fuzzy
 msgid "App. mag"
 msgstr "مقدار البرنامج"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 #, fuzzy
 msgid "Abs. mag"
 msgstr "القيمة المطلقة"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "النوع"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "السطوع"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "تصفية النجوم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 #, fuzzy
 msgid "With Planets"
 msgstr "مع الكواكب"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "نقطة المنتصف "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "تحديث"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&تحديد"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "أقصى عدد عرض للنجوم في القائمة"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&تحديد"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "المعلّم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "لا شيء"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "جوهرة"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "مثلث"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "مربع"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "زائد"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "اختيار &عنصر"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "اختيار &عنصر"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "مميزات الأسماء"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "عناصر"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&تحديد"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "بدن الأصل '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "البدء بشاشة كاملة"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "كسوف الشمس"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "كسوف الشمس"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "إلغاء التحديد &للكل"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "بحث"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "خسوف القمر"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "اختيار &عنصر"
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "كسوف الشمس"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "ضبط الوقت للوقت الآن"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, qt-format
 msgid "Near %1"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "ذهاب الى السطح"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, qt-format
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&معلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&معلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "المسافة: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "الحجم:"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "نص المعلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "وحدة قياس فضائية"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "طر&از النجمة"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "إظهار الوقت المحلي"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "منطقة الوقت"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "البدء"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3815,21 +4068,21 @@ msgid "&Select"
 msgstr "&اختيار"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&المركز"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&ذهاب الى"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&التابع"
 
@@ -3843,51 +4096,56 @@ msgid "Visible"
 msgstr "الإطارات الفعّالة مرئية"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&إلغاء التحديد"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "نمط عرض الاختيار"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 #, fuzzy
 msgid "Filled Square"
 msgstr "مربع"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&تحديد"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "&نقاط غير واضحة"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "بدن الأصل '"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "الإطارات الفعّالة مرئية"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "إظهار النجوم"
@@ -3895,193 +4153,41 @@ msgstr "إظهار النجوم"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "الملف الإضافي %1 غير موجود"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "أسطح بديلة"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "عادي"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "مركبة فضائية"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "عناصر"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "ضبط الوقت..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "منطقة الوقت"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-#, fuzzy
-msgid "Universal Time"
-msgstr "تم إيقاف الوقت مؤقتا"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "الوقت المحلي"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "منطقة الوقت"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "تاريخ"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "ضبط الوقت..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "ضبط الوقت..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "ضبط الوقت..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&وقت"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " الساعات"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " الدقائق"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "ضبط الوقت..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-#, fuzzy
-msgid "Julian Date: "
-msgstr "تاريخ/وقت"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "ضبط التاريخ و ذهاب إلى كوكب"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "ضبط الوقت..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "نقطة المنتصف "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "كوكب"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "كوكب"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "الأقمار"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "كويكب"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "مذنب"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&نقاط غير واضحة"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "حساب"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "ذهاب الى السطح"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "خطأ غير معروف في فتح المستند"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "الكويكبات"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&نقاط غير واضحة"
+msgid "Dwarf planets"
+msgstr "مع الكواكب"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4089,67 +4195,237 @@ msgstr "&نقاط غير واضحة"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "الأقمار"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "مركبة فضائية"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "عناصر"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "ضبط الوقت..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "منطقة الوقت"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+#, fuzzy
+msgid "Universal Time"
+msgstr "تم إيقاف الوقت مؤقتا"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "الوقت المحلي"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "منطقة الوقت"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "تاريخ"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "ضبط الوقت..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "ضبط الوقت..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "ضبط الوقت..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&وقت"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " الساعات"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " الدقائق"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "ضبط الوقت..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+#, fuzzy
+msgid "Julian Date: "
+msgstr "تاريخ/وقت"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "ضبط التاريخ و ذهاب إلى كوكب"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "ضبط الوقت..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "نقطة المنتصف "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "كوكب"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "كوكب"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "الأقمار"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "كويكب"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "مذنب"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&نقاط غير واضحة"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "حساب"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "ذهاب الى السطح"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "خطأ غير معروف في فتح المستند"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "الكويكبات"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&نقاط غير واضحة"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "مميزات اخرى"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "الكواب"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "عناصر"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "عكس الوقت"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "أبطأ بـ 10 مرات\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " أبطأ"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "ايقاف الوقت مؤقتاً"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " أسرع"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "&أسرع بـ 10 أضعاف\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "ضبط إلى الوقت الحالي"
@@ -4221,7 +4497,6 @@ msgstr "العرض: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "انصاف الاقطار"
 
@@ -4242,7 +4517,7 @@ msgstr "الدقة"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "تنظيم المفضلة"
 
@@ -4273,18 +4548,6 @@ msgstr "خيارات Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "عناصر"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "مع الكواكب"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4375,14 +4638,13 @@ msgstr "جزء المسار المنحني"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 #, fuzzy
 msgid "Equatorial"
 msgstr "إظهار النجوم"
@@ -4390,7 +4652,6 @@ msgstr "إظهار النجوم"
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 #, fuzzy
 msgid "Ecliptic"
 msgstr ", السطر"
@@ -4398,7 +4659,6 @@ msgstr ", السطر"
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 #, fuzzy
 msgid "Galactic"
 msgstr "المجرّات"
@@ -4406,7 +4666,6 @@ msgstr "المجرّات"
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 #, fuzzy
 msgid "Horizontal"
 msgstr "تقسيم العرض أفقياً"
@@ -4414,14 +4673,12 @@ msgstr "تقسيم العرض أفقياً"
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "Boundaries"
 msgstr "إظهار الحدود الفاصلة"
@@ -4457,7 +4714,6 @@ msgstr "إظهار أسماء المواقع"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "مدن"
 
@@ -4471,21 +4727,18 @@ msgstr "مواقع الهبوط"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "مراصد"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "فوهة بركان"
 
@@ -4520,7 +4773,6 @@ msgstr "البحار"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "مميزات اخرى"
 
@@ -4625,7 +4877,7 @@ msgstr "تاريخ"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 #, fuzzy
 msgid "Settings"
 msgstr "إضافة أوضاع المفضلة للمستند الحالي"
@@ -4869,21 +5121,21 @@ msgid "&About Celestia"
 msgstr "&عن Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "موافق"
 
@@ -4892,371 +5144,311 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
-msgid "Copyright (C) 2001-2019, Celestia Development Team"
+msgid "1.7.0"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:74
-msgid "https://celestia.space/"
+msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:75
+msgid "https://celestia.space/"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia هو برنامج مجاني ويأتي بدون أي ضمان بالتأكيد"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "المؤلفون"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "اختيار عنصر"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "اسم العنصر"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "الرخصة"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "تحكم Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "معلومات جهاز OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "ضبط وقت المحاكاة"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-#, fuzzy
-msgid "Format: "
-msgstr "إظهار الوقت المحلي"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "ضبط إلى الوقت الحالي"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "اضافة مفضلة"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "انشاء في >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "مجلد جديد..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "باحث نظام الخلية الشمسية"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&ذهاب إلى"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "عناصر نظام الخلية الشمسية"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "باحث النجوم"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "الأقرب"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "السطوع"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "مع الكواكب"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&تحديث"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "معيار بحث النجوم"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "أقصى عدد عرض للنجوم في القائمة"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "مرشد الجولة"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "ذهاب إلى"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "اختيار وجهتك:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "ذهاب إلى عنصر"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "عنصر"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "خط الطول"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "خط العرض"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "المسافة"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "الحجم:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "نمط عرض الاختيار"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "الدقة"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "خيارات العرض"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "إظهار"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "عرض"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#, fuzzy
-msgid "Ecliptic Line"
-msgstr ", السطر"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "المدارات / أسماء"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#, fuzzy
-msgid "Latin Names"
-msgstr ""
-"_:أسماء المترجمين \\n Ali Al-Khudair, Hussain Al-Ghamdi, Abdullah Al-Ghamdi"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "نص المعلومات"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "مصقول"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "مضجر"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "مواقع الهبوط"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "الجبال"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "البحار"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "الوديان"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "اثار التعرية"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "مميزات الأسماء"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "مميزات العرض"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-#, fuzzy
-msgid "Show Label"
-msgstr "مميزات الأسماء"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "الميزة المعلّمة الأقل حجماً"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:96
 msgid "Add New Bookmark Folder"
 msgstr "إضافة مجلد مفضلة جديد"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:99
 msgid "Folder Name"
 msgstr "مجلد جديد"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "إعادة تسمية..."
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "تحكم Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "إعادة تسمية مفضلة أو مجلد"
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "نمط عرض الاختيار"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "اسم جديد"
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "الدقة"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/win32/res/resource_strings.cpp:106
 msgid "Eclipse Finder"
 msgstr "كاشف الكسوف أو الخسوف"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:107
 msgid "Compute"
 msgstr "حساب"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:108
 msgid "Set Date and Go to Planet"
 msgstr "ضبط التاريخ و ذهاب إلى كوكب"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:109
 msgid "Close"
 msgstr "إغلاق"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:110
 #, fuzzy
 msgid "From:"
 msgstr "المسافة من المركز: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:111
 msgid "To:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:112
 msgid "On:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:113
 msgid "Search parameters"
 msgstr "البحث عن العوامل"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "كسوف الشمس"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "اختيار عنصر"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "اسم العنصر"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "معلومات جهاز OpenGL"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "ذهاب إلى عنصر"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "ذهاب إلى"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "عنصر"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "خط الطول"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "خط العرض"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "المسافة"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "الرخصة"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "مميزات العرض"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
-msgid "Lunar Eclipses"
-msgstr "كسوف الشمس"
+msgid "Show Label"
+msgstr "مميزات الأسماء"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "الميزة المعلّمة الأقل حجماً"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "الحجم:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "إعادة تسمية..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "إعادة تسمية مفضلة أو مجلد"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "اسم جديد"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "ضبط وقت المحاكاة"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+#, fuzzy
+msgid "Format: "
+msgstr "إظهار الوقت المحلي"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "ضبط إلى الوقت الحالي"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "باحث نظام الخلية الشمسية"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&ذهاب إلى"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "عناصر نظام الخلية الشمسية"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "باحث النجوم"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&تحديث"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "معيار بحث النجوم"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "أقصى عدد عرض للنجوم في القائمة"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "مرشد الجولة"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "اختيار وجهتك:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "خيارات العرض"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "إظهار"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "عرض"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "المدارات / أسماء"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "نص المعلومات"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "401"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 #, fuzzy
 msgid "Jan"
 msgstr "جينوس"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 #, fuzzy
 msgid "Mar"
 msgstr "المريخ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 #, fuzzy
 msgid "May"
 msgstr ""
@@ -5264,195 +5456,338 @@ msgstr ""
 "البدء سوف يكمل, لكن البرنامج سوف يفقد بعض البياناتوبعض الملفات لن تقوم "
 "بالعمل بالشكل المطلوب, تأكد من التحميل"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 #, fuzzy
 msgid "Nov"
 msgstr "الآن"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 #, fuzzy
 msgid "Oct"
 msgstr "عنصر"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 #, fuzzy
 msgid "Sep"
 msgstr "ضبط"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr ""
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "تاريخ"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "البدء"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+#, fuzzy
+msgid "Windowed Mode"
+msgstr "وضع التشكيل الثلاثي الابعاد"
+
+#: ../src/celestia/win32/winmain.cpp:1445
+#, fuzzy
+msgid "Invisibles"
+msgstr "الإطارات الفعّالة مرئية"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+#, fuzzy
+msgid "S&ync Orbit"
+msgstr "تزام%ن اختيار المسارات\tY"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&معلومات"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+#, fuzzy
+msgid "Show Body Axes"
+msgstr "بدن الأصل '"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+#, fuzzy
+msgid "Show Frame Axes"
+msgstr "الإطارات الفعّالة مرئية"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+#, fuzzy
+msgid "Show Sun Direction"
+msgstr "إظهار النجوم"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+#, fuzzy
+msgid "Show Velocity Vector"
+msgstr "إظهار النجوم"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+#, fuzzy
+msgid "Show Planetographic Grid"
+msgstr "إظهار النجوم"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+#, fuzzy
+msgid "Show Terminator"
+msgstr "إظهار النجوم"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:645
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
 #, fuzzy
-msgid "Renderer: "
-msgstr "فشل في انشاء الممثل"
+msgid "Loading: "
+msgstr "التحميل قائم "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "ar"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+#, fuzzy
+msgid "Loading URL"
+msgstr "إذهب إلى &موقع..."
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 #, fuzzy
 msgid "Version: "
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/win32/winmain.cpp:660
-#, fuzzy
-msgid "GLSL version: "
-msgstr "اصدار سيء للفهرس المتقاطع\n"
-
-#: ../src/celestia/win32/winmain.cpp:671
-#, fuzzy
-msgid "Max simultaneous textures: "
-msgstr "استعمال قوام سطح حد المعرفة."
-
-#: ../src/celestia/win32/winmain.cpp:678
-#, fuzzy
-msgid "Max texture size: "
-msgstr "حجم المميزات الأقل"
-
-#: ../src/celestia/win32/winmain.cpp:687
-#, fuzzy
-msgid "Max cube map size: "
-msgstr "حجم المميزات الأقل"
-
-#: ../src/celestia/win32/winmain.cpp:695
-#, fuzzy
-msgid "Point size range: "
-msgstr "حجم المميزات الأقل"
-
-#: ../src/celestia/win32/winmain.cpp:700
-#, fuzzy
-msgid "Supported Extensions:"
-msgstr "اصدار سيء للفهرس المتقاطع\n"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-#, fuzzy
-msgid "Windowed Mode"
-msgstr "وضع التشكيل الثلاثي الابعاد"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-#, fuzzy
-msgid "Invisibles"
-msgstr "الإطارات الفعّالة مرئية"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-#, fuzzy
-msgid "S&ync Orbit"
-msgstr "تزام%ن اختيار المسارات\tY"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&معلومات"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-#, fuzzy
-msgid "Show Body Axes"
-msgstr "بدن الأصل '"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-#, fuzzy
-msgid "Show Frame Axes"
-msgstr "الإطارات الفعّالة مرئية"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-#, fuzzy
-msgid "Show Sun Direction"
-msgstr "إظهار النجوم"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-#, fuzzy
-msgid "Show Velocity Vector"
-msgstr "إظهار النجوم"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-#, fuzzy
-msgid "Show Planetographic Grid"
-msgstr "إظهار النجوم"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-#, fuzzy
-msgid "Show Terminator"
-msgstr "إظهار النجوم"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr ""
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr ""
-
-#: ../src/celestia/win32/winmain.cpp:3194
-#, fuzzy
-msgid "Loading: "
-msgstr "التحميل قائم "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "ar"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-#, fuzzy
-msgid "Loading URL"
-msgstr "إذهب إلى &موقع..."
-
-#: ../src/celestia/win32/winmain.cpp:4006
-#, fuzzy
-msgid "Error opening script"
-msgstr "خطأ في فتح المستند '%s'"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-#, fuzzy
-msgid "Error loading script"
-msgstr "خطأ في تحميل النموذج '"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-#, fuzzy
-msgid "Running script"
-msgstr "&فتح مستند..."
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 #, fuzzy
 msgid "Time Zone Name"
 msgstr "منطقة الوقت"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 #, fuzzy
 msgid "UTC Offset"
 msgstr "UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "خطأ في فتح مستند."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "خطأ غير معروف في فتح المستند"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "خطأ في فتح المستند '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "خطأ في انشاء مستند برنامج جزئي"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "خطأ في فتح المستند '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "خطأ غير معروف في فتح المستند"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "خطأ في الفتح "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "تشغيل جزئية برنامج  NV:"
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "خطأ في تشغيل جزئية برنامج NV:"
+
+#~ msgid "Error in fragment program "
+#~ msgstr "خطأ في برنامج القطعة "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "تشغيل جزئية برنامج NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "تم تحميل جميع جزئيات برامج NV بنجاح.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "تشغيل جزئية برنامج ARB . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr "نوع الصورة غير مدعوم أو غير معروف.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "تشغيل برنامج القمة NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "خطأ في تشغيل برنامج القمة NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "خطأ في برنامج القمة "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "تشغير برنامج قمة ARB: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "خطأ في تشغيل برنامج قمة ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", السطر"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "تشغيل برنامج القمة NV ...\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "تم تشغيل جميع برامج المقة NV بنجاح.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "تشغيل برنامج القمة ARB . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "تم تشغيل جميع برامج المقة ARB بنجاح.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "خطأ غير معروف في فتح المستند"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "نسخ"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "ادخل الموقع"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "تفعيل ذيل المذنب"
+
+#~ msgid "Nearest"
+#~ msgstr "الأقرب"
+
+#~ msgid "Brightest"
+#~ msgstr "السطوع"
+
+#~ msgid "With planets"
+#~ msgstr "مع الكواكب"
+
+#, fuzzy
+#~ msgid "Ecliptic Line"
+#~ msgstr ", السطر"
+
+#, fuzzy
+#~ msgid "Latin Names"
+#~ msgstr ""
+#~ "_:أسماء المترجمين \\n Ali Al-Khudair, Hussain Al-Ghamdi, Abdullah Al-"
+#~ "Ghamdi"
+
+#~ msgid "Terse"
+#~ msgstr "مصقول"
+
+#~ msgid "Verbose"
+#~ msgstr "مضجر"
+
+#~ msgid "Landing Sites"
+#~ msgstr "مواقع الهبوط"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "الجبال"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "البحار"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "الوديان"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "اثار التعرية"
+
+#~ msgid "Label Features"
+#~ msgstr "مميزات الأسماء"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "كسوف الشمس"
+
+#, fuzzy
+#~ msgid "Lunar Eclipses"
+#~ msgstr "كسوف الشمس"
+
+#, fuzzy
+#~ msgid "GLSL version: "
+#~ msgstr "اصدار سيء للفهرس المتقاطع\n"
+
+#, fuzzy
+#~ msgid "Supported Extensions:"
+#~ msgstr "اصدار سيء للفهرس المتقاطع\n"
+
+#, fuzzy
+#~ msgid "Error opening script"
+#~ msgstr "خطأ في فتح المستند '%s'"
+
+#, fuzzy
+#~ msgid "Error loading script"
+#~ msgstr "خطأ في تحميل النموذج '"
+
+#, fuzzy
+#~ msgid "Running script"
+#~ msgstr "&فتح مستند..."
 
 #, fuzzy
 #~ msgid "Small Body"

--- a/po/be.po
+++ b/po/be.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2019-02-14 22:00+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Belarusian (https://www.transifex.com/celestia/teams/93131/"
@@ -32,12 +32,12 @@ msgstr "Мэркуры"
 msgid "Venus"
 msgstr "Вэнэра"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Зямля"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Месяц"
 
@@ -53,140 +53,140 @@ msgstr "Фобас"
 msgid "Deimos"
 msgstr "Дэймас"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Юпітэр"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Амальтэя"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Іо"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Эўропа"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ганімэд"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Каліста"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Сатурн"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Прамэтэй"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Пандора"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Эпімэтэй"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Янус"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Мімас"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Энцэляд"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Тэфія"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Дыёна"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Рэя"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Тытан"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Гіпэрыён"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Япэт"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Фэба"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Уран"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Міранда"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Арыель"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Умбрыель"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Тытанія"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Абэрон"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Нэптун"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Лярыса"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Пратэй"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Трытон"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Нэрэіда"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Плютон-Харон"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Плютон"
 
@@ -195,1028 +195,1290 @@ msgid "Charon"
 msgstr "Харон"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Нумэа"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Бамака"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Амальтэя"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Каліста"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Сту"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Порт-Віла"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Ґаляктыкі"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "ПАЎНОЧНАЯ АМЭРЫКА"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "ПАЎДНЁВАЯ АМЭРЫКА"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "ЭЎРАЗІЯ"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "АФРЫКА"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "АЎСТРАЛІЯ"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "АНТАРКТЫКА"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ПАЎНОЧНЫ АТЛЯНТЫЧНЫ АКІЯН"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ПАЎДНЁВЫ АТЛЯНТЫЧНЫ АКІЯН"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ПАЎНОЧНЫ ЦІХІ АКІЯН"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ПАЎДНЁВЫ ЦІХІ АКІЯН"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "ІНДЫЙСКІ АКІЯН"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "ПАЎНОЧНА-ЛЕДАВІТЫ АКІЯН"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Абу Дабі"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Акра"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Адамстаўн"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Адыс Абэба"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Альжыр"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Алофі"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Аман"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Амстэрдам"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Андора-ля-Вэлья"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Анкара"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Антанарыва"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Апія"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ашгабад"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Асмара"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Астана"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Асунсьён"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Афіны"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Баку"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Бамака"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Бандар Сэры Бэґаван"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Банґкок"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Банґі"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Банжул"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Бас-Тэр"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Бастэр"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Пэкін"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Бэйрут"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Бялград"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Бэльмапан"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Бэрлін"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Бэрн"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Бішкек"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Бісаў"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Блюмфантэйн"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Баґота"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Бразылія"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Братыслава"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Бразавіль"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Брыджтаўн"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Брусэль"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Бухарэст"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Будапэшт"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Буэнас Айрэс"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Каір"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Канбэра"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Кэйптаўн"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Каракас"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Кастрыз"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Каена"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Шарлёт Амалія"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Кішынёў"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Калёмба"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Конакры"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Капэнгаґен"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Катону"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Дакар"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Дар-эс-Салям"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Дака"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Дылі"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Джыбуці"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Дога"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Дуґлас"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Дублін"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Душанбэ"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Фанґафале"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Форт-дэ-Франс"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Фрытаўн"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Ґабаронэ"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "Джордж Таўн"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Джорджтаўн"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Ґібралтар"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Ґранд Турк"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Ґватэмала"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Гаґатна"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Гааґа"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Ґамільтан"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Харарэ"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Гавана"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Гельсынкі"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Ганіяра"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Ісламабад"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Джэймстаўн"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Ерусалім"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Кабул"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Кампала"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Кіеў"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Кіґалі"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Кінґстан"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Кінґстаўн"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Кіншаса"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Корар"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Куара Люмпур"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Кувэйт"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "Эль-Аюн"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "Ля Пас"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Лібрэвіль"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Лілонґвэ"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Ліма"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Лісабон"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Лабамба"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Ломэ"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Лёндан"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Лонґ'ір"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Луанда"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Люксэмбурґ"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Мадрыд"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Маджура"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Малаба"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Малі"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Манаґуа"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Манама"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Маніла"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Мапута"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Масэру"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Мбабанэ"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Мэхіка"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Менск"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Маґадышу"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Манака"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Манровія"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Монтэвідэа"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Мароні"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Масква"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Маскат"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Найробі"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Насаў"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Нджамэна"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Нью Дэлі"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Ньямэ"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Нікасія"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Нумэа"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Нуук"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Араньестад"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Осла"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Атава"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Уаґудуґу"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Паґа Паґа"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Палікір"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Панама"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Папээтэ"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Парамарыба"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Парыж"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Пнам Пень"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Плімут"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Порт Луі"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Порт Морсбі"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Порт-о-Прэнс"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Порт-оф-Спэйн"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Порта-Нова"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Порт-Віла"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Прага"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Прая"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Прэторыя"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Пхеньян"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Кіта"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Рабат"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Ранґун"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Рэйк'явік"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Рыга"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Рыяд"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Роўд Таўн"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Рым"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Разо"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Сэнт Джорджэс"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Сэнт Гэльер"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Сэнт Джонс"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Сэнт-Пітэр-Порт"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Сэн Дэні"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Сэн П'ер"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "Сан Хасэ"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "Сан Хуан"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "Сан Марына"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "Сан Сальвадор"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Сана"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Сант'яґа"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Санта Дамінґа"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Сан Тамэ"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Сараева"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Сэул"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "Сэтльмэнт"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Сынґапут"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Скоп'е"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Сафія"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шры-Джаявардэнэпура-Катэ"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Стэнлі"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Стакгольм"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Сукрэ"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Сува"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Тайпэй"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Талін"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Тарава"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Тбілісі"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Тэґусыґальпа"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Тэгеран"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Тэль Авіў"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Тымбу"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Тырана"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Токіё"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Торсгаўн"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Трыпалі"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Туніс"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Уланбатар"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Валета"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "Вэлі"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Ватыкан"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Вікторыя"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Вена"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Віенцьян"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Вільня"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Вашынґтон"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Вэлінґтан"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "Вэст Айлэнд"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Вілемстад"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Віндгук"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Ямусукра"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Яундэ"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Ярэн"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Ерыван"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Заграб"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Млечны шлях"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "ММВ"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "ВМВ"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Барыцэнтар сонечнай сыстэмы"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Памылка адкрыцьця файла відарыса «%s»\n"
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Памылка падчас чытаньня файла настаўленьняў."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1226,87 +1488,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr "Загружага %i аб'ектаў глыбокага космасу\n"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Загрузка фраґмэнтавых праґрамаў NV: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Памылка падчас загрузкі фраґмэнтавай праґрамы NV: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Памылка ў праґраме фраґмэнтаў"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Ініцыялізаваньне фраґмэнтавых праґрамаў NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Усе фраґмэнтавыя праґрамы NV загружаныя ўдала.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Ініцыялізаваньне праґрамаў фраґмэнтаў ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Ґаляктыка (Габлаў тып: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Шаравае скопішча (радыюс ядра: %4.2f', канцэнтрацыя Кінґа: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, c-format
 msgid "Loading image from file %s\n"
 msgstr "Загрузка відарыса з файла %s\n"
 
-#: ../src/celengine/image.cpp:337
-#, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr "%s: тып відарысаў не распазнаны або не падтрымліваецца.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, c-format
 msgid "Error opening image file %s\n"
 msgstr "Памылка адкрыцьця файла відарыса «%s»\n"
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "Памылка : %s не зьяўляецца файлам PNG file.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Памылка чытаньня файла відарыса PNG %s\n"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, c-format
 msgid "Loading model: %s\n"
 msgstr "Загрузка мадэлі: %s\n"
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Памылка загрузкі мадэлі «%s»\n"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Туманнасьць"
 
@@ -1314,92 +1547,92 @@ msgstr "Туманнасьць"
 msgid "Open cluster"
 msgstr "Адкрытае скопішча"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Памылка ў фале .ssc (радок %d): "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "бацькоўскае цела «%s» аб'екта «%s» не адшуканае.\n"
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "заўвага, падвоенае азначэньне %s %s\n"
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "кепская дадатковая паверхня"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "кепскае месца"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Кепскі загаловак для перакрыжаванай спасылкі\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Кепская вэрсія для перакрыжаванай спасылкі\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Загрузка перакрыжаваных спасылак пацярпела няўдачу на запісе %u\n"
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Кепскі спэктральны тып у базе зорак, зорка #%u\n"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, c-format
 msgid "%d stars in binary database\n"
 msgstr "%d зорак у двайковай базе\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, c-format
 msgid "Total star count: %d\n"
 msgstr "Агульная колькасьць зорак: %d\n"
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Памылка ў фале .stc (радок %i): %s\n"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Недапушчальная зорка: кепскі спэктральны тып.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Недапушчальная зорка: спэктральны тып адсутнічае.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr "Барыцэнтар «%s» не існуе.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Недапушчальная зорка: адсутнічае правільнае ўзыходжаньне\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Недапушчальная зорка: адсутнічае схіленьне.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Недапушчальная зорка: адсутнічае адлегласьць.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Недапушчальная зорка: адсутнічае яркасьць.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1407,765 +1640,727 @@ msgstr ""
 "Недапушчальная зорка: абсалтная (ня бачная) велічыня мусіць быць вызначаная "
 "для зорак, блізкіх да пачатку\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Стварэньне мазаічнай тэкстуры. Шырыня=%i, макс=%i\n"
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Стварэньне звычайнае тэкстуры: %i×%i\n"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Загрузка вяршыневых праґрамаў NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Памылка падчас загрузкі вяршыневай праґрамы NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Памылка ў вяршыневай праґраме"
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Загрузка вяршыневых праґрамаў ARB: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Памылка падчас загрузкі вяршыневай праґрамы ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", радок "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Ініцыялізаваньне вяршыневых праґрамаў NV . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Усе вяршыневыя праґрамы NV загружаныя ўдала.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Ініцыялізаваньне вяршыневых праґрамаў ARB . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Усе вяршыневыя праґрамы ARB загружаныя ўдала.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr ""
 "Памылка адкрыцьця %s\n"
 "\n"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Памылка чытаньня файла відарыса PNG %s\n"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr "Кепскі двайковы файл xyzv %s.\n"
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr "Парадак байтаў %i не падтрымліваецца, чакаўся %i.\n"
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr "Колькасьць лічбаў %i не падтрымліваецца, чакалася %i.\n"
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Памылка падчас чытаньня файла абранага."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-"%s\n"
-"Арыентацыя: [%f, %f, %f], %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Памылка падчас адкрыцьця файла сцэнара."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Памылка падчас адкрыцьця сцэнара «%s»"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Невядомая памылка падчас адкрыцьця сцэнара"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Памылка падчас ініцыялізацыі супраграмы сцэнара"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Недапушчальны тып файла"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Граніца яркасьці: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Пазнакі задзейнічаныя"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Пазнакі абязьдзейненыя"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Перайсьці на паверхню"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Рэжым «Вышыня-Азімут» задзейнічаны"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Рэжым «Вышыня-Азімут» абязьдзейнены"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Стыль зорак: размытыя кропкі"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Стыль зорак: кропкі"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Стыль зорак: маштабаваныя дыскі"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Хвасты камэт задзейнічаныя"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Хвасты камэт абязьдзейненыя"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Спосаб пабудовы: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 msgid "Anti-aliasing enabled"
 msgstr "Згладжваньне задзейнічана"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 msgid "Anti-aliasing disabled"
 msgstr "Згладжваньне абязьдзейнена"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Аўтаяркасьць задзейнічаная"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Аўтаяркасьць абязьдзейненая"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Адмяніць"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Час і сцэнар прыпыненыя"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Хада часу прыпыненая"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Працяг"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 msgid "Star color: Blackbody D65"
 msgstr "Колер зорак: чорнае цела D65"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 msgid "Star color: Enhanced"
 msgstr "Колер зорак: пашыраны"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Сьвятло даходзіць за:  %.4f с.г."
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Сьвятло даходзіць за:  %d хв  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Сьвятло даходзіць за:  %d гадз  %d хв  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Час руху сьвятла ўключаецца"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Затрымка руху сьвятла ня ўлучаная"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Час руху сьвятла іґнаруецца"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Ужываюцца нармальныя тэкстуры паверхняў."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Ужываюцца тэкстуры паверхняў з абмежаваньнем ведаў."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Ісьці ўсьлед"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Час: наперад"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Час: назад"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "Хуткасьць часу: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 msgid "Low res textures"
 msgstr "Тэкстуры нізкага разрозьненьня"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 msgid "Medium res textures"
 msgstr "Тэкстуры сярэдняга разрозьненьня"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 msgid "High res textures"
 msgstr "Тэкстуры высокага разрозьненьня"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Сынхранізаваць арбіту"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Захапіць"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Даганяць"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Абмежаваньне велічыні:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Гранічная аўтаяркасьць пры 45°:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Узровень расьсеянага сьвятла:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Узмацненьне сьвятла"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Эфэкт «bloom» задзейнічаны"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Эфэкт «bloom» абязьдзейнены"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Насьвятленьне"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Памылка GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Прагляд замалы, каб яго модна было падзяліць"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Даданы прагляд"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr "Мпк"
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr "кпк"
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "с.г."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "аа"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr "дзён"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr "гадзін"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 msgid "minutes"
 msgstr "хвіліны"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 msgid "seconds"
 msgstr "сэкунды"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Пэрыяд авароту: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2821
-msgid "m/s"
-msgstr "м/с"
+#: ../src/celestia/celestiacore.cpp:2456
+#, fuzzy, c-format
+msgid "Mass: %.6g kg\n"
+msgstr "Маса:%.2f зямных\n"
 
-#: ../src/celestia/celestiacore.cpp:2823
-msgid "km/s"
-msgstr "км/с"
+#: ../src/celestia/celestiacore.cpp:2458
+#, fuzzy, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr "Маса:%.2f зямных\n"
 
-#: ../src/celestia/celestiacore.cpp:2827
-msgid "AU/s"
-msgstr "АА/с"
-
-#: ../src/celestia/celestiacore.cpp:2829
-msgid "ly/s"
-msgstr "с.г./с"
-
-#: ../src/celestia/celestiacore.cpp:2831
-#, c-format
-msgid "Speed: %s %s\n"
-msgstr "Хуткасьць: %s %s\n"
-
-#: ../src/celestia/celestiacore.cpp:2895
-#, c-format
-msgid "Apparent diameter: %s\n"
-msgstr "Бачны дыямэтар: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:2908
-#, c-format
-msgid "Apparent magnitude: %.1f\n"
-msgstr "Бачная велічыня: %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:2912
-#, c-format
-msgid "Absolute magnitude: %.1f\n"
-msgstr "Абсалютная велічыня: %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:2992
-#, c-format
-msgid "%.6f%c %.6f%c %f km"
-msgstr "%.6f%c %.6f%c %f км"
-
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
-#, c-format
-msgid "Distance: %s\n"
-msgstr "Адлегласьць: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3022
-msgid "Star system barycenter\n"
-msgstr "Барыцэнтар сонечнай сыстэмы\n"
-
-#: ../src/celestia/celestiacore.cpp:3026
-#, c-format
-msgid "Abs (app) mag: %.2f (%.2f)\n"
-msgstr "Абс (бач) вел: %.2f (%.2f)\n"
-
-#: ../src/celestia/celestiacore.cpp:3032
-#, c-format
-msgid "Luminosity: %sx Sun\n"
-msgstr "Сьвятлівасьць: %s сонечных\n"
-
-#: ../src/celestia/celestiacore.cpp:3038
-msgid "Neutron star"
-msgstr "Нэўтронная зорка"
-
-#: ../src/celestia/celestiacore.cpp:3041
-msgid "Black hole"
-msgstr "Чорная дзірка"
-
-#: ../src/celestia/celestiacore.cpp:3046
-#, c-format
-msgid "Class: %s\n"
-msgstr "Кляса: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3053
-#, c-format
-msgid "Surface temp: %s K\n"
-msgstr "Тэмпэратура паверхні: %s K\n"
-
-#: ../src/celestia/celestiacore.cpp:3058
-#, c-format
-msgid "Radius: %s Rsun  (%s km)\n"
-msgstr "Радыюс: %s сонечных  (%s км)\n"
-
-#: ../src/celestia/celestiacore.cpp:3064
-#, c-format
-msgid "Radius: %s km\n"
-msgstr "Радыюс: %s км\n"
-
-#: ../src/celestia/celestiacore.cpp:3080
-msgid "Planetary companions present\n"
-msgstr "Наяўныя плянэтныя спадарожнікі\n"
-
-#: ../src/celestia/celestiacore.cpp:3096
-#, c-format
-msgid "Distance from center: %s\n"
-msgstr "Адлегласьць ад цэнтру: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
-#, c-format
-msgid "Radius: %s\n"
-msgstr "Радыюс %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3168
-#, c-format
-msgid "Phase angle: %.1f%s\n"
-msgstr "Фазавы вугал: %.1f%s\n"
-
-#: ../src/celestia/celestiacore.cpp:3180
+#: ../src/celestia/celestiacore.cpp:2460
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Маса:%.2f зямных\n"
 
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2471
+msgid "m/s"
+msgstr "м/с"
+
+#: ../src/celestia/celestiacore.cpp:2476
+msgid "km/s"
+msgstr "км/с"
+
+#: ../src/celestia/celestiacore.cpp:2486
+msgid "AU/s"
+msgstr "АА/с"
+
+#: ../src/celestia/celestiacore.cpp:2491
+msgid "ly/s"
+msgstr "с.г./с"
+
+#: ../src/celestia/celestiacore.cpp:2494
+#, c-format
+msgid "Speed: %s %s\n"
+msgstr "Хуткасьць: %s %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2558
+#, c-format
+msgid "Apparent diameter: %s\n"
+msgstr "Бачны дыямэтар: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2571
+#, c-format
+msgid "Apparent magnitude: %.1f\n"
+msgstr "Бачная велічыня: %.1f\n"
+
+#: ../src/celestia/celestiacore.cpp:2575
+#, c-format
+msgid "Absolute magnitude: %.1f\n"
+msgstr "Абсалютная велічыня: %.1f\n"
+
+#: ../src/celestia/celestiacore.cpp:2655
+#, c-format
+msgid "%.6f%c %.6f%c %f km"
+msgstr "%.6f%c %.6f%c %f км"
+
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
+#, c-format
+msgid "Distance: %s\n"
+msgstr "Адлегласьць: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Star system barycenter\n"
+msgstr "Барыцэнтар сонечнай сыстэмы\n"
+
+#: ../src/celestia/celestiacore.cpp:2689
+#, c-format
+msgid "Abs (app) mag: %.2f (%.2f)\n"
+msgstr "Абс (бач) вел: %.2f (%.2f)\n"
+
+#: ../src/celestia/celestiacore.cpp:2695
+#, c-format
+msgid "Luminosity: %sx Sun\n"
+msgstr "Сьвятлівасьць: %s сонечных\n"
+
+#: ../src/celestia/celestiacore.cpp:2701
+msgid "Neutron star"
+msgstr "Нэўтронная зорка"
+
+#: ../src/celestia/celestiacore.cpp:2704
+msgid "Black hole"
+msgstr "Чорная дзірка"
+
+#: ../src/celestia/celestiacore.cpp:2709
+#, c-format
+msgid "Class: %s\n"
+msgstr "Кляса: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2716
+#, c-format
+msgid "Surface temp: %s K\n"
+msgstr "Тэмпэратура паверхні: %s K\n"
+
+#: ../src/celestia/celestiacore.cpp:2721
+#, c-format
+msgid "Radius: %s Rsun  (%s km)\n"
+msgstr "Радыюс: %s сонечных  (%s км)\n"
+
+#: ../src/celestia/celestiacore.cpp:2727
+#, c-format
+msgid "Radius: %s km\n"
+msgstr "Радыюс: %s км\n"
+
+#: ../src/celestia/celestiacore.cpp:2743
+msgid "Planetary companions present\n"
+msgstr "Наяўныя плянэтныя спадарожнікі\n"
+
+#: ../src/celestia/celestiacore.cpp:2759
+#, c-format
+msgid "Distance from center: %s\n"
+msgstr "Адлегласьць ад цэнтру: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
+#, c-format
+msgid "Radius: %s\n"
+msgstr "Радыюс %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2831
+#, c-format
+msgid "Phase angle: %.1f%s\n"
+msgstr "Фазавы вугал: %.1f%s\n"
+
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Шчыльнасьць: %.2f × 1000 кг/м³\n"
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Тэмпэратура: %.0f K\n"
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  ПЧРС"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Сапраўдны час"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Сапраўдны час"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Хада часу спыненая"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, c-format
 msgid "%.6g x faster"
 msgstr "%.6g × хутчэй"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, c-format
 msgid "%.6g x slower"
 msgstr "%.6g × павольней"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Прыпыненая)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "Часьціня кадраў %.1f к/с\n"
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, c-format
 msgid "Travelling (%s)\n"
 msgstr "Падарожнічаем (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, c-format
 msgid "Travelling\n"
 msgstr "Падарожнічаем\n"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Сынхранізаваць арбіту з %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, c-format
 msgid "Chase %s\n"
 msgstr "Даганяць %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "ПЗ: %s (%.2fx)\n"
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Сонца"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Назва мэты: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr "%d×%d, %f к/с  %s"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Paused"
 msgstr "Прыпынена"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Recording"
 msgstr "Запіс"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пачаць/Паўза   F12 Спыніць"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Рэжым праўкі"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Загрузка каталёґу сонечнай сыстэмы: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Загрузка каталёґу %s: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Памылка падчас чытаньня файла настаўленьняў."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Не ўдалося ініцыялізаваць бібліятэку SPICE."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Немагчыма прачытаць базу зорак."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Памылка адкрыцьця файла каталёґу глыбокага космасу %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Немагчыма прачытаць базу аб'ектаў глыбокага космасу %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Памылка падчас адкрыцьця каталёґу сонечнай сыстэмы %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Памылка падчас адкрыцьця файла астэрызму %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Памылка падчас адкрыцьця файлаў зь межамі сузор'яў %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Не ўдалося ініцыялізаваць будаўнік"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Памылка падчас загрузкі шрыфта; тэкс ня будзе бачны.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Памылка чытаньня перакрыжаваных спасылак %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Загружаныя перакрыжаваныя спасылкі %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Памылка падчас чытаньня файла з назвамі зорак\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, c-format
 msgid "Error opening %s\n"
 msgstr ""
 "Памылка адкрыцьця %s\n"
 "\n"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Памылка падчас чытаньня файла з назвамі зорак\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Памылка падчас чытаньня файла зорак\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Памылка адкрыцьця каталёґу зорак %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
+#, fuzzy, c-format
+msgid "%s Version: %s\n"
+msgstr "Вэрсія: "
+
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Распаўсюднік: "
+
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Будаўнік: "
+
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Макс. колькасьць тэкстур: "
+
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Найб. памер тэкстуры: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Дыяпазон памераў пунктаў: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Дыяпазон памераў пунктаў: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Макс. памер кубічнае мапы: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Памылка адкрыцьця LuaHook «%s»"
-
-#: ../src/celestia/celestiacore.cpp:4976
-msgid "Unknown error loading hook script"
+msgid "Number of interpolators: %s\n"
 msgstr ""
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
-"УВАГА:\n"
-"\n"
-"Гэты сцэнар патрабуе дазвол на чытаньне/запіс файлаў\n"
-"і запуск вонкавых праґрам. Гэта — даволі небясьпечныя\n"
-"дзеяньні.\n"
-"Ці давяраеш сцэнару й хочаш дазволіць гэта?\n"
-"y = так, ESC = спыніць сцэнар, іншая клявіша = не"
-
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-"УВАГА:\n"
-"\n"
-"Гэты сцэнар патрабуе дазвол на чытаньне/запіс файлаў\n"
-"і запуск вонкавых праґрам. Гэта — даволі небясьпечныя\n"
-"дзеяньні.\n"
-"Ці давяраеш сцэнару й хочаш дазволіць гэта?"
-
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:135
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2347,14 +2542,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Памылка падчас ставарэньня файла ogg %s для захопу.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 msgid "Internal Ogg library error.\n"
 msgstr "Унутраная памылка бібліятэкі Ogg.\n"
 
@@ -2372,45 +2567,36 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() — запісана %d кадраў\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr "Аўтаматычная"
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr "Свая"
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Нябесны каталёґ"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 msgid "Info Browser"
 msgstr "Аглядальнік зьвестак"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Сонечная сыстэма"
 
@@ -2420,20 +2606,19 @@ msgstr "Сонечная сыстэма"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Зоркі"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 msgid "Deep Sky Objects"
 msgstr "Аб'екты глыбокага космасу"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Пошук падзей"
 
@@ -2441,103 +2626,105 @@ msgstr "Пошук падзей"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Час"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 msgid "Guides"
 msgstr "Накіроўныя"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 msgid "Full screen"
 msgstr "На ўвесь экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 msgid "Error opening bookmarks file"
 msgstr "Памылка падчас адкрыцьця файла закладак"
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 msgid "Error Saving Bookmarks"
 msgstr "Памылка падчас захоўваньня файла закладак"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 msgid "Save Image"
 msgstr "Захаваць відарыс"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 msgid "Images (*.png *.jpg)"
 msgstr "Відарысы (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Захапіць відэа"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 msgid "Video (*.avi)"
 msgstr "Відэа (*.avi)"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 msgid "Video (*.ogv)"
 msgstr "Відэа (*.ogv)"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 msgid "Resolution:"
 msgstr "Разрозьненьне:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 × %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Часьціня кадраў:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr "Зрабіць здымак экрана ў буфэр абмену"
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Скапіяваны URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 msgid "Pasting URL"
 msgstr "Устаўка URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 msgid "Open Script"
 msgstr "Адкрыць сцэнар"
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Сцэнары Celestia (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 msgid "New bookmark"
 msgstr "Новая закладка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
-#, qt-format
+#: ../src/celestia/qt/qtappwin.cpp:1004
+#, fuzzy, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 "<html><p><b>Celestia 1.7.0 (Qt5 &beta;-вэрсія,  каміт git %1)</b></"
 "p><p>Copyright (C) 2001-2018 Каманда распрацоўкі Celestia. Celestia — "
@@ -2549,251 +2736,305 @@ msgstr ""
 "github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/"
 "Celestia</a><br></html>"
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
-msgid "<b>OpenGL version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1039
+#, fuzzy
+msgid "Unknown compiler"
+msgstr "Невядомая"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+msgid "supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+msgid "not supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Пра Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>Вэрсія OpenGL: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
 msgstr "<b>Рэндэрэр: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>Рэндэрэр: </b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "<b>Вэрсія GLSL: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Макс. колькасьць тэкстур: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Найбольшы памер тэкстур: </b>"
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-msgid "<b>Extensions:</b><br>\n"
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Дыяпазон памераў пунктаў: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Дыяпазон памераў пунктаў: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Макс. памер кубічнае мапы: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "<b>Парамэтар пэрыяпсыды:/b> %L1%2"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Пашырэньні:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "Зьвесткі OpenGL"
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Будаўнік: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 msgid "&Grab image"
 msgstr "&Захапіць відарыс"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 msgid "Capture &video"
 msgstr "Захапіць &відэа"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 msgid "&Copy image"
 msgstr "&Капіяваць відарыс"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-msgid "Copy &URL"
-msgstr "К&апіваць URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-msgid "&Paste URL"
-msgstr "&Уставіць URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Адкрыць сцэнар…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 msgid "&Preferences..."
 msgstr "&Настаўленьні…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Выйсьці"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навіґацыя"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 msgid "Select Sun"
 msgstr "Вылучыць Сонца"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 msgid "Center Selection"
 msgstr "Цэтраваць вылучэньне"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 msgid "Goto Selection"
 msgstr "Перайсьці да вылучэньня"
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Перайсьці да аб'екта…"
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Час"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 msgid "Set &time"
 msgstr "Задаць &час"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 msgid "&Display"
 msgstr "П&аказаць"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 msgid "Dee&p Sky Objects"
 msgstr "Аб'екты &глыбокага космасу"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 msgid "&Shadows"
 msgstr "&Цені"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Стыль зорак"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 msgid "Texture &Resolution"
 msgstr "Разрозьненьне &тэкстур"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 msgid "&FPS control"
 msgstr "&Кіраваньне часьцінёй кадраў: "
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Закладкі"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Прагляд"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 msgid "&MultiView"
 msgstr "&Мультывід"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Split view vertically"
 msgstr "Падзяліць па вэртыкалі"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 msgid "Split view horizontally"
 msgstr "Падзяліць па гарызанталі"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 msgid "Cycle views"
 msgstr "Зьмяніць актыўны прагляд"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 msgid "Single view"
 msgstr "Адзіны від"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 msgid "Delete view"
 msgstr "Выдаліць від"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Выдаліць"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 msgid "Frames visible"
 msgstr "Бачныя межы"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 msgid "Active frame visible"
 msgstr "Межы актыўнага прагляду"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 msgid "Synchronize time"
 msgstr "Сынхранізаваць час"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Даведка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 msgid "Celestia Manual"
 msgstr "Дапаможнік па Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Пра Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "Зьвесткі OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 msgid "Add Bookmark..."
 msgstr "Дадаць закладку…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 msgid "Organize Bookmarks..."
 msgstr "Упарадкаваць закладкі…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr "Задаць сваю часьціню кадраў"
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr "Часьціня"
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -2802,52 +3043,52 @@ msgstr ""
 "Загрузка файлаў зьвестак: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Сцэнары"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr "Загаловак"
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 msgid "Description"
 msgstr "Апісаньне"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 msgid "Bookmarks Menu"
 msgstr "Мэню закладак"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr "Дадай закладкі ў гэтую тэчку каб яны былі ў мэню закладак."
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 msgid "Bookmarks Toolbar"
 msgstr "Панэль закладак"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr "Дадай закладкі ў гэтую тэчку каб яны былі на панэлі закладак."
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 msgid "Error reading bookmarks file"
 msgstr "Памылка чытаньня файла закладак"
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Закладкі"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 msgid "Current simulation time"
 msgstr "Бягучы час сымуляцыі"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 msgid "Simulation time at activation"
 msgstr "Удаваны час пры актывацыі"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 msgid "System time at activation"
 msgstr "Сыстэмныя дата й час пры актывацыі"
 
@@ -2855,72 +3096,70 @@ msgstr "Сыстэмныя дата й час пры актывацыі"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 msgid "New Folder"
 msgstr "Новы каталёґ"
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr "Экв"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 msgid "Equatorial coordinate grid"
 msgstr "Экватарыяльная каардынатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr "Ґа"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 msgid "Galactic coordinate grid"
 msgstr "Ґаляктычная каардынатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr "Эк"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 msgid "Ecliptic coordinate grid"
 msgstr "Экліптычная каардынатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr "Гц"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 msgid "Horizontal coordinate grid"
 msgstr "Гарызантальная каардынатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr "Экл"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 msgid "Ecliptic line"
 msgstr "Лінія экліптыкі"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 msgid "M"
 msgstr "Паз"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Пазнакі"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 msgid "C"
 msgstr "Суз"
 
@@ -2928,54 +3167,51 @@ msgstr "Суз"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Сузор'і"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 msgid "B"
 msgstr "Меж"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 msgid "Constellation boundaries"
 msgstr "Межы сузор'яў"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 msgid "O"
 msgstr "Арб"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Арбіты"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Плянэты"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Карлікавыя плянэты"
 
@@ -2985,19 +3221,17 @@ msgstr "Карлікавыя плянэты"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Месяцы"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Малыя месяцы"
 
@@ -3007,12 +3241,12 @@ msgstr "Малыя месяцы"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Астэроіды"
 
@@ -3022,12 +3256,12 @@ msgstr "Астэроіды"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Камэты"
 
@@ -3037,14 +3271,15 @@ msgstr "Камэты"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Караблі"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 msgid "L"
 msgstr "Наз"
 
@@ -3052,9 +3287,8 @@ msgstr "Наз"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Назвы"
 
@@ -3062,20 +3296,18 @@ msgstr "Назвы"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Ґаляктыкі"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Шаравыя"
 
@@ -3083,7 +3315,7 @@ msgstr "Шаравыя"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 msgid "Open clusters"
 msgstr "Адкрытыя скопішчы"
@@ -3092,576 +3324,594 @@ msgstr "Адкрытыя скопішчы"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Туманнасьці"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Месцы"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Адкрытыя скопішчы"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Воблакі"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Сьвятло начной часткі"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Хвасты камэт"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Атмасфэры"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Цені ад колцаў"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Цені зацьменьняў"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Цені аблокаў"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Нізкае"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Сярэдняе"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Высокае"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 msgid "Auto Magnitude"
 msgstr "Аўтаяркасьць"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr "Найцьмяная бачная велічыня ў залежнасьці ад поля зроку"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 msgid "More Stars Visible"
 msgstr "Больш бачных зорак"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 msgid "Fewer Stars Visible"
 msgstr "Менш бачных зорак"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 msgid "Points"
 msgstr "Кропкі"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 msgid "Fuzzy Points"
 msgstr "Размытыя кропкі"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 msgid "Scaled Discs"
 msgstr "Маштабаваныя дыскі"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 msgid "Light Time Delay"
 msgstr "Затрымка руху сьвятла"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-msgid "Enable Vsync"
-msgstr "Задзейнічаць Vsync"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Гранічная аўтаяркасьць пры 45°: %L1"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Абмежаваньне велічыні: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Назва"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Адлегласьць (с.г.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Бачн. вел."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Абс. вел."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Тып"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 msgid "Closest Stars"
 msgstr "Найбліжэйшыя зоркі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 msgid "Brightest Stars"
 msgstr "Найярчэйшая зоркі"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 msgid "Filter"
 msgstr "Фільтар"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "З плянэтамі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 msgid "Multiple Stars"
 msgstr "Розныя зоркі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 msgid "Barycenters"
 msgstr "Барыцэнтры"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 msgid "Spectral Type"
 msgstr "Спэктральны тып"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Абнавіць"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 msgid "Mark Selected"
 msgstr "Пазначыць вылучанае"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 msgid "Mark stars selected in list view"
 msgstr "Пазначыць зоркі, вылучаныя ў сьпісе прагляду"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 msgid "Unmark Selected"
 msgstr "Зьняць пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr "Зьняць пазнакі з зорак, вылучаных у сьпісе прагляду"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 msgid "Clear Markers"
 msgstr "Ачысьціць пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr "Прыбраць усе наяўныя пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Нічога"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Ромб"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Трохкутнік"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Акружына"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Стрэлка ўлева"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Стрэлка ўправа"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Стрэлка ўверх"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Стрэлка ўніз"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Select marker symbol"
 msgstr "Выберы выгляд пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 msgid "Select marker size"
 msgstr "Выберы памер пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 msgid "Click to select marker color"
 msgstr "Пстрыкні каб выбраць колер пазнак"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Label"
 msgstr "Метка"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, qt-format
 msgid "%1 objects found"
 msgstr "адшукана %1 абʼектаў"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr "Пазначыць АГК, вылучаныя ў сьпісе прагляду"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 msgid "Unmark DSOs selected in list view"
 msgstr "Зьняць пазнакі з АГК, вылучаных у сьпісе прагляду"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 msgid "Eclipsed body"
 msgstr "Зацьмёнае цела"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr "Зацямняльнік"
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 msgid "Start time"
 msgstr "Час пачатку"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Працягласьць"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 msgid "Solar eclipses"
 msgstr "Сонечныя зацьменьні"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 msgid "Lunar eclipses"
 msgstr "Месяцовыя зацьменьні"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 msgid "All eclipses"
 msgstr "Усе зацьменьні"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 msgid "Search range"
 msgstr "Дыяпазон пошуку"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 msgid "Find eclipses"
 msgstr "Шукаць зацьменьні"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, qt-format
 msgid "%1 is not a valid object"
 msgstr "%1 не зьяўляецца дапушчальным аб'ектам"
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr "Пачатковая дата пазьнейшая за канчатковую!"
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 msgid "Finding eclipses..."
 msgstr "Пошук зацьменьняў…"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 msgid "Set time to mid-eclipse"
 msgstr "Час на сярэдзіну зацьменьня"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, qt-format
 msgid "Near %1"
 msgstr "Каля %1"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, qt-format
 msgid "From surface of %1"
 msgstr "З паверхні %1"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, qt-format
 msgid "Behind %1"
 msgstr "Па-за %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr "Памылка: ніякі аб'ект ня вылучаны!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 msgid "Info"
 msgstr "Зьвесткі"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, qt-format
 msgid "Web info: %1"
 msgstr "Сеціўныя зьвесткі: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Экватарыяльны радыюс:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Памер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr "<b>Сплюшчанасьць: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Сыдэрычны пэрыяд авароту:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Даўжыня дня:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr "гады"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "<b>Эксцэнтрысытэт:</b> %L1"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "<b>Пэрыяд:</b> %L1 %2"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 msgid "Orbit information"
 msgstr "Зьвесткі пра арбіту"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Аскуляваныя элемэнты для %1"
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Пэрыяд:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 msgid "AU"
 msgstr "АА"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Дадатковыя восі:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Эксцэнтрысытэт:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Схіленьне:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Адлегласьць да пэрыцэнтру:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Адлегласьць да апацэнтру:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Узыходны вузел:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Парамэтар пэрыяпсыды:/b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Сярэдняя анамалія:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Пэрыяд (разьлічаны):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>ПУ:</b> %L1г %L2м %L3с"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Сх:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr "Чорнае цела D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 msgid "Classic colors"
 msgstr "Клясычныя колеры"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 msgid "Local format"
 msgstr "Мясцовы фармат"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 msgid "Time zone name"
 msgstr "Назва часавага поясу"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 msgid "UTC offset"
 msgstr "Зрух ад UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Пачатак"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3680,21 +3930,21 @@ msgid "&Select"
 msgstr "&Вылучыць"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Цэнтраваць"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Перайсьці"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Ісьці ўсьлед"
 
@@ -3707,211 +3957,88 @@ msgid "Visible"
 msgstr "Бачны"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Зьняць пазнаку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Выберы рэжым экрану"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Запоўнены квадрат"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Дыск"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Дадаць пазнаку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Арыенцірныя пазнакі"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 msgid "Show &Body Axes"
 msgstr "Паказаць восі &цела"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 msgid "Show &Frame Axes"
 msgstr "Паказаць восі сыстэмы &каардынат"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 msgid "Show &Sun Direction"
 msgstr "Паказваць напрамак &Сонца"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 msgid "Show &Velocity Vector"
 msgstr "Паказваць вэктар &хуткасьці"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 msgid "Show S&pin Vector"
 msgstr "Паказваць вэктар &аварачэньня"
 
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, qt-format
 msgid "Show &Direction to %1"
 msgstr "Паказваць &напрамак на %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 msgid "Show Planetographic &Grid"
 msgstr "Паказваць плянэтаґрафічную &сетку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 msgid "Show &Terminator"
 msgstr "Паказаць &тэрмінатар"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Дадатковыя паверхні"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Нармальны"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Карабель"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
-msgid "Other objects"
-msgstr "Іншыя аб'екты"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-msgid "Set Time"
-msgstr "Задаць час"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Часавы пояс: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Унівэрсальны час"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Мясцовы час"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-msgid "Select Time Zone"
-msgstr "Выберы часавы пояс"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-msgid "Date: "
-msgstr "Дата:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-msgid "Set Year"
-msgstr "Задаць год"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-msgid "Set Month"
-msgstr "Задаць месяц"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-msgid "Set Day"
-msgstr "Задаць дзень"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-msgid "Time: "
-msgstr "Час:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-msgid "Set Hours"
-msgstr "Задаць гадзіны"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ":"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-msgid "Set Minutes"
-msgstr "Задаць хвіліны"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-msgid "Set Seconds"
-msgstr "Задаць секунды"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Юліянская дата: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-msgid "Set Julian Date"
-msgstr "Задаць юліянскую дату"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-msgid "Set time"
-msgstr "Задаць час"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Барыцэнтар"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-msgid "Star"
-msgstr "Зорка"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Плянэта"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-msgid "Dwarf planet"
-msgstr "Карлікавая плянэта"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-msgid "Minor moon"
-msgstr "Малы месяц"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Астэроід"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Камэта"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-msgid "Reference point"
-msgstr "Арыенцір"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-msgid "Component"
-msgstr "Складнік"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-msgid "Surface feature"
-msgstr "Дэталь паверхні"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-msgid "Unknown"
-msgstr "Невядомая"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-msgid "Asteroids & comets"
-msgstr "Астэроіды й камэты"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-msgid "Reference points"
-msgstr "Арыенціры"
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
+msgid "Dwarf planets"
+msgstr "Карлікавыя плянэты"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -3919,58 +4046,203 @@ msgstr "Арыенціры"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr "Малыя месяцы"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Карабель"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+msgid "Other objects"
+msgstr "Іншыя аб'екты"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+msgid "Set Time"
+msgstr "Задаць час"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Часавы пояс: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Унівэрсальны час"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Мясцовы час"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+msgid "Select Time Zone"
+msgstr "Выберы часавы пояс"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+msgid "Date: "
+msgstr "Дата:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+msgid "Set Year"
+msgstr "Задаць год"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+msgid "Set Month"
+msgstr "Задаць месяц"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+msgid "Set Day"
+msgstr "Задаць дзень"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+msgid "Time: "
+msgstr "Час:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+msgid "Set Hours"
+msgstr "Задаць гадзіны"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ":"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+msgid "Set Minutes"
+msgstr "Задаць хвіліны"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+msgid "Set Seconds"
+msgstr "Задаць секунды"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Юліянская дата: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+msgid "Set Julian Date"
+msgstr "Задаць юліянскую дату"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+msgid "Set time"
+msgstr "Задаць час"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Барыцэнтар"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+msgid "Star"
+msgstr "Зорка"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Плянэта"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+msgid "Dwarf planet"
+msgstr "Карлікавая плянэта"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+msgid "Minor moon"
+msgstr "Малы месяц"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Астэроід"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Камэта"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+msgid "Reference point"
+msgstr "Арыенцір"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+msgid "Component"
+msgstr "Складнік"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+msgid "Surface feature"
+msgstr "Дэталь паверхні"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+msgid "Unknown"
+msgstr "Невядомая"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+msgid "Asteroids & comets"
+msgstr "Астэроіды й камэты"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+msgid "Reference points"
+msgstr "Арыенціры"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr "Складнікі"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 msgid "Surface features"
 msgstr "Дэталі паверхні"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Колцы плянэт"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 msgid "Group objects by class"
 msgstr "Ґрупаваць аб'екты паводле клясы"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr "Пазначыць целы, вылучаныя ў сьпісе прагляду"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 msgid "Reverse time"
 msgstr "Зьмяніць кірунак часу"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "10x slower"
 msgstr "10× павольней"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 msgid "2x slower"
 msgstr "2× павольней"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 msgid "Pause time"
 msgstr "Прыпыніць хаду часу"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 msgid "2x faster"
 msgstr "2× хутчэй"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 msgid "10x faster"
 msgstr "10× хутчэй"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 msgid "Set to current time"
 msgstr "Цяперашні час"
 
@@ -4033,7 +4305,6 @@ msgstr "Шырата:"
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "радыюсаў"
 
@@ -4052,7 +4323,7 @@ msgstr "Апісаньне:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Упарадкаваць закладкі"
 
@@ -4081,17 +4352,6 @@ msgstr "Настаўленьні"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Аб'екты"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-msgid "Dwarf planets"
-msgstr "Карлікавыя плянэты"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4170,49 +4430,43 @@ msgstr "Частковыя траекторыі"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Сеткі"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Экватарыяльная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Экліптычная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Ґаляктычная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Гарызантальная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Дыяґрамы"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Межы"
 
@@ -4243,7 +4497,6 @@ msgstr "Віды мясцовасьцяў:"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Гарады"
 
@@ -4256,21 +4509,18 @@ msgstr "Месцы пасадкі"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Вульканы"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Абсэрваторыі"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Кратэры"
 
@@ -4301,7 +4551,6 @@ msgstr "Maria (моры)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Іншыя дэталі"
 
@@ -4393,7 +4642,7 @@ msgstr "Фармат адлюстраваньня даты: "
 msgid "Not an XBEL version 1.0 file."
 msgstr "Не зьяўляецца файлам XBEL вэрсіі 1.0."
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Настаўленьні"
 
@@ -4630,21 +4879,21 @@ msgid "&About Celestia"
 msgstr "&Пра Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "Так"
 
@@ -4653,526 +4902,627 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Аўтарскія правы (C) 2001-2019, Каманда распрацоўкі Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr "https://celestia.space/"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr ""
 "Celestia зьяўляецца свабоднай праґрамай і пастаўляецца абсалютна без аніякае "
 "ґарантыі."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Стваральнікі"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Вылучыць аб'ект"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Назва аб'екта"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Ліцэнзія"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Кіраваньне Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Зьвесткі драйвэра OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Задаць час сымуляцыі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Фармат:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Цяперашні час"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Дадаць закладку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Стварыць у >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Новы каталёґ…"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Каталёґ сонечнай сыстэмы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Перайсьці да"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Аб'екты сонечнай сыстэмы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Каталёґ зорак"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Найбліжэйшыя"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Найярчэйшыя"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "З плянэтамі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Абнавіць"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Крытэр пошуку зорак"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Найбольшая колькасьць зорак у сьпісе "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Даведнік"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Перайсьці да"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Выберы мэту прызначэньня:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Перайсьці да аб'екта"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Аб'ект"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Даўг."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Шыр."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Адлегласьць"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Памер:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "Выберы рэжым экрану"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "Разрозьненьне"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Выборы прагляду"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-msgid "Show:"
-msgstr "Паказваць:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-msgid "Display:"
-msgstr "Адлюстроўваць:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Лінія экліптыкі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-msgid "Body / Orbit / Label display"
-msgstr "Паказваць аб'екты / арбіты / назвы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Лацінскія назвы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Тэкст зьвестак"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Сьцісла"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Падрабязна"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Месцы пасадкі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Горы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Моры й акіяны"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Даліны"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Кантынэнты"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Называць дэталі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "Паказваць дэталі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-msgid "Show Label"
-msgstr "Паказаць метку"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "Найменшы памер дэталі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:96
 msgid "Add New Bookmark Folder"
 msgstr "Дадаць новы каталёґ закладак"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:99
 msgid "Folder Name"
 msgstr "Назва каталёґу"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "Перайменаваць…"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Кіраваньне Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "Перайменаваць закладку ці каталёґ"
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "Выберы рэжым экрану"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "Новая назва"
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "Разрозьненьне"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/win32/res/resource_strings.cpp:106
 msgid "Eclipse Finder"
 msgstr "Пошук зацьменьняў"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:107
 msgid "Compute"
 msgstr "Разьлічыць"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:108
 msgid "Set Date and Go to Planet"
 msgstr "Задаць дату й перайсьці да плянэты"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:109
 msgid "Close"
 msgstr "Закрыць"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:110
 msgid "From:"
 msgstr "Ад:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:111
 msgid "To:"
 msgstr "Да:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:112
 msgid "On:"
 msgstr "Ад:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:113
 msgid "Search parameters"
 msgstr "Параметры пошуку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Сонечныя зацьменьні"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Вылучыць аб'ект"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Месяцовыя зацьменьні"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Назва аб'екта"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Зьвесткі драйвэра OpenGL"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Перайсьці да аб'екта"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Перайсьці да"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Аб'ект"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Даўг."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Шыр."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Адлегласьць"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Ліцэнзія"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "Паказваць дэталі"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+msgid "Show Label"
+msgstr "Паказаць метку"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "Найменшы памер дэталі"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Памер:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "Перайменаваць…"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "Перайменаваць закладку ці каталёґ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "Новая назва"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Задаць час сымуляцыі"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Фармат:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Цяперашні час"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Каталёґ сонечнай сыстэмы"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Перайсьці да"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Аб'екты сонечнай сыстэмы"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Каталёґ зорак"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Абнавіць"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Крытэр пошуку зорак"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Найбольшая колькасьць зорак у сьпісе "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Даведнік"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Выберы мэту прызначэньня:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Выборы прагляду"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+msgid "Show:"
+msgstr "Паказваць:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+msgid "Display:"
+msgstr "Адлюстроўваць:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+msgid "Body / Orbit / Label display"
+msgstr "Паказваць аб'екты / арбіты / назвы"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Тэкст зьвестак"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "423"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Кра"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Лют"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Сту"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Чэр"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Сак"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Тра"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Жні"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Сьн"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Ліп"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Ліс"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Кас"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Вер"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Спадарожнік"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Дата"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Пачатак"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Распаўсюднік: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Ваконны рэжым"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Будаўнік: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Нябачныя"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "&Сынхранізаваць арбіту"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Зьвесткі"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Паказаць восі цела"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Паказаць восі сыстэмы каардынат"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Паказваць напрамак Сонца"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Паказваць вэктар хуткасьці"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Паказваць плянэтаґрафічную сетку"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Паказаць тэрмінатар"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Спадарожнікі"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Арбітальныя целы"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Загрузка: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "be"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Загрузка URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Вэрсія: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Вэрсія GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Макс. колькасьць тэкстур: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Найб. памер тэкстуры: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Макс. памер кубічнае мапы: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Дыяпазон памераў пунктаў: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Падтрымліваюцца пашырэньні:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Ваконны рэжым"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Нябачныя"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "&Сынхранізаваць арбіту"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Зьвесткі"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Паказаць восі цела"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Паказаць восі сыстэмы каардынат"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Паказваць напрамак Сонца"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Паказваць вэктар хуткасьці"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Паказваць плянэтаґрафічную сетку"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Паказаць тэрмінатар"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Спадарожнікі"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Арбітальныя целы"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Загрузка: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "be"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Загрузка URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Памылка падчас адкрыцьця файла"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Памылка падчас загрузкі сцэнара"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Выконваньне сцэнара"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Нозва часавага поясу"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Зрух ад UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Памылка падчас адкрыцьця файла сцэнара."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Невядомая памылка падчас адкрыцьця сцэнара"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+"УВАГА:\n"
+"\n"
+"Гэты сцэнар патрабуе дазвол на чытаньне/запіс файлаў\n"
+"і запуск вонкавых праґрам. Гэта — даволі небясьпечныя\n"
+"дзеяньні.\n"
+"Ці давяраеш сцэнару й хочаш дазволіць гэта?\n"
+"y = так, ESC = спыніць сцэнар, іншая клявіша = не"
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+"УВАГА:\n"
+"\n"
+"Гэты сцэнар патрабуе дазвол на чытаньне/запіс файлаў\n"
+"і запуск вонкавых праґрам. Гэта — даволі небясьпечныя\n"
+"дзеяньні.\n"
+"Ці давяраеш сцэнару й хочаш дазволіць гэта?"
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Памылка падчас адкрыцьця сцэнара «%s»"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Памылка падчас ініцыялізацыі супраграмы сцэнара"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Памылка адкрыцьця LuaHook «%s»"
+
+#: ../src/celscript/lua/luascript.cpp:223
+msgid "Unknown error loading hook script"
+msgstr ""
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, c-format
 msgid "Error openning %s or .\n"
 msgstr "Памылка адкрыцьця %s ці .\n"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Загрузка фраґмэнтавых праґрамаў NV: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Памылка падчас загрузкі фраґмэнтавай праґрамы NV: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Памылка ў праґраме фраґмэнтаў"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Ініцыялізаваньне фраґмэнтавых праґрамаў NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Усе фраґмэнтавыя праґрамы NV загружаныя ўдала.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Ініцыялізаваньне праґрамаў фраґмэнтаў ARB . . .\n"
+
+#, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr "%s: тып відарысаў не распазнаны або не падтрымліваецца.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Загрузка вяршыневых праґрамаў NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Памылка падчас загрузкі вяршыневай праґрамы NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Памылка ў вяршыневай праґраме"
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Загрузка вяршыневых праґрамаў ARB: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Памылка падчас загрузкі вяршыневай праґрамы ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", радок "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Ініцыялізаваньне вяршыневых праґрамаў NV . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Усе вяршыневыя праґрамы NV загружаныя ўдала.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Ініцыялізаваньне вяршыневых праґрамаў ARB . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Усе вяршыневыя праґрамы ARB загружаныя ўдала.\n"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Orientation: [%f, %f, %f], %.1f\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Арыентацыя: [%f, %f, %f], %.1f\n"
+
+#~ msgid "Copy &URL"
+#~ msgstr "К&апіваць URL"
+
+#~ msgid "&Paste URL"
+#~ msgstr "&Уставіць URL"
+
+#~ msgid "Enable Vsync"
+#~ msgstr "Задзейнічаць Vsync"
+
+#~ msgid "Nearest"
+#~ msgstr "Найбліжэйшыя"
+
+#~ msgid "Brightest"
+#~ msgstr "Найярчэйшыя"
+
+#~ msgid "With planets"
+#~ msgstr "З плянэтамі"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Лінія экліптыкі"
+
+#~ msgid "Latin Names"
+#~ msgstr "Лацінскія назвы"
+
+#~ msgid "Terse"
+#~ msgstr "Сьцісла"
+
+#~ msgid "Verbose"
+#~ msgstr "Падрабязна"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Месцы пасадкі"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Горы"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Моры й акіяны"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Даліны"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Кантынэнты"
+
+#~ msgid "Label Features"
+#~ msgstr "Называць дэталі"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Сонечныя зацьменьні"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Месяцовыя зацьменьні"
+
+#~ msgid "GLSL version: "
+#~ msgstr "Вэрсія GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Падтрымліваюцца пашырэньні:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Памылка падчас адкрыцьця файла"
+
+#~ msgid "Error loading script"
+#~ msgstr "Памылка падчас загрузкі сцэнара"
+
+#~ msgid "Running script"
+#~ msgstr "Выконваньне сцэнара"
 
 #~ msgid "Kpc"
 #~ msgstr "кпк"

--- a/po/bg.po
+++ b/po/bg.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
 "POT-Creation-Date: 2020-07-14 09:41+0300\n"
-"PO-Revision-Date: 2020-07-30 19:12+0200\n"
+"PO-Revision-Date: 2020-09-21 10:57+0200\n"
 "Last-Translator: Georgi Georgiev <georgiev_1994@abv.bg>, 2020\n"
 "Language-Team: Bulgarian (https://www.transifex.com/celestia/teams/93131/"
 "bg/)\n"
@@ -812,7 +812,7 @@ msgstr "Хелзинки"
 
 #: ??
 msgid "Hong Kong"
-msgstr ""
+msgstr "Хонконг"
 
 #: ../data/data.cpp:197
 msgid "Honiara"
@@ -1060,7 +1060,7 @@ msgstr "Нукуалофа"
 
 #: ??
 msgid "Nur-Sultan"
-msgstr ""
+msgstr "Нур Султан"
 
 #: ../data/data.cpp:259
 msgid "Nuuk"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1,10 +1,10 @@
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
-# 
+#
 # Translators:
 # Hleb Valoshka <375gnu@gmail.com>, 2020
 # Georgi Georgiev <georgiev_1994@abv.bg>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
@@ -12,11 +12,12 @@ msgstr ""
 "POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2020-07-30 19:12+0200\n"
 "Last-Translator: Georgi Georgiev <georgiev_1994@abv.bg>, 2020\n"
-"Language-Team: Bulgarian (https://www.transifex.com/celestia/teams/93131/bg/)\n"
+"Language-Team: Bulgarian (https://www.transifex.com/celestia/teams/93131/"
+"bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../data/data.cpp:1
@@ -809,6 +810,10 @@ msgstr "Хавана"
 msgid "Helsinki"
 msgstr "Хелзинки"
 
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
 #: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Хониара"
@@ -1052,6 +1057,10 @@ msgstr "Нумеа"
 #: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
+
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
 
 #: ../data/data.cpp:259
 msgid "Nuuk"
@@ -1460,12 +1469,14 @@ msgstr "Очаквана 'Конфигурация' %s:%d.\n"
 msgid "%s: Bad configuration file.\n"
 msgstr "%s: Лош конфигурационен файл.\n"
 
+#.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
 #. for (int i = 0; i < nDSOs; ++i)
 #. {
 #. if(DSOs[i]->getAbsoluteMagnitude() == DSO_DEFAULT_ABS_MAGNITUDE)
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
+#.
 #: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
@@ -1913,26 +1924,22 @@ msgstr "ае"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2403
-#: ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
 #: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2409
-#: ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/celestiacore.cpp:2432
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
 #: ../src/celestia/qt/qtinfopanel.cpp:196
 #: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr "дни"
 
-#: ../src/celestia/celestiacore.cpp:2437
-#: ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
 #: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr "часа"
@@ -2345,8 +2352,7 @@ msgid "Max anisotropy filtering: %s\n"
 msgstr "Максимално анизотропно филтриране: %s\n"
 
 #. if (glGetError())
-#. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not
-#. available--",""), desc];
+#. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
 #. else
 #: ../src/celestia/macosx/CGLInfo.m:53
 #, objc-format
@@ -2391,11 +2397,14 @@ msgstr "Разширения:"
 
 #: ../src/celestia/macosx/CelestiaController.m:161
 msgid ""
-"It appears that the \"CelestiaResources\" directory has not been properly installed in the correct location as indicated in the installation instructions. \n"
+"It appears that the \"CelestiaResources\" directory has not been properly "
+"installed in the correct location as indicated in the installation "
+"instructions. \n"
 "\n"
 "Please correct this and try again."
 msgstr ""
-"Директорията \"CelestiaResources\" не е инсталирана на мястото, което е указано в инсталационните инструкции на програмата.\n"
+"Директорията \"CelestiaResources\" не е инсталирана на мястото, което е "
+"указано в инсталационните инструкции на програмата.\n"
 "\n"
 "Моля, преместете директорията и опитайте отново."
 
@@ -2410,11 +2419,9 @@ msgstr "Фатална грешка"
 #: ../src/celestia/macosx/CelestiaController.m:323
 #, objc-format
 msgid ""
-"It appears you are running Celestia on %s hardware. Do you wish to install a"
-" workaround?"
-msgstr ""
-"Използвате Celestia на %s хардуер. Искате ли да заобиколите"
-" проблема?"
+"It appears you are running Celestia on %s hardware. Do you wish to install a "
+"workaround?"
+msgstr "Използвате Celestia на %s хардуер. Искате ли да заобиколите проблема?"
 
 #: ../src/celestia/macosx/CelestiaController.m:324
 #, objc-format
@@ -2532,7 +2539,8 @@ msgstr "Неправилен формат за дата или време"
 
 #: ../src/celestia/macosx/SetTimeWindowController.m:213
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
-msgstr "Моля въведете датата във като \"мм/дд/гггг\" и времето като \"чч:мм:сс\"."
+msgstr ""
+"Моля въведете датата във като \"мм/дд/гггг\" и времето като \"чч:мм:сс\"."
 
 #: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
@@ -2548,11 +2556,11 @@ msgstr "Вътрешна грешка на Ogg библиотеката.\n"
 #: ../src/celestia/oggtheoracapture.cpp:311
 #, c-format
 msgid ""
-"OggTheoraCapture::start() - Theora video: %s %.2f(%d/%d) fps quality %d "
-"%dx%d offset (%dx%d)\n"
+"OggTheoraCapture::start() - Theora video: %s %.2f(%d/%d) fps quality %d %dx"
+"%d offset (%dx%d)\n"
 msgstr ""
-"OggTheoraCapture::start() - Theora видео: %s %.2f(%d/%d) fps качество %d "
-"%dx%d отклонение (%dx%d)\n"
+"OggTheoraCapture::start() - Theora видео: %s %.2f(%d/%d) fps качество %d %dx"
+"%d отклонение (%dx%d)\n"
 
 #: ../src/celestia/oggtheoracapture.cpp:426
 #, c-format
@@ -2569,8 +2577,8 @@ msgstr "Персонализирано"
 
 #: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directory was not found, probably"
-" due to improper installation."
+"Celestia is unable to run because the data directory was not found, probably "
+"due to improper installation."
 msgstr ""
 "Celestia не може да се изпълни, защото директорията с данните липсва, "
 "вероятната причина за проблема е неправилна инсталация."
@@ -2611,8 +2619,7 @@ msgstr "Звезди"
 msgid "Deep Sky Objects"
 msgstr "Обекти от дълбокия космос"
 
-#: ../src/celestia/qt/qtappwin.cpp:325
-#: ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Търсач на събития"
@@ -2709,31 +2716,29 @@ msgstr "Нова отметка"
 #: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt "
-"library: %5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright"
-" (C) 2001-2020 by the Celestia Development Team.<br>Celestia is free "
-"software. You can redistribute it and/or modify it under the terms of the "
-"GNU General Public License as published by the Free Software Foundation; "
-"either version 2 of the License, or (at your option) any later "
-"version.</p><p>Main site: <a "
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
 "href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>GitHub"
-" project: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
-"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>За %2 битови CPU<br>Използва %3 %4<br>Работи с Qt "
-"библиотека: %5<br>NAIF кърнърите са %7<br>Работна Qt версия: "
-"%6</p><p>Авторско право (C) 2001-2020 от Екипа на Celestia.<br>Celestia е "
-"безплатен софтуер. Може да се разпространява и/или модифицира под условията "
-"на GNU General Public License, който е публикуван от Free Software "
-"Foundation; версия 2 или всяка по-нова версия на Лиценза (по Ваша "
-"преценка).</p><p>Сайт: <a "
-"href=\"https://celestia.space/\">https://celestia.space/</a><br>Форум: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>GitHub"
-" проект: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>За %2 битови CPU<br>Използва %3 %4<br>Работи с Qt библиотека: "
+"%5<br>NAIF кърнърите са %7<br>Работна Qt версия: %6</p><p>Авторско право (C) "
+"2001-2020 от Екипа на Celestia.<br>Celestia е безплатен софтуер. Може да се "
+"разпространява и/или модифицира под условията на GNU General Public License, "
+"който е публикуван от Free Software Foundation; версия 2 или всяка по-нова "
+"версия на Лиценза (по Ваша преценка).</p><p>Сайт: <a href=\"https://celestia."
+"space/\">https://celestia.space/</a><br>Форум: <a href=\"https://celestia."
+"space/forum/\">https://celestia.space/forum/</a><br>GitHub проект: <a href="
+"\"https://github.com/CelestiaProject/Celestia\">https://github.com/"
+"CelestiaProject/Celestia</a></p></html>"
 
 #: ../src/celestia/qt/qtappwin.cpp:1039
 msgid "Unknown compiler"
@@ -3089,8 +3094,7 @@ msgid "System time at activation"
 msgstr "Системно време при активиране"
 
 #. i18n: file: ../src/celestia/qt/newbookmarkfolder.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. newBookmarkFolderDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
 #: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
@@ -3199,9 +3203,9 @@ msgstr "Орбити"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111
 #: ../src/celestia/qt/qtselectionpopup.cpp:387
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581
-#: ../src/celestia/qt/rc.cpp:75 ../src/celestia/qt/rc.cpp:156
-#: ../src/celestia/qt/rc.cpp:222 ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
+#: ../src/celestia/win32/winmain.cpp:1449
 #: ../src/celestia/win32/winmain.cpp:1484
 #: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
@@ -3221,9 +3225,9 @@ msgstr "Планети Джуджета"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
 #: ../src/celestia/qt/qtselectionpopup.cpp:393
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583
-#: ../src/celestia/qt/rc.cpp:81 ../src/celestia/qt/rc.cpp:162
-#: ../src/celestia/qt/rc.cpp:228 ../src/celestia/win32/winmain.cpp:1447
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Луни"
 
@@ -3241,9 +3245,9 @@ msgstr "Астероидни Спътници"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
 #: ../src/celestia/qt/qtselectionpopup.cpp:399
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742
-#: ../src/celestia/qt/rc.cpp:87 ../src/celestia/qt/rc.cpp:168
-#: ../src/celestia/qt/rc.cpp:234 ../src/celestia/win32/winmain.cpp:1441
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Астероиди"
 
@@ -3256,9 +3260,9 @@ msgstr "Астероиди"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750
-#: ../src/celestia/qt/rc.cpp:90 ../src/celestia/qt/rc.cpp:171
-#: ../src/celestia/qt/rc.cpp:237 ../src/celestia/win32/winmain.cpp:1443
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Комети"
 
@@ -3270,9 +3274,8 @@ msgstr "Комети"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746
-#: ../src/celestia/qt/rc.cpp:93 ../src/celestia/qt/rc.cpp:174
-#: ../src/celestia/qt/rc.cpp:240
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Космически апарати"
 
@@ -4043,9 +4046,8 @@ msgstr "Планети джуджета"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:396
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591
-#: ../src/celestia/qt/rc.cpp:84 ../src/celestia/qt/rc.cpp:165
-#: ../src/celestia/qt/rc.cpp:231
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr "Астероидни спътници"
 
@@ -4317,8 +4319,7 @@ msgid "Description:"
 msgstr "Описание:"
 
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. organizeBookmarksDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
 #: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
@@ -5357,7 +5358,9 @@ msgid ""
 msgstr ""
 "ВНИМАНИЕ:\n"
 "\n"
-"Този скрипт се нуждае от разрешение за четене и записване на файлове, както и изпълнение на външни програми. Това може да доведе до потенциални рискове за Вашата сигурност.\n"
+"Този скрипт се нуждае от разрешение за четене и записване на файлове, както "
+"и изпълнение на външни програми. Това може да доведе до потенциални рискове "
+"за Вашата сигурност.\n"
 "Сигурни ли сте, че искате да продължите?"
 
 #: ../src/celscript/lua/luascript.cpp:87

--- a/po/celestia.pot
+++ b/po/celestia.pot
@@ -807,6 +807,10 @@ msgstr ""
 msgid "Helsinki"
 msgstr ""
 
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
 #: ../data/data.cpp:197
 msgid "Honiara"
 msgstr ""
@@ -1049,6 +1053,10 @@ msgstr ""
 
 #: ../data/data.cpp:258
 msgid "Nuku'alofa"
+msgstr ""
+
+#: ??
+msgid "Nur-Sultan"
 msgstr ""
 
 #: ../data/data.cpp:259

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-08-10 19:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Merkur"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Erde"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Mond"
 
@@ -47,140 +47,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymed"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Kallisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturn"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tethys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phoebe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uranus"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptun"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereid"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluto"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Kallisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxien"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "NORDAMERIKA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "SÜDAMERIKA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIEN"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIEN"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARKTIS"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NORDATLANTIK"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "SÜDATLANTIK"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NORDPAZIFIK"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "SÜDPAZIFIK"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "INDISCHER OZEAN"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "ARKTISCHER OZEAN"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Algier"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Aşgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Athen"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Peking"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bischkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Brüssel"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bukarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Kairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Kapstadt"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Kopenhagen"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damaskus"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Dschibuti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Duschanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Den Haag"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havanna"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiew"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiun"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lissabon"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "London"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Male"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexiko-Stadt"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadischu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moskau"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Maskat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Neu Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nikosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Prag"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pjöngjang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riadh"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Rom"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seoul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapur"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Taschkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tiflis"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teheran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv-Jaffa"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripolis"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vatikanstadt"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Wien"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Wilna"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Warschau"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D. C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Distrikt Yaren"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Eriwan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Milchstraße"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Kleine Magellansche Wolke"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Große Magellansche Wolke"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Schwerezentrum des Sternsystems"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Fehler beim Öffnen der Bilddatei "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Fehler beim Einlesen der Konfigurationsdatei."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " Deep-Space-Objekte"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Lade NV fragment program: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Fehler beim Laden des NV fragment program: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Fehler im Fragment-Programm "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Initialisiere NV fragment programs . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Alle NV fragment programs wurden erfolgreich geladen.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Initialisiere ARB fragment programs . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxie (Hubble-Typ: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Kugelsternhaufen (Kernradius: %4.2f', King-Konzentration: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Lade Bild aus Datei "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": unbekanntes oder nicht unterstütztes Bild-Dateiformat.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Fehler beim Öffnen der Bilddatei "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " ist keine PNG-Datei.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Fehler beim Lesen der PNG-Bilddatei "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Lade Modell: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Fehler beim Laden des Modells '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebel"
 
@@ -1308,92 +1541,92 @@ msgstr "Nebel"
 msgid "Open cluster"
 msgstr "Offene Sternhaufen"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Fehler in .ssc-Datei (Zeile "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Warnung: mehrfache Definition von "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "fehlerhafte Alternative Oberfläche"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "fehlerhafter (Stand-)Ort"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Falsches Header-Format im Cross-Index\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Falsche Version des Cross-Index\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Laden des Cross-Index fehlgeschlagen bei Eintrag "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Falscher Spektraltyp in Sternkatalog, Stern #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " Sterne im binären Sternkatalog\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Gesamtzahl der Sterne: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Fehler in .stc-Datei (Zeile "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ungültiger Eintrag: Spektraltyp fehlerhaft.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ungültiger Eintrag: Spektraltyp fehlt.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " existiert nicht.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'right ascension'\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'declination'.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'distance'.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'magnitude'.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "Unültiger Stern: Absolute (nicht scheinbare) Magnitude für Stern nahe dem "
 "Ursprung benötigt\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Erzeuge gekachelte Textur. Breite="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Erzeuge einfache Textur: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Lade NV vertex program: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Fehler beim Laden des NV vertex program: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Fehler im Vertex program "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Lade ARB vertex program: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Fehler beim Laden des ARB vertex program: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", Zeile "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Initialisiere NV vertex programs . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Alle NV vertex programs wurden erfolgreich geladen.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Initialisiere ARB vertex programs . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Alle ARB vertex programs wurden erfolgreich geladen.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Fehler beim Öffnen von "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Fehler beim Lesen der PNG-Bilddatei "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Fehler beim Einlesen der Favoriten-Datei."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Fehler beim Öffnen der Skript-Datei."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Fehler beim Öffnen des Skripts '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Unbekannter Fehler beim Öffnen des Skripts"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Initialisierung der Skript-Koroutine ist fehlgeschlagen"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Falscher Dateityp"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Grenz-Magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Markierungen eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Markierungen ausgeschaltet"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Gehe auf die Oberfläche"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Azimut-Modus eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Azimut-Modus ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Stern-Darstellung: verschwommene Punkte"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Stern-Darstellung: Punkte"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Stern-Darstellung: skalierte Scheiben"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Kometenschweife eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Kometenschweife ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Renderpfad: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-Azimut-Modus eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-Azimut-Modus ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Auto-Magnitude eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Auto-Magnitude ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Zeit und Skript wurden angehalten"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Zeit wurde angehalten"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Fortsetzen"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Sterndarstellung"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Sterndarstellung"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Lichtlaufzeit:  %.4f Jahre "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Lichtlaufzeit:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Lichtlaufzeit:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Lichtlaufzeit berücksichtigt"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Lichtlaufzeit ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Lichtlaufzeit nicht berücksichtigt"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Benutze interpretierende Oberflächentexturen."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Benutze \"Limit of knowledge\"-Oberflächentexturen."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Folgen"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Zeit: vorwärts"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Zeit: rückwärts"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Zeitrate"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Synchr. Orbit"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Verbinden"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Nacheilen"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Grenz-Magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Auto-Magnitude-Grenzwert bei 45 Grad:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Streulicht:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Lichtverstärkung"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Überstrahlung eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Überstrahlung ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Belichtung"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL-Fehler: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Ansicht zu klein zum Aufteilen"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Ansicht hinzugefügt"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "Lj"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "AE"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " Tage"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " Stunden"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " Minuten"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " Sekunden"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AE/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " Lj/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Geschwindigkeit: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Scheinbarer Durchmesser: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Scheinbare Magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolute Magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Entfernung: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Schwerezentrum des Sternsystems\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Absolute (scheinb.) Mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Leuchtkraft: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Neutronenstern"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Schwarzes Loch"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Oberflächentemp.: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Planetare Begleiter vorhanden\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Entfernung vom Zentrum: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Phasenwinkel: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Echtzeit"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Echtzeit"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Zeit angehalten"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "2x schneller"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "2x langsamer"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Angehalten)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Objekt wird angeflogen "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Objekt wird angeflogen "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Zentriert halten: "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Folge "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchr. Orbit: "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Nacheilen: "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sonne"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Name des Ziels: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "  Angehalten"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Aufnahme"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause    F12 Beenden"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Editier-Modus"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Lade Sonnensystem-Katalog: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Lade Sonnensystem-Katalog: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Fehler beim Einlesen der Konfigurationsdatei."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Initialisierung der SPICE-Bibliothek ist fehlgeschlagen."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Konnte Stern-Datenbank nicht einlesen."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Fehler beim Öffnen des DSO-Katalogs."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Konnte Stern-Datenbank nicht einlesen."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Fehler beim Öffnen des Sonnensystem-Katalogs.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Fehler beim Öffnen der Asterismen-Datei."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Fehler beim Öffnen der Sternbildgrenzen-Dateien."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Initialisierung des Renderers fehlgeschlagen"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Fehler beim Laden der Schriftdaten, keine Textanzeige möglich.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Fehler beim Einlesen des Cross-Index "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Cross-Index eingelesen "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Fehler beim Einlesen der Sternnamen-Datei\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Fehler beim Öffnen von "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Fehler beim Einlesen der Sternnamen-Datei\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Fehler beim Einlesen der Stern-Datei\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Fehler beim Öffnen des Sternkataloges "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Fehler beim Öffnen des Skripts '%s'"
+msgid "%s Version: %s\n"
+msgstr "Version: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Unbekannter Fehler beim Öffnen des Skripts"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Anbieter: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Renderer: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Maximale Anzahl simultaner Texturen: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Maximale Texturgröße: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Bereich der Punktgröße: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Bereich der Punktgröße: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Maximale Cube-Map-Texturgröße: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Fehler beim Erzeugen der Videodatei %s.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Interner Fehler in der Ogg-Bibliothek."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Himmels-Browser"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Himmels-Browser"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sonnensystem"
 
@@ -2433,20 +2633,19 @@ msgstr "Sonnensystem"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Sterne"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 msgid "Deep Sky Objects"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Finsternis-Suche"
@@ -2455,451 +2654,502 @@ msgstr "Finsternis-Suche"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Zeit"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Interessante Ziele"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Vollbild"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Fehler beim Öffnen der Asterismen-Datei."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Lesezeichen verwalten"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Speichern unter:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " ist keine PNG-Datei.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 msgid "Resolution:"
 msgstr "Auflösung: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Bildrate:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL kopiert"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Lade URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Skript laden..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Neue Trennlinie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Unbekannter Fehler beim Öffnen des Skripts"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Unterstützte Erweiterungen:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Unterstützte Erweiterungen:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Über Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Language</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Anbieter: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL-Version: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Maximale Anzahl simultaner Texturen: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maximale Texturgröße: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Bereich der Punktgröße: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Bereich der Punktgröße: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Maximale Cube-Map-Texturgröße: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Äquatorial"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "OpenGL-Informationen"
+msgid "Renderer Info"
+msgstr "Renderer: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Datei"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Bildschirmfoto erstellen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopiere URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Kopiere URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL kopiert"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Skript laden..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 msgid "&Preferences..."
 msgstr "&Einstellungen..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "B&eenden"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigation"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Auswählen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "Auswahl &zentrieren\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Auswahl: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Gehe zu..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Zeit"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Zeitquelle:"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Anzeige"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Wolkenschatten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Sterndarstellung"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 msgid "Texture &Resolution"
 msgstr "Auflösung der &Texturen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Steuerung"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Lesezeichen"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Ansicht"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Mehrfachansicht"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Ansicht vertikal aufteilen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Ansicht horizontal aufteilen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Zur nächsten Ansicht wechseln"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Einzelansicht"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Ansicht entfernen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Entfernen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Rahmen sichtbar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktiver Rahmen sichtbar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Zeitquelle:"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Hilfe"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia-Einstellungen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Über Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "OpenGL-Informationen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Name: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 msgid "Organize Bookmarks..."
 msgstr "Lesezeichen verwalten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Lade "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skripte"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Lesezeichen verwalten"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Lesezeichen verwalten"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Fehler beim Einlesen der Favoriten-Datei."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Zeitquelle:"
@@ -2908,77 +3158,75 @@ msgstr "Zeitquelle:"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 msgid "New Folder"
 msgstr "Neuer Ordner"
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Himmelsraster anzeigen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galaktisch"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Ekliptikal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 msgid "Ecliptic line"
 msgstr "Ekliptikal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Markierungen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Copyright (C) 2001-2017, Celestia Development Team"
@@ -2987,56 +3235,53 @@ msgstr "Copyright (C) 2001-2017, Celestia Development Team"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Sternbilder"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, no vertex programs</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 msgid "Constellation boundaries"
 msgstr "Sternbildgrenzen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Orbit-Linien"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planeten"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Zwergplaneten"
 
@@ -3046,19 +3291,17 @@ msgstr "Zwergplaneten"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Monde"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Kleine Monde"
 
@@ -3068,12 +3311,12 @@ msgstr "Kleine Monde"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroiden"
 
@@ -3083,12 +3326,12 @@ msgstr "Asteroiden"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Kometen"
 
@@ -3098,14 +3341,15 @@ msgstr "Kometen"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Raumfahrzeuge"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Schne&ller\tL"
@@ -3114,9 +3358,8 @@ msgstr "10x Schne&ller\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Bezeichnungen"
 
@@ -3124,20 +3367,18 @@ msgstr "Bezeichnungen"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxien"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Kugelsternhaufen"
 
@@ -3145,7 +3386,7 @@ msgstr "Kugelsternhaufen"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3155,614 +3396,631 @@ msgstr "Kugelsternhaufen"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebel"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "(Stand-)Orte"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Offene Sternhaufen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Wolken"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Lichter auf der Nachtseite"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Kometenschweife"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosphären"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Ringschatten"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Finsternis-Schatten"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Wolkenschatten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Gering"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Mittel"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Hoch"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Auto-Magnitude\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Mehr Sterne sichtbar\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Weniger Sterne sichtbar\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 msgid "Points"
 msgstr "Punkte"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Verschwommene Punkte"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Skalierte Scheiben"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Alt-Azimut-Modus eingeschaltet"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Auto-Magnitude-Grenzwert bei 45 Grad:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Grenz-Magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Name"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Scheinb. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Sterne anzeigen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Sterne"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Sterne filtern"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Mit Planeten"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Sterne anzeigen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Schwerezentrum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Falscher Spektraltyp in Sternkatalog, Stern #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Markierung setzen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximale Anzahl von Sternen in der Liste"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Markierung setzen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markierungen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Keiner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Raute"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Dreieck"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Quadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Kreis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Pfeil nach links"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Pfeil nach rechts"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Pfeil nach oben"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Pfeil nach unten"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Objekt auswählen..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Größe:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Objekt auswählen..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Merkmale beschriften"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Markierung setzen"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "Übergeordnetes Objekt '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Dauer"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Sonnenfinsternisse"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Mondfinsternisse"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "&Alle Markierungen aufheben"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Bereich der Punktgröße: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Mondfinsternisse"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "&Objekt auswählen..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Sonnenfinsternisse"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Zeit auf aktuelle Zeit setzen"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Lade Bild aus Datei "
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-Informationen"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Entfernung (Lichtjahre)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Größe: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Infotext"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "AE"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Sterndarstellung"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Lokales Format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Name: "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC-Versatz"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Start"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3781,21 +4039,21 @@ msgid "&Select"
 msgstr "&Auswählen"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Zentrieren"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Gehe zu"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Folgen"
 
@@ -3809,49 +4067,54 @@ msgid "Visible"
 msgstr "Aktiver Rahmen sichtbar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Markierung aufheben"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Anzeigemodus auswählen"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Gefülltes Quadrat"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Scheibe"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Markierung setzen"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Referenzvektoren"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Zeige Orte"
@@ -3859,187 +4122,40 @@ msgstr "Zeige Orte"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Zeige Orte"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternative Oberflächen"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Raumfahrzeuge"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
-#, fuzzy
-msgid "Other objects"
-msgstr "Deep-Space-Objekte"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Zeitquelle:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Zeitzone: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Universalzeit"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Lokalzeit"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Zeitquelle:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-msgid "Date: "
-msgstr "Datum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Zeit einstellen..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Zeit einstellen..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Zeit einstellen..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "Zeitquelle:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " Stunden"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " Minuten"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " Sekunden"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Julianisches Datum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Datum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Zeitquelle:"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Schwerezentrum"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-msgid "Star"
-msgstr "Stern"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-msgid "Dwarf planet"
-msgstr "Zwergplanet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Kleine Monde"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroid"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Komet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Referenzvektoren"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Berechne"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Gehe auf die Oberfläche"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Unbekannter Fehler beim Öffnen des Skripts"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-msgid "Asteroids & comets"
-msgstr "Asteroiden und Kometen"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "Verschwommene Punkte"
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
+msgid "Dwarf planets"
+msgstr "Zwergplaneten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4047,62 +4163,226 @@ msgstr "Verschwommene Punkte"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr "Kleine Monde"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Raumfahrzeuge"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Deep-Space-Objekte"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Zeitquelle:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Zeitzone: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Universalzeit"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Lokalzeit"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Zeitquelle:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+msgid "Date: "
+msgstr "Datum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Zeit einstellen..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Zeit einstellen..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Zeit einstellen..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "Zeitquelle:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " Stunden"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " Minuten"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " Sekunden"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Julianisches Datum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Datum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Zeitquelle:"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Schwerezentrum"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+msgid "Star"
+msgstr "Stern"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+msgid "Dwarf planet"
+msgstr "Zwergplanet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Kleine Monde"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroid"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Komet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Referenzvektoren"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Berechne"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Gehe auf die Oberfläche"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Unbekannter Fehler beim Öffnen des Skripts"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+msgid "Asteroids & comets"
+msgstr "Asteroiden und Kometen"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "Verschwommene Punkte"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Besonderheiten"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planeten"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "10x slower"
 msgstr "10x langsamer"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 msgid "2x slower"
 msgstr "2x langsamer"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 msgid "2x faster"
 msgstr "2x schneller"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 msgid "10x faster"
 msgstr "10x schneller"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 msgid "Set to current time"
 msgstr "Setze auf aktuelle Zeit"
 
@@ -4169,7 +4449,6 @@ msgstr "Breitengrad: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "Radien"
 
@@ -4188,7 +4467,7 @@ msgstr "Beschreibung:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Lesezeichen verwalten"
 
@@ -4217,17 +4496,6 @@ msgstr "Einstellungen"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objekte"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-msgid "Dwarf planets"
-msgstr "Zwergplaneten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4312,49 +4580,43 @@ msgstr "Partielle Flugbahnen"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Koordinatennetze"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Äquatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptikal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktisch"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Linien"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Grenzen"
 
@@ -4385,7 +4647,6 @@ msgstr "Typen:"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Städte"
 
@@ -4398,21 +4659,18 @@ msgstr "Landeplätze"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulkane"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatorien"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Krater"
 
@@ -4443,7 +4701,6 @@ msgstr "Maria (Meere)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Andere Merkmale"
 
@@ -4543,7 +4800,7 @@ msgstr "Datum: "
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -4784,21 +5041,21 @@ msgid "&About Celestia"
 msgstr "Über &Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4807,529 +5064,619 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2017, Celestia Development Team"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia ist freie Software und es wird keinerlei Garantie übernommen."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autoren"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Objekt auswählen"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Objektname"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Lizenz"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Celestia-Steuerung"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL-Treiberinformationen"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Setze Simulationszeit"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Format: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Setze auf aktuelle Zeit"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Lesezeichen hinzufügen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Erzeuge in >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Neuer Ordner..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Sonnensystem-Browser"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Neuen Lesezeichenordner hinzufügen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Gehe zu"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Ordnername"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Objekte im Sonnensystem"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Celestia-Steuerung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Sternkatalog"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Nächste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Hellste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "Mit planeten"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Aktualisieren"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Suchkriterien für Sterne"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maximale Anzahl von Sternen in der Liste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Interessante Ziele"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Gehe zu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Ziel auswählen:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Gehe zu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Längengrad"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Breitengrad"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Entfernung"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Größe:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Anzeigemodus auswählen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Auflösung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Anzeigeoptionen"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Finsternis-Suche"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Anzeigen"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Berechne"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Anzeige"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Zeit setzen und zum Planeten gehen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Ekliptikal"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Schließen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Orbits / Bezeichnungen"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Von:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Lateinische Namen"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Infotext"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Knapp"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Suchparameter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Ausführlich"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Objekt auswählen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Landeplätze"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Objektname"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Berge)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL-Treiberinformationen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Meere)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Gehe zu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Täler)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Gehe zu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Landmassen)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Merkmale beschriften"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Längengrad"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Breitengrad"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Entfernung"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Lizenz"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Merkmale anzeigen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Zeige Orbits"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Minimale Größe beschrifteter Merkmale"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Neuen Lesezeichenordner hinzufügen"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Größe:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Ordnername"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Umbenennen..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Lesezeichen oder Ordner umbenennen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Neuer Name"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Finsternis-Suche"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Setze Simulationszeit"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Berechne"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Zeit setzen und zum Planeten gehen"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Setze auf aktuelle Zeit"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Schließen"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Sonnensystem-Browser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Von:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Gehe zu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Objekte im Sonnensystem"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Sternkatalog"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Suchparameter"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Aktualisieren"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Sonnenfinsternisse"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Suchkriterien für Sterne"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Mondfinsternisse"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maximale Anzahl von Sternen in der Liste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Interessante Ziele"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Ziel auswählen:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Anzeigeoptionen"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Anzeigen"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Anzeige"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Orbits / Bezeichnungen"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Infotext"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "407"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mär"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dez"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satellit"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Datum"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Anbieter: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Fenstermodus"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Renderer: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Unsichtbare Objekte"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "S&ynchr. Orbit"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Körperachsen anzeigen"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Koordinatenachsen anzeigen"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Richtung zur Sonne anzeigen"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Geschwindigkeitsvektor anzeigen"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Gradnetz des Planeten anzeigen"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Terminator anzeigen"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satelliten"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Umlaufende Objekte"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Lade: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "de"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Lade URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Version: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL-Version: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Maximale Anzahl simultaner Texturen: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Maximale Texturgröße: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Maximale Cube-Map-Texturgröße: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Bereich der Punktgröße: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Unterstützte Erweiterungen:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Fenstermodus"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Unsichtbare Objekte"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "S&ynchr. Orbit"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Körperachsen anzeigen"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Koordinatenachsen anzeigen"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Richtung zur Sonne anzeigen"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Geschwindigkeitsvektor anzeigen"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Gradnetz des Planeten anzeigen"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Terminator anzeigen"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satelliten"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Umlaufende Objekte"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Lade: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "de"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Lade URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Fehler beim Öffnen des Skripts"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Fehler beim Laden des Skripts"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Starte Skript"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Zeitzone"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "UTC-Versatz"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Fehler beim Öffnen der Skript-Datei."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Unbekannter Fehler beim Öffnen des Skripts"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Fehler beim Öffnen des Skripts '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Initialisierung der Skript-Koroutine ist fehlgeschlagen"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Fehler beim Öffnen des Skripts '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Unbekannter Fehler beim Öffnen des Skripts"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Fehler beim Öffnen von "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Lade NV fragment program: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Fehler beim Laden des NV fragment program: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Fehler im Fragment-Programm "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Initialisiere NV fragment programs . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Alle NV fragment programs wurden erfolgreich geladen.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Initialisiere ARB fragment programs . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": unbekanntes oder nicht unterstütztes Bild-Dateiformat.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Lade NV vertex program: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Fehler beim Laden des NV vertex program: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Fehler im Vertex program "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Lade ARB vertex program: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Fehler beim Laden des ARB vertex program: "
+
+#~ msgid ", line "
+#~ msgstr ", Zeile "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Initialisiere NV vertex programs . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Alle NV vertex programs wurden erfolgreich geladen.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Initialisiere ARB vertex programs . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Alle ARB vertex programs wurden erfolgreich geladen.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Unbekannter Fehler beim Öffnen des Skripts"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Kopiere URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL kopiert"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Alt-Azimut-Modus eingeschaltet"
+
+#~ msgid "Nearest"
+#~ msgstr "Nächste"
+
+#~ msgid "Brightest"
+#~ msgstr "Hellste"
+
+#~ msgid "With planets"
+#~ msgstr "Mit planeten"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Ekliptikal"
+
+#~ msgid "Latin Names"
+#~ msgstr "Lateinische Namen"
+
+#~ msgid "Terse"
+#~ msgstr "Knapp"
+
+#~ msgid "Verbose"
+#~ msgstr "Ausführlich"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Landeplätze"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Berge)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Meere)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Täler)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Landmassen)"
+
+#~ msgid "Label Features"
+#~ msgstr "Merkmale beschriften"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Sonnenfinsternisse"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Mondfinsternisse"
+
+#~ msgid "Vendor: "
+#~ msgstr "Anbieter: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL-Version: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Unterstützte Erweiterungen:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Fehler beim Öffnen des Skripts"
+
+#~ msgid "Error loading script"
+#~ msgstr "Fehler beim Laden des Skripts"
+
+#~ msgid "Running script"
+#~ msgstr "Starte Skript"
 
 #~ msgid "Invisible"
 #~ msgstr "Unsichtbares Objekt"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Ερμής"
 msgid "Venus"
 msgstr "Αφροδίτη"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Γη"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Σελήνη"
 
@@ -47,140 +47,140 @@ msgstr "Φόβος"
 msgid "Deimos"
 msgstr "Δείμος"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Δίας "
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Αμάλθεια"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Ιω"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Ευρώπη"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Γανυμήδης"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Καλλιστώ"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Κρόνος "
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Προμηθέας"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Πανδώρα"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Επιμηθέας"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Ιανός"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Μιμάς"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Εγκέλαδος"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Τήθυς"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Διώνη"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Ρέα"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Τιτάνας"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Υπερίων"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Ιάπετος"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Φοίβος"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Ουρανός"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Μιράντα"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Άριελ"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Ουμβριήλ"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Τιτάνια"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Ομπερόν"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Ποσειδών"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Λάρισσα"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Πρωτέας"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Τρίτων"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Νηρηίδα"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Πλούτωνας-Χάροντας"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Πλούτωνας "
 
@@ -189,1037 +189,1297 @@ msgid "Charon"
 msgstr "Χάροντας"
 
 #: ../data/data.cpp:42
-msgid "NORTH AMERICA"
-msgstr "ΒΟΡΕΙΑ ΑΜΕΡΙΚΗ"
-
-#: ../data/data.cpp:43
-msgid "SOUTH AMERICA"
-msgstr "ΝΟΤΙΑ ΑΜΕΡΙΚΗ"
-
-#: ../data/data.cpp:44
-msgid "EURASIA"
-msgstr "ΕΥΡΑΣΙΑ"
-
-#: ../data/data.cpp:45
-msgid "AFRICA"
-msgstr "ΑΦΡΙΚΗ"
-
-#: ../data/data.cpp:46
-msgid "AUSTRALIA"
-msgstr "ΑΥΣΤΡΑΛΙΑ"
-
-#: ../data/data.cpp:47
-msgid "ANTARCTICA"
-msgstr "ΑΝΤΑΡΚΤΙΚΗ"
-
-#: ../data/data.cpp:48
-msgid "NORTH ATLANTIC OCEAN"
-msgstr "ΒΟΡΕΙΟΑΤΛΑΝΤΙΚΟΣ ΩΚΕΑΝΟΣ"
-
-#: ../data/data.cpp:49
-msgid "SOUTH ATLANTIC OCEAN"
-msgstr "ΝΟΤΙΟΑΤΛΑΝΤΙΚΟΣ ΩΚΕΑΝΟΣ"
-
-#: ../data/data.cpp:50
-msgid "NORTH PACIFIC OCEAN"
-msgstr "ΒΟΡΕΙΟΣ ΕΙΡΗΝΙΚΟΣ ΩΚΕΑΝΟΣ"
-
-#: ../data/data.cpp:51
-msgid "SOUTH PACIFIC OCEAN"
-msgstr "ΝΟΤΙΟΣ ΕΙΡΗΝΙΚΟΣ ΩΚΕΑΝΟΣ"
-
-#: ../data/data.cpp:52
-msgid "INDIAN OCEAN"
-msgstr "ΙΝΔΙΚΟΣ ΩΚΕΑΝΟΣ"
-
-#: ../data/data.cpp:53
-msgid "ARCTIC OCEAN"
-msgstr "ΑΡΚΤΙΚΟΣ ΩΚΕΑΝΟΣ"
-
-#: ../data/data.cpp:54
-msgid "Abu Dhabi"
-msgstr "Αμπού Ντάμπι"
-
-#: ../data/data.cpp:55
-msgid "Abuja"
+msgid "Styx"
 msgstr ""
 
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+msgid "Haumea"
+msgstr ""
+
+#: ../data/data.cpp:47
+msgid "Namaka"
+msgstr ""
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Αμάλθεια"
+
 #: ../data/data.cpp:56
-msgid "Accra"
+msgid "Thebe"
 msgstr ""
 
 #: ../data/data.cpp:57
-msgid "Adamstown"
+msgid "Themisto"
 msgstr ""
 
 #: ../data/data.cpp:58
-msgid "Addis Ababa"
-msgstr "Αντίς Αμπέμπα"
+msgid "Leda"
+msgstr ""
 
 #: ../data/data.cpp:59
-msgid "Algiers"
-msgstr "Αλγέρι"
+msgid "Himalia"
+msgstr ""
 
 #: ../data/data.cpp:60
-msgid "Alofi"
+msgid "Lysithea"
 msgstr ""
 
 #: ../data/data.cpp:61
-msgid "Amman"
-msgstr "Αμμάν"
+msgid "Elara"
+msgstr ""
 
 #: ../data/data.cpp:62
-msgid "Amsterdam"
-msgstr "Άμστερνταμ"
+msgid "Iocaste"
+msgstr ""
 
 #: ../data/data.cpp:63
-msgid "Andorra la Vella"
+msgid "Praxidike"
 msgstr ""
 
 #: ../data/data.cpp:64
-msgid "Ankara"
-msgstr "Άγκυρα"
+msgid "Harpalyke"
+msgstr ""
 
 #: ../data/data.cpp:65
-msgid "Antananarivo"
+msgid "Ananke"
 msgstr ""
 
 #: ../data/data.cpp:66
-msgid "Apia"
+msgid "Isonoe"
 msgstr ""
 
 #: ../data/data.cpp:67
-msgid "Ashgabat"
+msgid "Erinome"
 msgstr ""
 
 #: ../data/data.cpp:68
-msgid "Asmara"
+msgid "Taygete"
 msgstr ""
 
 #: ../data/data.cpp:69
-msgid "Astana"
-msgstr "Aστάνα"
+msgid "Chaldene"
+msgstr ""
 
 #: ../data/data.cpp:70
-msgid "Asuncion"
+msgid "Carme"
 msgstr ""
 
 #: ../data/data.cpp:71
-msgid "Athens"
-msgstr "Αθήνα"
+msgid "Pasiphae"
+msgstr ""
 
 #: ../data/data.cpp:72
-msgid "Avarua"
-msgstr "Αβαρούα"
+msgid "Kalyke"
+msgstr ""
 
 #: ../data/data.cpp:73
-msgid "Baghdad"
-msgstr "Βαγδάτη"
+msgid "Megaclite"
+msgstr ""
 
 #: ../data/data.cpp:74
-msgid "Baku"
+msgid "Sinope"
 msgstr ""
 
 #: ../data/data.cpp:75
-msgid "Bamako"
-msgstr ""
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Καλλιστώ"
 
 #: ../data/data.cpp:76
-msgid "Bandar Seri Begawan"
-msgstr ""
+#, fuzzy
+msgid "Pan"
+msgstr "Ιαν"
 
 #: ../data/data.cpp:77
-msgid "Bangkok"
-msgstr "Μπανγκόκ"
-
-#: ../data/data.cpp:78
-msgid "Bangui"
+msgid "Atlas"
 msgstr ""
 
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
 #: ../data/data.cpp:79
-msgid "Banjul"
+msgid "Calypso"
 msgstr ""
 
 #: ../data/data.cpp:80
-msgid "Basse-Terre"
+msgid "Helene"
 msgstr ""
 
 #: ../data/data.cpp:81
-msgid "Basseterre"
+msgid "Cordelia"
 msgstr ""
 
 #: ../data/data.cpp:82
-msgid "Beijing"
-msgstr "Πεκίνο"
+msgid "Ophelia"
+msgstr ""
 
 #: ../data/data.cpp:83
-msgid "Beirut"
-msgstr "Βηρυτός"
+msgid "Bianca"
+msgstr ""
 
 #: ../data/data.cpp:84
-msgid "Belgrade"
-msgstr "Βελιγράδι"
+msgid "Cressida"
+msgstr ""
 
 #: ../data/data.cpp:85
-msgid "Belmopan"
+msgid "Desdemona"
 msgstr ""
 
 #: ../data/data.cpp:86
-msgid "Berlin"
-msgstr "Βερολίνο"
+msgid "Juliet"
+msgstr ""
 
 #: ../data/data.cpp:87
-msgid "Bern"
-msgstr "Βέρνη"
+#, fuzzy
+msgid "Portia"
+msgstr "Πορ Λουί"
 
 #: ../data/data.cpp:88
-msgid "Bishkek"
+msgid "Rosalind"
 msgstr ""
 
 #: ../data/data.cpp:89
-msgid "Bissau"
+msgid "Belinda"
 msgstr ""
 
 #: ../data/data.cpp:90
-msgid "Bloemfontein"
+msgid "Puck"
 msgstr ""
 
 #: ../data/data.cpp:91
-msgid "Bogota"
-msgstr "Μπογκοτά"
+msgid "Caliban"
+msgstr ""
 
 #: ../data/data.cpp:92
-msgid "Brasilia"
+msgid "Stephano"
 msgstr ""
 
 #: ../data/data.cpp:93
-msgid "Bratislava"
-msgstr "Μπρατισλάβα"
+msgid "Sycorax"
+msgstr ""
 
 #: ../data/data.cpp:94
-msgid "Brazzaville"
+msgid "Prospero"
 msgstr ""
 
 #: ../data/data.cpp:95
-msgid "Bridgetown"
+msgid "Setebos"
 msgstr ""
 
 #: ../data/data.cpp:96
-msgid "Brussels"
-msgstr "Βρυξέλλες"
+msgid "Naiad"
+msgstr ""
 
 #: ../data/data.cpp:97
-msgid "Bucharest"
-msgstr "Βουκουρέστι"
+msgid "Thalassa"
+msgstr ""
 
 #: ../data/data.cpp:98
-msgid "Budapest"
-msgstr "Βουδαπέστη"
+msgid "Despina"
+msgstr ""
 
 #: ../data/data.cpp:99
-msgid "Buenos Aires"
-msgstr "Μπουένος Άιρες"
+#, fuzzy
+msgid "Galatea"
+msgstr "Γαλαξίες"
 
 #: ../data/data.cpp:100
-msgid "Bujumbura"
-msgstr ""
+msgid "NORTH AMERICA"
+msgstr "ΒΟΡΕΙΑ ΑΜΕΡΙΚΗ"
 
 #: ../data/data.cpp:101
-msgid "Cairo"
-msgstr "Κάιρο"
+msgid "SOUTH AMERICA"
+msgstr "ΝΟΤΙΑ ΑΜΕΡΙΚΗ"
 
 #: ../data/data.cpp:102
-msgid "Canberra"
-msgstr ""
+msgid "EURASIA"
+msgstr "ΕΥΡΑΣΙΑ"
 
 #: ../data/data.cpp:103
-msgid "Cape Town"
-msgstr "Κέιπ Τάουν"
+msgid "AFRICA"
+msgstr "ΑΦΡΙΚΗ"
 
 #: ../data/data.cpp:104
-msgid "Caracas"
-msgstr "Καράκας"
+msgid "AUSTRALIA"
+msgstr "ΑΥΣΤΡΑΛΙΑ"
 
 #: ../data/data.cpp:105
-msgid "Castries"
-msgstr ""
+msgid "ANTARCTICA"
+msgstr "ΑΝΤΑΡΚΤΙΚΗ"
 
 #: ../data/data.cpp:106
-msgid "Cayenne"
-msgstr ""
+msgid "NORTH ATLANTIC OCEAN"
+msgstr "ΒΟΡΕΙΟΑΤΛΑΝΤΙΚΟΣ ΩΚΕΑΝΟΣ"
 
 #: ../data/data.cpp:107
-msgid "Charlotte Amalie"
-msgstr ""
+msgid "SOUTH ATLANTIC OCEAN"
+msgstr "ΝΟΤΙΟΑΤΛΑΝΤΙΚΟΣ ΩΚΕΑΝΟΣ"
 
 #: ../data/data.cpp:108
-msgid "Chisinau"
-msgstr ""
+msgid "NORTH PACIFIC OCEAN"
+msgstr "ΒΟΡΕΙΟΣ ΕΙΡΗΝΙΚΟΣ ΩΚΕΑΝΟΣ"
 
 #: ../data/data.cpp:109
-msgid "Colombo"
-msgstr "Κολόμπο"
+msgid "SOUTH PACIFIC OCEAN"
+msgstr "ΝΟΤΙΟΣ ΕΙΡΗΝΙΚΟΣ ΩΚΕΑΝΟΣ"
 
 #: ../data/data.cpp:110
-msgid "Conakry"
-msgstr ""
+msgid "INDIAN OCEAN"
+msgstr "ΙΝΔΙΚΟΣ ΩΚΕΑΝΟΣ"
 
 #: ../data/data.cpp:111
-msgid "Copenhagen"
-msgstr "Κοπεγχάγη"
+msgid "ARCTIC OCEAN"
+msgstr "ΑΡΚΤΙΚΟΣ ΩΚΕΑΝΟΣ"
 
 #: ../data/data.cpp:112
-msgid "Cotonou"
-msgstr ""
+msgid "Abu Dhabi"
+msgstr "Αμπού Ντάμπι"
 
 #: ../data/data.cpp:113
-msgid "Dakar"
-msgstr "Ντακάρ"
+msgid "Abuja"
+msgstr ""
 
 #: ../data/data.cpp:114
-msgid "Damascus"
-msgstr "Δαμασκός"
+msgid "Accra"
+msgstr ""
 
 #: ../data/data.cpp:115
-msgid "Dar es Salaam"
+msgid "Adamstown"
 msgstr ""
 
 #: ../data/data.cpp:116
-msgid "Dhaka"
-msgstr ""
+msgid "Addis Ababa"
+msgstr "Αντίς Αμπέμπα"
 
 #: ../data/data.cpp:117
-msgid "Dili"
-msgstr ""
+msgid "Algiers"
+msgstr "Αλγέρι"
 
 #: ../data/data.cpp:118
-msgid "Djibouti"
-msgstr "Τζιμπουτί"
+msgid "Alofi"
+msgstr ""
 
 #: ../data/data.cpp:119
-msgid "Doha"
-msgstr ""
+msgid "Amman"
+msgstr "Αμμάν"
 
 #: ../data/data.cpp:120
-msgid "Douglas"
-msgstr ""
+msgid "Amsterdam"
+msgstr "Άμστερνταμ"
 
 #: ../data/data.cpp:121
-msgid "Dublin"
-msgstr "Δουβλίνο"
-
-#: ../data/data.cpp:122
-msgid "Dushanbe"
+msgid "Andorra la Vella"
 msgstr ""
 
+#: ../data/data.cpp:122
+msgid "Ankara"
+msgstr "Άγκυρα"
+
 #: ../data/data.cpp:123
-msgid "Fongafale"
+msgid "Antananarivo"
 msgstr ""
 
 #: ../data/data.cpp:124
-msgid "Fort-de-France"
+msgid "Apia"
 msgstr ""
 
 #: ../data/data.cpp:125
-msgid "Freetown"
+msgid "Ashgabat"
 msgstr ""
 
 #: ../data/data.cpp:126
-msgid "Gaborone"
+msgid "Asmara"
 msgstr ""
 
 #: ../data/data.cpp:127
+msgid "Astana"
+msgstr "Aστάνα"
+
+#: ../data/data.cpp:128
+msgid "Asuncion"
+msgstr ""
+
+#: ../data/data.cpp:129
+msgid "Athens"
+msgstr "Αθήνα"
+
+#: ../data/data.cpp:130
+msgid "Avarua"
+msgstr "Αβαρούα"
+
+#: ../data/data.cpp:131
+msgid "Baghdad"
+msgstr "Βαγδάτη"
+
+#: ../data/data.cpp:132
+msgid "Baku"
+msgstr ""
+
+#: ../data/data.cpp:133
+msgid "Bamako"
+msgstr ""
+
+#: ../data/data.cpp:134
+msgid "Bandar Seri Begawan"
+msgstr ""
+
+#: ../data/data.cpp:135
+msgid "Bangkok"
+msgstr "Μπανγκόκ"
+
+#: ../data/data.cpp:136
+msgid "Bangui"
+msgstr ""
+
+#: ../data/data.cpp:137
+msgid "Banjul"
+msgstr ""
+
+#: ../data/data.cpp:138
+msgid "Basse-Terre"
+msgstr ""
+
+#: ../data/data.cpp:139
+msgid "Basseterre"
+msgstr ""
+
+#: ../data/data.cpp:140
+msgid "Beijing"
+msgstr "Πεκίνο"
+
+#: ../data/data.cpp:141
+msgid "Beirut"
+msgstr "Βηρυτός"
+
+#: ../data/data.cpp:142
+msgid "Belgrade"
+msgstr "Βελιγράδι"
+
+#: ../data/data.cpp:143
+msgid "Belmopan"
+msgstr ""
+
+#: ../data/data.cpp:144
+msgid "Berlin"
+msgstr "Βερολίνο"
+
+#: ../data/data.cpp:145
+msgid "Bern"
+msgstr "Βέρνη"
+
+#: ../data/data.cpp:146
+msgid "Bishkek"
+msgstr ""
+
+#: ../data/data.cpp:147
+msgid "Bissau"
+msgstr ""
+
+#: ../data/data.cpp:148
+msgid "Bloemfontein"
+msgstr ""
+
+#: ../data/data.cpp:149
+msgid "Bogota"
+msgstr "Μπογκοτά"
+
+#: ../data/data.cpp:150
+msgid "Brasilia"
+msgstr ""
+
+#: ../data/data.cpp:151
+msgid "Bratislava"
+msgstr "Μπρατισλάβα"
+
+#: ../data/data.cpp:152
+msgid "Brazzaville"
+msgstr ""
+
+#: ../data/data.cpp:153
+msgid "Bridgetown"
+msgstr ""
+
+#: ../data/data.cpp:154
+msgid "Brussels"
+msgstr "Βρυξέλλες"
+
+#: ../data/data.cpp:155
+msgid "Bucharest"
+msgstr "Βουκουρέστι"
+
+#: ../data/data.cpp:156
+msgid "Budapest"
+msgstr "Βουδαπέστη"
+
+#: ../data/data.cpp:157
+msgid "Buenos Aires"
+msgstr "Μπουένος Άιρες"
+
+#: ../data/data.cpp:158
+msgid "Bujumbura"
+msgstr ""
+
+#: ../data/data.cpp:159
+msgid "Cairo"
+msgstr "Κάιρο"
+
+#: ../data/data.cpp:160
+msgid "Canberra"
+msgstr ""
+
+#: ../data/data.cpp:161
+msgid "Cape Town"
+msgstr "Κέιπ Τάουν"
+
+#: ../data/data.cpp:162
+msgid "Caracas"
+msgstr "Καράκας"
+
+#: ../data/data.cpp:163
+msgid "Castries"
+msgstr ""
+
+#: ../data/data.cpp:164
+msgid "Cayenne"
+msgstr ""
+
+#: ../data/data.cpp:165
+msgid "Charlotte Amalie"
+msgstr ""
+
+#: ../data/data.cpp:166
+msgid "Chisinau"
+msgstr ""
+
+#: ../data/data.cpp:167
+msgid "Colombo"
+msgstr "Κολόμπο"
+
+#: ../data/data.cpp:168
+msgid "Conakry"
+msgstr ""
+
+#: ../data/data.cpp:169
+msgid "Copenhagen"
+msgstr "Κοπεγχάγη"
+
+#: ../data/data.cpp:170
+msgid "Cotonou"
+msgstr ""
+
+#: ../data/data.cpp:171
+msgid "Dakar"
+msgstr "Ντακάρ"
+
+#: ../data/data.cpp:172
+msgid "Damascus"
+msgstr "Δαμασκός"
+
+#: ../data/data.cpp:173
+msgid "Dar es Salaam"
+msgstr ""
+
+#: ../data/data.cpp:174
+msgid "Dhaka"
+msgstr ""
+
+#: ../data/data.cpp:175
+msgid "Dili"
+msgstr ""
+
+#: ../data/data.cpp:176
+msgid "Djibouti"
+msgstr "Τζιμπουτί"
+
+#: ../data/data.cpp:177
+msgid "Doha"
+msgstr ""
+
+#: ../data/data.cpp:178
+msgid "Douglas"
+msgstr ""
+
+#: ../data/data.cpp:179
+msgid "Dublin"
+msgstr "Δουβλίνο"
+
+#: ../data/data.cpp:180
+msgid "Dushanbe"
+msgstr ""
+
+#: ../data/data.cpp:181
+msgid "Fongafale"
+msgstr ""
+
+#: ../data/data.cpp:182
+msgid "Fort-de-France"
+msgstr ""
+
+#: ../data/data.cpp:183
+msgid "Freetown"
+msgstr ""
+
+#: ../data/data.cpp:184
+msgid "Gaborone"
+msgstr ""
+
+#: ../data/data.cpp:185
 #, fuzzy
 msgid "George Town"
 msgstr "Κέιπ Τάουν"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr ""
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Γιβραλτάρ"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr ""
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Γουατεμάλα"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr ""
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Χάγη"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr ""
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Ανόι"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr ""
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Αβάνα"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Ελσίνκι"
 
-#: ../data/data.cpp:139
-msgid "Honiara"
-msgstr ""
-
-#: ../data/data.cpp:140
-msgid "Islamabad"
-msgstr "Ισλαμαμπάντ"
-
-#: ../data/data.cpp:141
-msgid "Jakarta"
-msgstr "Τζακάρτα"
-
-#: ../data/data.cpp:142
-msgid "Jamestown"
-msgstr ""
-
-#: ../data/data.cpp:143
-msgid "Jerusalem"
-msgstr "Ιερουσαλήμ"
-
-#: ../data/data.cpp:144
-msgid "Kabul"
-msgstr "Καμπούλ"
-
-#: ../data/data.cpp:145
-msgid "Kampala"
-msgstr "Καμπάλα"
-
-#: ../data/data.cpp:146
-msgid "Kathmandu"
-msgstr "Κατμαντού"
-
-#: ../data/data.cpp:147
-msgid "Khartoum"
-msgstr "Χαρτούμ"
-
-#: ../data/data.cpp:148
-msgid "Kiev"
-msgstr "Κίεβο"
-
-#: ../data/data.cpp:149
-msgid "Kigali"
-msgstr ""
-
-#: ../data/data.cpp:150 ../data/data.cpp:151
-msgid "Kingston"
-msgstr ""
-
-#: ../data/data.cpp:152
-msgid "Kingstown"
-msgstr ""
-
-#: ../data/data.cpp:153
-msgid "Kinshasa"
-msgstr "Κινσάσα"
-
-#: ../data/data.cpp:154
-msgid "Koror"
-msgstr ""
-
-#: ../data/data.cpp:155
-msgid "Kuala Lumpur"
-msgstr "Κουάλα Λουμπούρ"
-
-#: ../data/data.cpp:156
-msgid "Kuwait"
-msgstr "Κουβέιτ"
-
-#: ../data/data.cpp:157
-msgid "La'youn"
-msgstr ""
-
-#: ../data/data.cpp:158
-msgid "La Paz"
-msgstr ""
-
-#: ../data/data.cpp:159
-msgid "Libreville"
-msgstr ""
-
-#: ../data/data.cpp:160
-msgid "Lilongwe"
-msgstr ""
-
-#: ../data/data.cpp:161
-msgid "Lima"
-msgstr "Λίμα"
-
-#: ../data/data.cpp:162
-msgid "Lisbon"
-msgstr "Λισαβόνα"
-
-#: ../data/data.cpp:163
-msgid "Ljubljana"
-msgstr "Λιουμπλιάνα"
-
-#: ../data/data.cpp:164
-msgid "Lobamba"
-msgstr ""
-
-#: ../data/data.cpp:165
-msgid "Lome"
-msgstr ""
-
-#: ../data/data.cpp:166
-msgid "London"
-msgstr "Λονδίνο"
-
-#: ../data/data.cpp:167
-msgid "Longyearbyen"
-msgstr ""
-
-#: ../data/data.cpp:168
-msgid "Luanda"
-msgstr ""
-
-#: ../data/data.cpp:169
-msgid "Lusaka"
-msgstr ""
-
-#: ../data/data.cpp:170
-msgid "Luxembourg"
-msgstr "Λουξεμβούργο"
-
-#: ../data/data.cpp:171
-msgid "Madrid"
-msgstr "Μαδρίτη"
-
-#: ../data/data.cpp:172
-msgid "Majuro"
-msgstr ""
-
-#: ../data/data.cpp:173
-msgid "Malabo"
-msgstr ""
-
-#: ../data/data.cpp:174
-msgid "Male"
-msgstr ""
-
-#: ../data/data.cpp:175
-msgid "Mamoutzou"
-msgstr ""
-
-#: ../data/data.cpp:176
-msgid "Managua"
-msgstr ""
-
-#: ../data/data.cpp:177
-msgid "Manama"
-msgstr ""
-
-#: ../data/data.cpp:178
-msgid "Manila"
-msgstr "Μανίλα"
-
-#: ../data/data.cpp:179
-msgid "Maputo"
-msgstr ""
-
-#: ../data/data.cpp:180
-msgid "Maseru"
-msgstr ""
-
-#: ../data/data.cpp:181
-msgid "Mata-Utu"
-msgstr ""
-
-#: ../data/data.cpp:182
-msgid "Mbabane"
-msgstr ""
-
-#: ../data/data.cpp:183
-msgid "Mexico City"
-msgstr "Πόλη του Μεξικό"
-
-#: ../data/data.cpp:184
-msgid "Minsk"
-msgstr "Μινσκ"
-
-#: ../data/data.cpp:185
-msgid "Mogadishu"
-msgstr "Μογκαντίσου"
-
-#: ../data/data.cpp:186
-msgid "Monaco"
-msgstr "Μονακό"
-
-#: ../data/data.cpp:187
-msgid "Monrovia"
-msgstr ""
-
-#: ../data/data.cpp:188
-msgid "Montevideo"
-msgstr "Μοντεβιδέο"
-
-#: ../data/data.cpp:189
-msgid "Moroni"
-msgstr ""
-
-#: ../data/data.cpp:190
-msgid "Moscow"
-msgstr "Μόσχα"
-
-#: ../data/data.cpp:191
-msgid "Muscat"
-msgstr ""
-
-#: ../data/data.cpp:192
-msgid "Nairobi"
-msgstr "Ναϊρόμπι"
-
-#: ../data/data.cpp:193
-msgid "Nassau"
-msgstr ""
-
-#: ../data/data.cpp:194
-msgid "N'Djamena"
-msgstr ""
-
-#: ../data/data.cpp:195
-msgid "New Delhi"
-msgstr "Νέο Δελχί"
-
-#: ../data/data.cpp:196
-msgid "Niamey"
+#: ??
+msgid "Hong Kong"
 msgstr ""
 
 #: ../data/data.cpp:197
-msgid "Nicosia"
-msgstr "Λευκωσία"
+msgid "Honiara"
+msgstr ""
 
 #: ../data/data.cpp:198
-msgid "Nouakchott"
-msgstr ""
+msgid "Islamabad"
+msgstr "Ισλαμαμπάντ"
 
 #: ../data/data.cpp:199
-msgid "Noumea"
-msgstr ""
+msgid "Jakarta"
+msgstr "Τζακάρτα"
 
 #: ../data/data.cpp:200
-msgid "Nuku'alofa"
+msgid "Jamestown"
 msgstr ""
 
 #: ../data/data.cpp:201
-msgid "Nuuk"
-msgstr ""
+msgid "Jerusalem"
+msgstr "Ιερουσαλήμ"
 
 #: ../data/data.cpp:202
-msgid "Oranjestad"
-msgstr ""
+msgid "Kabul"
+msgstr "Καμπούλ"
 
 #: ../data/data.cpp:203
-msgid "Oslo"
-msgstr "Όσλο"
+msgid "Kampala"
+msgstr "Καμπάλα"
 
 #: ../data/data.cpp:204
-msgid "Ottawa"
-msgstr "Οτάβα"
+msgid "Kathmandu"
+msgstr "Κατμαντού"
 
 #: ../data/data.cpp:205
-msgid "Ouagadougou"
-msgstr "Ουαγκαντούγκου"
+msgid "Khartoum"
+msgstr "Χαρτούμ"
 
 #: ../data/data.cpp:206
-msgid "Pago Pago"
-msgstr "Πάγκο Πάγκο"
+msgid "Kiev"
+msgstr "Κίεβο"
 
 #: ../data/data.cpp:207
-msgid "Palikir"
+msgid "Kigali"
 msgstr ""
 
-#: ../data/data.cpp:208
-msgid "Panama"
-msgstr "Παναμάς"
-
-#: ../data/data.cpp:209
-msgid "Papeete"
+#: ../data/data.cpp:208 ../data/data.cpp:209
+msgid "Kingston"
 msgstr ""
 
 #: ../data/data.cpp:210
+msgid "Kingstown"
+msgstr ""
+
+#: ../data/data.cpp:211
+msgid "Kinshasa"
+msgstr "Κινσάσα"
+
+#: ../data/data.cpp:212
+msgid "Koror"
+msgstr ""
+
+#: ../data/data.cpp:213
+msgid "Kuala Lumpur"
+msgstr "Κουάλα Λουμπούρ"
+
+#: ../data/data.cpp:214
+msgid "Kuwait"
+msgstr "Κουβέιτ"
+
+#: ../data/data.cpp:215
+msgid "La'youn"
+msgstr ""
+
+#: ../data/data.cpp:216
+msgid "La Paz"
+msgstr ""
+
+#: ../data/data.cpp:217
+msgid "Libreville"
+msgstr ""
+
+#: ../data/data.cpp:218
+msgid "Lilongwe"
+msgstr ""
+
+#: ../data/data.cpp:219
+msgid "Lima"
+msgstr "Λίμα"
+
+#: ../data/data.cpp:220
+msgid "Lisbon"
+msgstr "Λισαβόνα"
+
+#: ../data/data.cpp:221
+msgid "Ljubljana"
+msgstr "Λιουμπλιάνα"
+
+#: ../data/data.cpp:222
+msgid "Lobamba"
+msgstr ""
+
+#: ../data/data.cpp:223
+msgid "Lome"
+msgstr ""
+
+#: ../data/data.cpp:224
+msgid "London"
+msgstr "Λονδίνο"
+
+#: ../data/data.cpp:225
+msgid "Longyearbyen"
+msgstr ""
+
+#: ../data/data.cpp:226
+msgid "Luanda"
+msgstr ""
+
+#: ../data/data.cpp:227
+msgid "Lusaka"
+msgstr ""
+
+#: ../data/data.cpp:228
+msgid "Luxembourg"
+msgstr "Λουξεμβούργο"
+
+#: ../data/data.cpp:229
+msgid "Madrid"
+msgstr "Μαδρίτη"
+
+#: ../data/data.cpp:230
+msgid "Majuro"
+msgstr ""
+
+#: ../data/data.cpp:231
+msgid "Malabo"
+msgstr ""
+
+#: ../data/data.cpp:232
+msgid "Male"
+msgstr ""
+
+#: ../data/data.cpp:233
+msgid "Mamoutzou"
+msgstr ""
+
+#: ../data/data.cpp:234
+msgid "Managua"
+msgstr ""
+
+#: ../data/data.cpp:235
+msgid "Manama"
+msgstr ""
+
+#: ../data/data.cpp:236
+msgid "Manila"
+msgstr "Μανίλα"
+
+#: ../data/data.cpp:237
+msgid "Maputo"
+msgstr ""
+
+#: ../data/data.cpp:238
+msgid "Maseru"
+msgstr ""
+
+#: ../data/data.cpp:239
+msgid "Mata-Utu"
+msgstr ""
+
+#: ../data/data.cpp:240
+msgid "Mbabane"
+msgstr ""
+
+#: ../data/data.cpp:241
+msgid "Mexico City"
+msgstr "Πόλη του Μεξικό"
+
+#: ../data/data.cpp:242
+msgid "Minsk"
+msgstr "Μινσκ"
+
+#: ../data/data.cpp:243
+msgid "Mogadishu"
+msgstr "Μογκαντίσου"
+
+#: ../data/data.cpp:244
+msgid "Monaco"
+msgstr "Μονακό"
+
+#: ../data/data.cpp:245
+msgid "Monrovia"
+msgstr ""
+
+#: ../data/data.cpp:246
+msgid "Montevideo"
+msgstr "Μοντεβιδέο"
+
+#: ../data/data.cpp:247
+msgid "Moroni"
+msgstr ""
+
+#: ../data/data.cpp:248
+msgid "Moscow"
+msgstr "Μόσχα"
+
+#: ../data/data.cpp:249
+msgid "Muscat"
+msgstr ""
+
+#: ../data/data.cpp:250
+msgid "Nairobi"
+msgstr "Ναϊρόμπι"
+
+#: ../data/data.cpp:251
+msgid "Nassau"
+msgstr ""
+
+#: ../data/data.cpp:252
+msgid "N'Djamena"
+msgstr ""
+
+#: ../data/data.cpp:253
+msgid "New Delhi"
+msgstr "Νέο Δελχί"
+
+#: ../data/data.cpp:254
+msgid "Niamey"
+msgstr ""
+
+#: ../data/data.cpp:255
+msgid "Nicosia"
+msgstr "Λευκωσία"
+
+#: ../data/data.cpp:256
+msgid "Nouakchott"
+msgstr ""
+
+#: ../data/data.cpp:257
+msgid "Noumea"
+msgstr ""
+
+#: ../data/data.cpp:258
+msgid "Nuku'alofa"
+msgstr ""
+
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
+msgid "Nuuk"
+msgstr ""
+
+#: ../data/data.cpp:260
+msgid "Oranjestad"
+msgstr ""
+
+#: ../data/data.cpp:261
+msgid "Oslo"
+msgstr "Όσλο"
+
+#: ../data/data.cpp:262
+msgid "Ottawa"
+msgstr "Οτάβα"
+
+#: ../data/data.cpp:263
+msgid "Ouagadougou"
+msgstr "Ουαγκαντούγκου"
+
+#: ../data/data.cpp:264
+msgid "Pago Pago"
+msgstr "Πάγκο Πάγκο"
+
+#: ../data/data.cpp:265
+msgid "Palikir"
+msgstr ""
+
+#: ../data/data.cpp:266
+msgid "Panama"
+msgstr "Παναμάς"
+
+#: ../data/data.cpp:267
+msgid "Papeete"
+msgstr ""
+
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Παραμαρίμπο"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Παρίσι"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Πνομ Πενχ"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr ""
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Πορ Λουί"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 #, fuzzy
 msgid "Port Moresby"
 msgstr "Πορτ οφ Σπέιν"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Πορτ-ο-Πρενς"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Πορτ οφ Σπέιν"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Πόρτο Νόβο"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 #, fuzzy
 msgid "Port-Vila"
 msgstr "Πορ Λουί"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Πράγα"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr ""
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr ""
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr ""
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr ""
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr ""
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr ""
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Ρέικιαβικ"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Ρίγα"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr ""
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 #, fuzzy
 msgid "Road Town"
 msgstr "Κέιπ Τάουν"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Ρώμη"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr ""
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Σεντ Τζόρτζες"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 #, fuzzy
 msgid "Saint Helier"
 msgstr "Σεντ Τζονς"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Σεντ Τζονς"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 #, fuzzy
 msgid "Saint Peter Port"
 msgstr "Πορ Λουί"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 #, fuzzy
 msgid "Saint-Denis"
 msgstr "Σεντ Τζονς"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 #, fuzzy
 msgid "Saint-Pierre"
 msgstr "Σεντ Τζονς"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr ""
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "Σαν Χοσέ"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "Σαν Χουάν"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "Σαν Μαρίνο"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "Σαν Σαλβαδόρ"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr ""
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Σαντιάγο"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Σάντο Ντομίνγκο"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr ""
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Σεράγεβο"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Σεούλ"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr ""
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Σιγκαπούρη"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Σκόπια"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Σόφια"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr ""
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Στοκχόλμη"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Σούκρε"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr ""
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Ταϊπέι"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr ""
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr ""
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Τασκένδη"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Τιφλίδα"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr ""
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Τεχεράνη"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Τελ Αβίβ"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr ""
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Τίρανα"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Τόκιο"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr ""
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Τρίπολη"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr ""
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr ""
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr ""
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Βαλέττα"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr ""
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Βατικανό"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Βικτόρια"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Βιέννη"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr ""
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Βίλνιους"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Βαρσοβία"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Ουάσιγκτον"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Ουέλλιγκτον"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 #, fuzzy
 msgid "West Island"
 msgstr "Δυτικά"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr ""
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr ""
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr ""
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr ""
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr ""
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr ""
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Ζάγκρεμπ "
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Γαλαξίας"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Βαρύκεντρο Ηλιακού Συστήματος"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Σφάλμα κατά το άνοιγμα του αρχείου εικόνας "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Σφάλμα κατά την ανάγνωση του αρχείου ρυθμίσεων."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1229,87 +1489,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " αντικείμενα βαθέως ουρανού"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Φόρτωση προγράμματος NV Fragment: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Λάθος κατά την φόρτωση NV fragment προγράμματος: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Σφάλμα στο πρόγραμμα fragment"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Αρχικοποίηση προγραμμάτων NV fragment . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Φόρτωση όλων των NV fragment προγραμμάτων επιτυχής.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Αρχικοποιήση ARB fragment προγραμμάτων . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Γαλαξίας (Τύπος Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Φόρτωση εικόνας από αρχείο"
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": μη αναγνωρίσιμο ή μη υποστηριζόμενο αρχείο εικόνας.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου εικόνας "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " δεν είναι αρχείο PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Φόρτωση μοντέλου: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Σφάλμα κατά τη φόρτωση του μοντέλου '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Νεφέλωμα"
 
@@ -1317,92 +1548,92 @@ msgstr "Νεφέλωμα"
 msgid "Open cluster"
 msgstr "Ανοιχτό σμήνος "
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Σφάλμα στο αρχείο .ssc (γραμμή "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "προειδοποιήση ανατύπωση ορισμού από "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "λανθασμένη εναλλακτική επιφάνεια"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "λανθασμένη τοποθεσία"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Λανθασμένη επικεφαλίδα για διασταυρωμένο ευρετήριο\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Λανθασμένη έκδοση για διασταυρωτό ευρετήριο\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Η φόρτωση διασταυρωμένου ευρετηρίου απέτυχε κατά την εγγραφή "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " αστέρες στη δυαδική βάση δεδομένων\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Συνολικό πλήθος αστέρων: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Σφάλμα στο αρχείο .stc (γραμμή"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Άκυρο αστέρι: κακός φασματικός τύπος.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Άκυρο αστέρι: λείπει φασματικός τύπος.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " δεν υπάρχει.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Άκυρο αστέρι:λείπει ορθή αναφορά\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Άκυρο αστέρι:λείπει η κλίση.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Άκυρο αστέρι:λείπει η απόσταση.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Άκυρο αστέρι:λείπει το μέγεθος.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1410,768 +1641,744 @@ msgstr ""
 "Λανθασμένος αστέρας: πρέπει να καθοριστεί απόλυτο (και όχι φαινόμενο) "
 "μέγεθος για τον αστέρα\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Δημιουργία υφής σε παράθεση. Πλάτος="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Δημιουργία συνηθισμένης υφής:"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Φόρτωση του  NV vertex προγράμματος: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Σφάλμα κατά τη φόρτωση του προγράμματος NV vertex: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Σφάλμα στο πρόγραμμα  vertex "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Φόρτωση προγράμματος ARB vertex: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Σφάλμα κατά τη φόρτωση του προγράμματος ARB vertex: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", γραμμή"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Αρχικοποιήση προγραμμάτων NV vertex . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Όλα τα προγράμματα NV vertex φορτώθηκαν επιτυχώς.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Αρχικοποιήση προγραμμάτων ARB vertex  . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Όλα τα προγράμματα ARB vertex φορτώθηκαν επιτυχώς.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Σφάλμα κατά το άνοιγμα"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου αγαπημένων."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Σφάλμα κατά το άνοιγμα του αρχείου σεναρίων."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Αποτυχία αρχικοποίησης σεναρίου"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Μη αποδεκτό είδος αρχείου"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Όριο μεγέθους: %.2f "
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Δείκτες ενεργοποιημένοι"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Δείκτες απενεργοποιημένοι"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Μετάβαση στην επιφάνεια"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Κατάσταση Alt-azimuth ενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Κατάσταση Alt-azimuth απενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Είδος αστέρων: ασαφή σημεία"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Είδος αστέρων: σημεία"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Είδος αστέρων: δίσκοι υπό κλίμακα"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Εμφάνιση ουράς κομητών"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Απόκρυψη ουράς κομητών"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Μονοπάτι αποτύπωσης: OpenGL 2.0 "
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Κατάσταση Alt-azimuth ενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Κατάσταση Alt-azimuth απενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Αυτόματο μέγεθος ενεργοποιημένο"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Αυτόματο μέγεθος απενεργοποιημένο "
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Ο χρόνος και το σενάριο έχουν σταματήσει"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Ο χρόνος είναι σταματημένος"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Επανάληψη"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Συνολικό πλήθος αστέρων: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Συνολικό πλήθος αστέρων: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Χρόνος μετακίνησης του φωτός:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Χρόνος μετακίνησης του φωτός:  %d min  %.1f s "
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Χρόνος μετακίνησης του φωτός:  %d h  %d min  %.1f s "
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Συμπεριλαμβάνεται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Δεν συμπεριλαμβάνεται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Αγνοείται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Χρήση κανονικών υφών επιφάνειας."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Χρήση περιορισμένης γνώσης για τις υφές επιφάνειας. "
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Παρακολούθηση"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Χρόνος: Μπροστά"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Χρόνος: Πίσω"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Ρυθμός χρόνου"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Υφές"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Υφές"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Υφές"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Συγχρονισμός Τροχιάς"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Κλείδωμα"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Καταδίωξη"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Όριο μεγέθους: %.2f "
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Αυτόματο όριο μέγέθους στις 45 μοίρες: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Επίπεδο περιβάλλοντος φωτός:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Light gain"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Bloom ενεργοποιημένο"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Bloom απενεργοποιημένο"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Έκθεση"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Σφάλμα GL:"
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Προβολή πολύ μικρή για να διαιρεθεί"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Προσθήκη προβολής"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "εφ"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "αμ"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "χμ"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " μ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " μέρες"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " ώρες"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " λεπτά"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " δευτερόλεπτα"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " μ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " χμ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " ΑΜ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " εφ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Ταχύτητα:"
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Φαινόμενη διάμετρος: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Φαινόμενο μέγεθος: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Απόλυτο μέγεθος:"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Απόσταση: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Βαρύκεντρο συστήματος αστέρων\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Απόλυτο(φαινόμενο)μέγεθος: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Φωτεινότητα: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Αστέρας νετρονίων"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Μαύρη τρύπα"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Τάξη: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Θερμοκρασία επιφάνειας:"
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Planetary companions present\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Απόσταση από το κέντρο: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Θερμοκρασία: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Πραγματικός χρόνος"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Πραγματικός χρόνος "
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Ο χρόνος έχει σταματήσει"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " πιο γρήγορα"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " πιο αργά"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr "(Σταματημένο)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Ταξιδεύοντας"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Ταξιδεύοντας"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Τροχιά"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Παρακολούθηση"
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Συγχρονισμός Τροχιάς"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Καταδίωξη"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Ήλιος"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Όνομα στόχου:"
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "  Σταματημένο"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Εγγραφή"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Εκκίνηση/Παύση    F12 Σταμάτημα "
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Κατάσταση Επεξεργασίας"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Φόρτωση καταλόγου του ηλιακού συστήματος: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Φόρτωση καταλόγου του ηλιακού συστήματος: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου ρυθμίσεων."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Η αρχικοποίηση της βιβλιοθήκης SPICE απέτυχε."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Δεν ήταν δυνατή η ανάγνωση της βάσης δεδομένων των αστέρων."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου deepsky"
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Δεν ήταν δυνατή η ανάγνωση της βάσης δεδομένων των αστέρων."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου του πλανητικού συστήματος .\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου αστερισμών."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Σφάλμα κατά το άνοιγμα των αρχείων των συνόρων των αστερισμών."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Σφάλμα κατά την αρχικοποίηση της μεθόδου αποτύπωσης"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr ""
 "Σφάλμα κατά την φόρτωση της γραμματοσειράς, το κείμενο δε θα είναι ορατό.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Σφάλμα κατά την ανάγνωση του ευρετηρίου "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Φορτώθηκε το ευρετήριο"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Σφάλμα κατά την ανάγνωση του αρχείου με τα ονόματα των αστεριών\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Σφάλμα κατά το άνοιγμα"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Σφάλμα κατά την ανάγνωση του αρχείου με τα ονόματα των αστεριών\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου αστεριών\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου αστέρων "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
+msgid "%s Version: %s\n"
+msgstr "Έκδοση:"
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Κατασκευαστής:"
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Μέθοδος αποτύπωσης:"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Μέγιστος αριθμός ταυτόχρονων υφών:"
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Μέγιστο μέγεθος υφών:"
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Απόσταση point size: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Απόσταση point size: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Μέγιστο μέγεθος cube map:"
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2369,14 +2576,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Σφάλμα κατά τη δημιουργία του αρχείου ogg %s για τη σύλληψη.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Σφάλμα της βιβλιοθήκης Ogg."
@@ -2395,46 +2602,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - εγγραφή %d καρέ\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Ουράνιος Πλοηγητής"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Ουράνιος Πλοηγητής"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Ηλιακό Σύστημα"
 
@@ -2444,21 +2642,20 @@ msgstr "Ηλιακό Σύστημα"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Άστρα"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " αντικείμενα βαθέως ουρανού"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Εύρεση Έκλειψης "
@@ -2467,463 +2664,514 @@ msgstr "Εύρεση Έκλειψης "
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Χρόνος "
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Ταξιδιωτικός Οδηγός"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Πλήρης Οθόνη"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Σύλληψη &Ταινίας...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου αστερισμών."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Προσθήκη Σελιδοδεικτών..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Αποθήκευση Ως:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " δεν είναι αρχείο PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Ανάλυση:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Ρυθμός καρέ:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Το URL αντιγράφτηκε"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Φόρτωση URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Άνοιγμα Σεναρίου..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Δημιουργία νέου φακέλου σελιδοδείκτη σε αυτή τη λίστα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Υποστηριζόμενες Επεκτάσεις:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Υποστηριζόμενες Επεκτάσεις:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Περί Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>Γλώσσα Shading OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Κατασκευαστής:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "Έκδοση GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Μέγιστος αριθμός ταυτόχρονων υφών:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Μέγιστο μέγεθος υφών:"
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Απόσταση point size: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Απόσταση point size: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Μέγιστο μέγεθος cube map:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Ισημερινή"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Πληροφορίες OpenGL"
+msgid "Renderer Info"
+msgstr "Μέθοδος αποτύπωσης:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Αρχείο"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Σύλληψη Εικόνας"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Σύλληψη &Εικόνας...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Σύλληψη &Ταινίας...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Αντιγραφή URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Αντιγραφή URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Το URL αντιγράφτηκε"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Άνοιγμα Σεναρίου..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Προτιμήσεις Celestia "
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Έ&ξοδος"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Εξομάλυνση Γραμμών\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Πλοήγηση"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Επιλογή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Κεντράρισμα Επιλογής\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Επιλογή: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Μετάβαση στο Αντικείμενο..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Χρόνος "
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Καθορισμός Χρόνου..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Προβολή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Σημειωμένα αντικείμενα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Εμφάνιση Σκιών από Σύννεφα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Τ&ύπος Αστέρα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Ανάλυση Υφής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Πλήκτρα χειρισμού"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "Σ&ελιδοδείκτες "
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Προβολή"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Πολλαπλή Προβολή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Κάθετος Οπτικός Διαχωρισμός Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Οριζόντιος &Διαχωρισμός\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Οριζόντιος Οπτικός Διαχωρισμός Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Κάθετος Δ&ιαχωρισμός\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Κυκλική διάταξη Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Μοναδική Προβολή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Μοναδική Προβολή\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Διαγραφή Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Εμφάνιση Πλαισίων"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Εμφάνιση Πλαισίων Ενεργή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Συγχρονισμός Χρόνου"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Βοήθεια"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Προτιμήσεις Celestia "
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Περί Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Πληροφορίες OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Προσθήκη Σελιδοδείκτη"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Οργάνωση Σελιδοδεικτών..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Φόρτωση"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Σενάρια"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Διάρκεια"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Σ&ελιδοδείκτες "
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Κύρια Γραμμή Εργαλείων"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου αγαπημένων."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Σελιδοδείκτες "
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Καθορισμός Χρόνου Προσομοίωσης"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Καθορισμός Χρόνου Προσομοίωσης"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Χρόνος "
@@ -2932,79 +3180,77 @@ msgstr "Χρόνος "
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Νέος Φάκελος... "
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Εμφάνιση Πλέγματος Ισημερινού"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Γαλαξιακό"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Πλέγμα Ισημερινού"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Οριζόντια"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr ", γραμμή"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " μ/δ"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Δείκτες"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Κεντράρισμα Επιλογής\tC"
@@ -3013,57 +3259,54 @@ msgstr "&Κεντράρισμα Επιλογής\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Αστερισμοί"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, no vertex programs</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Σύνορα αστερισμών"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "Εντάξει"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Τροχιές"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Πλάνητες"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Νάνοι Πλανήτες"
 
@@ -3073,19 +3316,17 @@ msgstr "Νάνοι Πλανήτες"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Δορυφόροι"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Μικροί Δορυφόροι"
 
@@ -3095,12 +3336,12 @@ msgstr "Μικροί Δορυφόροι"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Αστεροειδείς"
 
@@ -3110,12 +3351,12 @@ msgstr "Αστεροειδείς"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Κομήτες"
 
@@ -3125,14 +3366,15 @@ msgstr "Κομήτες"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Διαστημόπλοια"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Πιο &Γρήγορα\tL"
@@ -3141,9 +3383,8 @@ msgstr "10x Πιο &Γρήγορα\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Ετικέτες"
 
@@ -3151,20 +3392,18 @@ msgstr "Ετικέτες"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Γαλαξίες"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Σφαιροειδή"
 
@@ -3172,7 +3411,7 @@ msgstr "Σφαιροειδή"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3182,615 +3421,632 @@ msgstr "Ανοιχτά Σμήνη "
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Νεφελώματα"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Τοποθεσίες"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Ανοιχτά Σμήνη "
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Σύννεφα"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Νυχτερινός Φωτισμός "
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Ουρές Κομητών"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Ατμόσφαιρα"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Σκιές δακτυλίων"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Σκιές έκλειψης"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Σκιές από Σύννεφα"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Χαμηλό"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Μεσαίο"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Υψηλό"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Αυτόματο Μέγεθος\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Εμφάνιση Περισσότερων Αστέρων\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Εμφάνιση Λιγότερων Αστέρων\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Σημεία"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&Ασαφή Σημεία"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Κλιμακούμενοι &Δίσκοι"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Δεν συμπεριλαμβάνεται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Κατάσταση Alt-azimuth ενεργοποιήθηκε"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Αυτόματο όριο μέγέθους στις 45 μοίρες: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Όριο μεγέθους: %.2f "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Όνομα"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Φαιν. Μέγεθος "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Απόλ. Μέγεθος "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Είδος"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Εμφάνιση Αστέρων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Άστρα"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Φιλτράρισμα Αστέρων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Με τους Πλανήτες "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Εμφάνιση Αστέρων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Βαρύκεντρο"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Σημείωση"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Μέγιστος Αριθμός Αστέρων που Εμφανίζονται στη Λίστα"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Σημείωση"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Δείκτες"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Κανένα"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Ρόμβος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Τρίγωνο"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Τετράγωνο"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Πλεον"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Κύκλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Αριστερό Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Δεξί Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Πάνω Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Κάτω Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Επιλογή &Αντικειμένου..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Μέγεθος:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Επιλογή &Αντικειμένου..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Ετικέτες  Δυνατοτήτων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Αντικείμενα"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Σημείωση"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "πατρικό σώμα'"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Έναρξη λειτουργίας πλήρους οθόνης"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Διάρκεια"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Ηλιακές Εκλείψεις"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Εκλείψεις Σελήνης"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Αποεπιλογή &Όλων"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Απόσταση point size: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Εκλείψεις Σελήνης"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Επιλογή &Αντικειμένου..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Ηλιακές Εκλείψεις"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Καθορισμός Χρόνου στο Παρόν"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Φόρτωση εικόνας από αρχείο"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Πληροφορίες"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Πληροφορίες OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Απόσταση (εφ)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Μέγεθος: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Πληροφοριακό Κείμενο"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "αμ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Τ&ύπος Αστέρα"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Τοπική Μορφή"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Όνομα Ζώνης Ώρας "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Αντιστάθμιση UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Εκκίνηση"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3809,21 +4065,21 @@ msgid "&Select"
 msgstr "&Επιλογή"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Κέντρο"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Μετάβαση"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Παρακολούθηση"
 
@@ -3837,49 +4093,54 @@ msgid "Visible"
 msgstr "Εμφάνιση Πλαισίων Ενεργή"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Αποσημείωση"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Επιλογή Κατάστασης Προβολής"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Τετράγωνο με Γέμισμα"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Δίσκος"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Σημείωση"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Σημεία Αναφοράς"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Εμφάνιση Αξόνων Σωμάτων"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Εμφάνιση Αξόνων Καρέ"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Εμφάνιση Κατεύθυνσης Ήλιου"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
@@ -3887,191 +4148,41 @@ msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Εμφάνιση Κατεύθυνσης Ήλιου"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Εμφάνιση Πλέγματος Πλανητογραφίας"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Εμφάνιση Terminator"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Εναλλαγή Επιφανειών"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Κανονικό"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Διαστημόπλοιο"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Αντικείμενα"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Καθορισμός Χρόνου..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Ζώνη Ώρας: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Παγκόσμια Ώρα"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Τοπική ώρα"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Όνομα Ζώνης Ώρας "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Ημερομηνία"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Καθορισμός Χρόνου..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Καθορισμός Χρόνου..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Καθορισμός Χρόνου..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Χρόνος "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " ώρες"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " λεπτά"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " δευτερόλεπτα"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Ιουλιανή Ημερομηνία:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Ιουλιανή Ημερομηνία:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Καθορισμός Χρόνου..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Βαρύκεντρο"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Πλανήτης "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Νάνος Πλανήτης"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Μικροί Δορυφόροι"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Αστεροειδής "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Κομήτης "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Σημεία Αναφοράς"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Υπολογισμός"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Μετάβαση στην επιφάνεια"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Αστεροειδείς"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Σημεία Αναφοράς"
+msgid "Dwarf planets"
+msgstr "Νάνοι Πλανήτες"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4079,67 +4190,235 @@ msgstr "&Σημεία Αναφοράς"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Μικροί Δορυφόροι"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Διαστημόπλοιο"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Αντικείμενα"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Καθορισμός Χρόνου..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Ζώνη Ώρας: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Παγκόσμια Ώρα"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Τοπική ώρα"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Όνομα Ζώνης Ώρας "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Ημερομηνία"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Καθορισμός Χρόνου..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Καθορισμός Χρόνου..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Καθορισμός Χρόνου..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Χρόνος "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " ώρες"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " λεπτά"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " δευτερόλεπτα"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Ιουλιανή Ημερομηνία:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Ιουλιανή Ημερομηνία:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Καθορισμός Χρόνου..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Βαρύκεντρο"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Πλανήτης "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Νάνος Πλανήτης"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Μικροί Δορυφόροι"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Αστεροειδής "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Κομήτης "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Σημεία Αναφοράς"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Υπολογισμός"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Μετάβαση στην επιφάνεια"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Αστεροειδείς"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Σημεία Αναφοράς"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Άλλες δυνατότητες"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Πλάνητες"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Αντικείμενα"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Αντιστροφή Χρόνου"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x Πιο &Αργά\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " πιο αργά"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Παύση Χρόνου"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " πιο γρήγορα"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Πιο &Γρήγορα\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Καθορισμός Τρέχοντος Χρόνου"
@@ -4211,7 +4490,6 @@ msgstr "Γεωγραφικό πλάτος: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "ακτίνα"
 
@@ -4232,7 +4510,7 @@ msgstr "Ανάλυση:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Οργάνωση Σελιδοδεικτών "
 
@@ -4263,18 +4541,6 @@ msgstr "Προτιμήσεις Celestia "
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Αντικείμενα"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Νάνοι Πλανήτες"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4365,49 +4631,43 @@ msgstr "Ατελείς τροχιές"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Πλέγματα"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Ισημερινή"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ελλειπτικά"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Γαλαξιακό"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Οριζόντια"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Διαγράμματα"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Σύνορα"
 
@@ -4441,7 +4701,6 @@ msgstr "Εμφάνιση Ετικετών Τοποθεσιών"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Πόλεις"
 
@@ -4455,21 +4714,18 @@ msgstr "Τοποθεσίες Προσγείωσης "
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Ηφαίστεια"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Αστεροσκοπεία"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Κρατήρες "
 
@@ -4504,7 +4760,6 @@ msgstr "Θάλλασες"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Άλλες δυνατότητες"
 
@@ -4609,7 +4864,7 @@ msgstr "Προβολή"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
@@ -4851,21 +5106,21 @@ msgid "&About Celestia"
 msgstr "Περ&ί Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "Εντάξει"
 
@@ -4874,533 +5129,623 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Πνευματική Ιδιοκτησία (C) 2001-2009, Η Ομάδα Συγγραφής του Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr ""
 "Το Celestia είναι ελεύθερο λογισμικό και διανέμεται χωρίς οποιαδήποτε "
 "εγγύηση."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Συγγραφείς"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Επιλογή Αντικειμένου"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Όνομα Αντικειμένου "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Άδεια Χρήσης"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Πλήκτρα Χειρισμού Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Πληροφορίες οδηγού OpenGL "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Καθορισμός Χρόνου Προσομοίωσης"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Μορφή: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Καθορισμός Τρέχοντος Χρόνου"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Προσθήκη Σελιδοδείκτη"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Δημιουργία σε >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Νέος Φάκελος... "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Πλοηγός Ηλιακού Συστήματος"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Προσθήκη Νέου Φακέλου Σελιδοδεικτών"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Μετάβαση"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Όνομα Φακέλου"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Αντικείμενα Ηλιακού Συστήματος"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Πλήκτρα Χειρισμού Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Ουράνιος Πλοηγητής"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Κοντινότερος"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Λαμπρότερο"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "Με τους πλανήτες "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Ανανέωση"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Κριτήρια Αναζήτησης Αστέρων"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Μέγιστος Αριθμός Αστέρων που Εμφανίζονται στη Λίστα"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Ταξιδιωτικός Οδηγός"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Μετάβαση"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Επιλέξτε τον προορισμό σας:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Μετάβαση στο Αντικείμενο "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Αντικείμενο"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Μήκ."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Πλάτ."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Απόσταση"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Μέγεθος:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Επιλογή Κατάστασης Προβολής"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Ανάλυση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Επιλογές Προβολής"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Εύρεση Έκλειψης "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Εμφάνιση"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Υπολογισμός"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Προβολή"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Καθορισμός Χρόνου και Μετάβαση στον Πλανήτη"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#, fuzzy
-msgid "Ecliptic Line"
-msgstr ", γραμμή"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Κλείσιμο"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Τροχιές  / Ετικέτες"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Από:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Λατινικά Ονόματα"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Πληροφοριακό Κείμενο"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Περιεκτικός "
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Παράμετροι αναζήτησης"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Διεξοδικός"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Επιλογή Αντικειμένου"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Τοποθεσίες Προσγείωσης "
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Όνομα Αντικειμένου "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Όρη"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Πληροφορίες οδηγού OpenGL "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Θάλλασες"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Μετάβαση στο Αντικείμενο "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Κοιλάδες"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Μετάβαση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Γαίες"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Αντικείμενο"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Ετικέτες  Δυνατοτήτων"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Μήκ."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Πλάτ."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Απόσταση"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Άδεια Χρήσης"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Εμφάνιση Δυνατοτήτων"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Ετικέτες  Δυνατοτήτων"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 #, fuzzy
 msgid "Minimum Labeled Feature Size"
 msgstr "Ελάχιστο Χαρακτηριστικό Μέγεθος"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Προσθήκη Νέου Φακέλου Σελιδοδεικτών"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Μέγεθος:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Όνομα Φακέλου"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Μετονομασία..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Μετονομασία Σελιδοδείκτη ή Φακέλου"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Νέο Όνομα"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Εύρεση Έκλειψης "
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Καθορισμός Χρόνου Προσομοίωσης"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Υπολογισμός"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Μορφή: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Καθορισμός Χρόνου και Μετάβαση στον Πλανήτη"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Καθορισμός Τρέχοντος Χρόνου"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Κλείσιμο"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Πλοηγός Ηλιακού Συστήματος"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Από:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Μετάβαση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Αντικείμενα Ηλιακού Συστήματος"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Ουράνιος Πλοηγητής"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Παράμετροι αναζήτησης"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Ανανέωση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Ηλιακές Εκλείψεις"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Κριτήρια Αναζήτησης Αστέρων"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Εκλείψεις Σελήνης"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Μέγιστος Αριθμός Αστέρων που Εμφανίζονται στη Λίστα"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Ταξιδιωτικός Οδηγός"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Επιλέξτε τον προορισμό σας:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Επιλογές Προβολής"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Εμφάνιση"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Προβολή"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Τροχιές  / Ετικέτες"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Πληροφοριακό Κείμενο"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "408"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Απρ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Φεβ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Ιαν"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Ιούν"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Μαρ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Μάι"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Αύγ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Δεκ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Ιούλ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Νοέ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Οκτ "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Σεπ"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Δορυφόρος"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Εκκίνηση"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Κατασκευαστής:"
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Κατάσταση Παραθύρου"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Μέθοδος αποτύπωσης:"
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Αόρατα"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "&Συγχρονισμός Τροχιάς"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Πληροφορίες"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Εμφάνιση Αξόνων Σωμάτων"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Εμφάνιση Αξόνων Καρέ"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Εμφάνιση Κατεύθυνσης Ήλιου"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Εμφάνιση Πλέγματος Πλανητογραφίας"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Εμφάνιση Terminator"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Δορυφόροι"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Σώματα σε Τροχιά"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Φόρτωση:"
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "el"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Φόρτωση URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Έκδοση:"
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Έκδοση GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Μέγιστος αριθμός ταυτόχρονων υφών:"
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Μέγιστο μέγεθος υφών:"
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Μέγιστο μέγεθος cube map:"
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Απόσταση point size: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Υποστηριζόμενες Επεκτάσεις:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Κατάσταση Παραθύρου"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Αόρατα"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "&Συγχρονισμός Τροχιάς"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Πληροφορίες"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Εμφάνιση Αξόνων Σωμάτων"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Εμφάνιση Αξόνων Καρέ"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Εμφάνιση Κατεύθυνσης Ήλιου"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Εμφάνιση Πλέγματος Πλανητογραφίας"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Εμφάνιση Terminator"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Δορυφόροι"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Σώματα σε Τροχιά"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Φόρτωση:"
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "el"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Φόρτωση URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Σφάλμα κατά τη φόρτωση του σεναρίου"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Εκτέλεση σεναρίου"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Όνομα Ζώνης Ώρας "
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Αντιστάθμιση UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Σφάλμα κατά το άνοιγμα του αρχείου σεναρίων."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Αποτυχία αρχικοποίησης σεναρίου"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Σφάλμα κατά το άνοιγμα"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Φόρτωση προγράμματος NV Fragment: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Λάθος κατά την φόρτωση NV fragment προγράμματος: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Σφάλμα στο πρόγραμμα fragment"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Αρχικοποίηση προγραμμάτων NV fragment . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Φόρτωση όλων των NV fragment προγραμμάτων επιτυχής.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Αρχικοποιήση ARB fragment προγραμμάτων . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": μη αναγνωρίσιμο ή μη υποστηριζόμενο αρχείο εικόνας.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Φόρτωση του  NV vertex προγράμματος: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Σφάλμα κατά τη φόρτωση του προγράμματος NV vertex: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Σφάλμα στο πρόγραμμα  vertex "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Φόρτωση προγράμματος ARB vertex: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Σφάλμα κατά τη φόρτωση του προγράμματος ARB vertex: "
+
+#~ msgid ", line "
+#~ msgstr ", γραμμή"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Αρχικοποιήση προγραμμάτων NV vertex . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Όλα τα προγράμματα NV vertex φορτώθηκαν επιτυχώς.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Αρχικοποιήση προγραμμάτων ARB vertex  . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Όλα τα προγράμματα ARB vertex φορτώθηκαν επιτυχώς.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Αντιγραφή URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Το URL αντιγράφτηκε"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Κατάσταση Alt-azimuth ενεργοποιήθηκε"
+
+#~ msgid "Nearest"
+#~ msgstr "Κοντινότερος"
+
+#~ msgid "Brightest"
+#~ msgstr "Λαμπρότερο"
+
+#~ msgid "With planets"
+#~ msgstr "Με τους πλανήτες "
+
+#, fuzzy
+#~ msgid "Ecliptic Line"
+#~ msgstr ", γραμμή"
+
+#~ msgid "Latin Names"
+#~ msgstr "Λατινικά Ονόματα"
+
+#~ msgid "Terse"
+#~ msgstr "Περιεκτικός "
+
+#~ msgid "Verbose"
+#~ msgstr "Διεξοδικός"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Τοποθεσίες Προσγείωσης "
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Όρη"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Θάλλασες"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Κοιλάδες"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Γαίες"
+
+#~ msgid "Label Features"
+#~ msgstr "Ετικέτες  Δυνατοτήτων"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Ηλιακές Εκλείψεις"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Εκλείψεις Σελήνης"
+
+#~ msgid "Vendor: "
+#~ msgstr "Κατασκευαστής:"
+
+#~ msgid "GLSL version: "
+#~ msgstr "Έκδοση GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Υποστηριζόμενες Επεκτάσεις:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου"
+
+#~ msgid "Error loading script"
+#~ msgstr "Σφάλμα κατά τη φόρτωση του σεναρίου"
+
+#~ msgid "Running script"
+#~ msgstr "Εκτέλεση σεναρίου"
 
 #~ msgid "Invisible"
 #~ msgstr "Αόρατο"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Mercurio"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Tierra"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Luna"
 
@@ -47,140 +47,140 @@ msgstr "Fobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Júpiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amaltea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganímedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Calixto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturno"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometeo"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimeteo"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Jano"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encélado"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tetis"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titán"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hiperión"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Japeto"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Febe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Urano"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberón"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptuno"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larisa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteo"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tritón"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Plutón-Caronte"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plutón"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Caronte"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amaltea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Calixto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Ene"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxias"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "AMÉRICA DEL NORTE"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "AMÉRICA DEL SUR"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "ÁFRICA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTÁRTIDA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCÉANO ATLÁNTICO NORTE"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCÉANO ATLÁNTICO SUR"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCÉANO PACÍFICO NORTE"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCÉANO PACÍFICO SUR"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCÉANO ÍNDICO"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCÉANO ÁRTICO"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuya"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Adís Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Argel"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Ammán"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vieja"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Asjabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astaná"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Atenas"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Bakú"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Beijing"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlín"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Berna"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruselas"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "El Cairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Ciudad del Cabo"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonú"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damasco"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublín"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "De Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagåtña"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "La Haya"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "La Habana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Yakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalén"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandú"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Jartum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lomé"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londres"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Macho"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Ciudad de México"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Mónaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moscú"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Muscat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Yamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Nueva Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panamá"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "París"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Puerto España"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praga"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangún"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San José"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Santo Tomé"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seúl"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "El Acuerdo"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapur"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofía"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallin"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teherán"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Túnez"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "El Valle"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Ciudad del Vaticano"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Viena"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsovia"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaundé"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Distrito de Yaren"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Ereván"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Vía Láctea"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Nube Menor de Magallanes"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Nube Mayor de Magallanes"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Baricentro del sistema estelar"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Hora de verano"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Error abriendo archivo de imagen "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Error al leer el archivo de configuración"
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,88 +1482,59 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " objetos de espacio profundo"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Cargando el programa de fragmentos NV:"
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Error durante la carga del programa de fragmentos NV:"
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Error en el programa de fragmentos"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Inicialización del programa de fragmentos NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Todos los programas de fragmentos NV cargados correctamente.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Inicialización de los programas de fragmentos ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxia (tipo de Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Cúmulo globular (radio del núcleo: %4.2f', concentración según King: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Cargando imagen del archivo "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": formato de imagen no reconocido o no soportado.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Error abriendo archivo de imagen "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " no es un archivo PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Error al leer un archivo PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Cargando modelo: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Error cargando modelo '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebulosa"
 
@@ -1309,92 +1542,92 @@ msgstr "Nebulosa"
 msgid "Open cluster"
 msgstr "Cúmulo abierto"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Error en el archivo .ssc (línea "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "alerta, doble definición de "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "superficie alternativa equivocada"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "punto de referencia erróneo"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Encabezamiento del índice cruzado erróneo\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Versión errónea del índice cruzado\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "La carga del índice cruzado ha fallado en el registro "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " estrellas en la base de datos de binarias\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Número total de estrellas: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Error en el archivo .stc (línea "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrella inválida: tipo espectral inválido.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrella inválida: tipo espectral no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " no existe.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrella inválida: ascensión recta no disponible\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrella inválida: declinación no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrella inválida: distancia no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrella invalida: magnitud no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1402,767 +1635,743 @@ msgstr ""
 "Estrella inválida: la magnitud absoluta (no la aparente) debe especificarse "
 "para una estrella cercana al origen\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Creando textura en baldosas. Ancho="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Creando textura ordinaria: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Cargando programa de vértices NV : "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Error cargando programa de vértices NV : "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Error en programa de vértices "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Cargando programa de vértices ARB : "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Error cargando programa de vértices ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", línea "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Initialización de programas de vértices NV . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Todos los programas de vértices NV cargados con éxito.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Initialización programas de vértices ARB . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Todos los programas de vértices ARB cargados con éxito.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Error abriendo"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Error al leer un archivo PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Error leyendo el archivo de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Error abriendo archivo de script"
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Error abriendo script '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Error desconocido abriendo script"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Falla de inicialización de co-rutina de script"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Tipo de archivo inválido"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitud límite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marcadores activados"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marcadores desactivados"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Ir a la superficie"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo Alt-Azimutal habilitado"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo Alt-Azimutal dehabilitado"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Estilo de estrellas: puntos difusos"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Estilo de estrellas: puntos"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Estilo de estrellas: discos a escala"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Colas de cometas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Colas de cometas desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Representación gráfica: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Modo Alt-Azimutal habilitado"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Modo Alt-Azimutal dehabilitado"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Magnitudes automáticas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Magnitudes automáticas desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Tiempo y script en pausa"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Tiempo en pausa"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Continuar"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Número total de estrellas: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Número total de estrellas: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tiempo de viaje de un rayo de luz:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tiempo de viaje de un rayo de luz:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tiempo de viaje de un rayo de luz:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Demora temporal incluida"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Demora temporal desactivada"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Demora temporal ignorada"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Uso de texturas de superficie normales"
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Usando texturas de superficie del mundo conocido"
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tiempo: Hacia adelante"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tiempo: Hacia atrás"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Cuadros por segundo"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Órbita sincrónica"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Trabar"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Perseguir"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitud límite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Límite de automag a 45 grados:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiental: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Ganancia de luz"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Bloom activado"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Bloom desactivado"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Exposición"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Error GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vista demasiada pequeña para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Vista agregada"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "años luz"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "UA"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " días"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " segundos"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Velocidad: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diámetro aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitud aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitud absoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distancia: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Baricentro del sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag. abs. (aparente): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Luminosidad: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Estrella de neutrones"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Agujero negro"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clase: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Temp. superficial: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Radio: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Radio: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Existen compañeros planetarios\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distancia desde el centro: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radio: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Ángulo de fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tiempo real"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Tiempo real"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tiempo detenido"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " más rápido"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " más lento"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pausa)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "CPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Viajando "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Viajando "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rastrear "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Orbita sincrónica "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Perseguir "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sol"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nombre del blanco: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr " Grabando"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Empezar/Pausar    F12 Detener"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Modo de edición"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Cargando el catálogo del sistema solar: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Cargando el catálogo del sistema solar: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Error al leer el archivo de configuración"
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Falla en la inicialización de la biblioteca SPICE."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Imposible leer la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Error al abrir catálogo estelar "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Imposible leer la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Error al abrir el catálogo del sistema solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Error abriendo archivo de asterismos."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Error abriendo el archivo de límites de las constelaciones."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Error al inicializar renderer"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Error al cargar fuente; el texto no será visible.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Error al leer el índice cruzado "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Índice cruzado cargado "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Error al leer archivo de nombres estelares\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Error abriendo"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Error al leer archivo de nombres estelares\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Error al leer archivo de estrellas\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Error al abrir catálogo estelar "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Error abriendo script '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versión: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Error desconocido abriendo script"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Proveedor: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Visualizador: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Máximas texturas simultáneas: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Máximo tamaño de textura: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Rango de tamaño de punto: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Rango de tamaño de punto: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Máximo tamaño de mapa cúbico: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2359,14 +2568,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Error in creating ogg file %s for capture.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Error interno en la biblioteca Ogg."
@@ -2385,46 +2594,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - escribió %d cuadros\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navegador celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navegador celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -2434,21 +2634,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Estrellas"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " objetos de espacio profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
@@ -2457,465 +2656,516 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Tiempo"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Guía"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Pantalla completa"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Error abriendo archivo de asterismos."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Añadir señalador..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Guardar como: "
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " no es un archivo PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolución: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Cuadros por segundo: "
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Cargando URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "Abrir script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crear una nueva carpeta de señaladores en este menú"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Error desconocido abriendo script"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Extensiones aceptadas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Extensiones aceptadas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+#, fuzzy
+msgid "About Celestia"
+msgstr "Acerca de Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>Lenguaje de sombreado OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Proveedor: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "Versión GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Máximas texturas simultáneas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Máximo tamaño de textura: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Rango de tamaño de punto: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Rango de tamaño de punto: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Máximo tamaño de mapa cúbico: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Ecuatorial"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Información OpenGL"
+msgid "Renderer Info"
+msgstr "Visualizador: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Capturar imagen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Capturar imagen...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Copiar URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Copiar URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Abrir script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferencias de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Salir"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Anti-aliasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegación"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "Centrar selección\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selección: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir a objeto..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tiempo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Establecer fecha y hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Pantalla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objetos marcados"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Mostrar sombras de nubes"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Estilo de estrellas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Resolución de texturas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Señaladores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Ve&r"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vista múltiple"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividir vista verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir vista horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividir vista horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividir vista verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Intercambiar vistas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Vista única"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Vista única\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Borrar vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Marcos visibles"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Marco activo visible"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizar hora"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "A&yuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Preferencias de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
+#: ../src/celestia/qt/qtappwin.cpp:1439
 #, fuzzy
-msgid "About Celestia"
-msgstr "Acerca de Celestia"
+msgid "OpenGL Info"
+msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Añadir señalador"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizar señaladores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Cargando "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Duración"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Señaladores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Barra de tareas principal"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Error leyendo el archivo de favoritos."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Señaladores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Establecer hora"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Establecer hora"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Tiempo"
@@ -2924,79 +3174,77 @@ msgstr "Tiempo"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Nueva carpeta..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Mostrargrilla celeste"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galáctica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Grilla celeste"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Eclíptica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Centrar selección\tC"
@@ -3005,57 +3253,54 @@ msgstr "Centrar selección\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Constelaciones"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>Combinadores NVIDIA, sin programas de vértices</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Límites de constelaciones"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Órbitas"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planetas enanos"
 
@@ -3065,19 +3310,17 @@ msgstr "Planetas enanos"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Satélites"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Satélites menores"
 
@@ -3087,12 +3330,12 @@ msgstr "Satélites menores"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroides"
 
@@ -3102,12 +3345,12 @@ msgstr "Asteroides"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Cometas"
 
@@ -3117,14 +3360,15 @@ msgstr "Cometas"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Naves espaciales"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x más rápido\tL"
@@ -3133,9 +3377,8 @@ msgstr "10x más rápido\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Etiquetas"
 
@@ -3143,20 +3386,18 @@ msgstr "Etiquetas"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxias"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Cúmulos globulares"
 
@@ -3164,7 +3405,7 @@ msgstr "Cúmulos globulares"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3174,615 +3415,632 @@ msgstr "Cúmulos abiertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulosas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Ubicaciones"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Cúmulos abiertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nubes"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Luces nocturnas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Colas de cometas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmósferas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Sombras de anillos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Sombras de eclipses"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Sombras de nubes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Baja"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Media"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Alto"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Magnitudes automáticas\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Más estrellas\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Menos estrellas\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "Puntos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Puntos difusos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Discos a escala"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Demora temporal desactivada"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Modo Alt-Azimutal habilitado"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Límite de automag a 45 grados:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Magnitud límite: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nombre"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag. aparente"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag. absoluta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Mostrar estrellas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Estrellas"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar estrellas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Con planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Mostrar estrellas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Máximo de estrellas en la lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Ninguna"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triángulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Cuadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Suma"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Flecha izquierda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Flecha derecha"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Flecha arriba"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Flecha abajo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Seleccionar objeto..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamaño: "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Seleccionar objeto..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Etiquetar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "objeto padre '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Iniciar en pantalla completa"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Duración"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Eclipses solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Eclipses lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Desmarcar &todo"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Rango de tamaño de punto: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Eclipses lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Seleccionar objeto..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Eclipses solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Volver al presente"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Cargando imagen del archivo "
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Distancia (años luz) "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Tamaño: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Estilo de estrellas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Formato local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Zona horaria"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Corrimiento UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Comenzar"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3801,21 +4059,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Ir"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -3829,49 +4087,54 @@ msgid "Visible"
 msgstr "Marco activo visible"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Seleccione modo de visualización"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Cuadrado lleno"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Marcas de referencia"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Mostrar ejes del cuerpo"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Mostrar ejes del marco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Mostrar dirección al Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Mostrar vector velocidad"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Mostrar vector velocidad"
@@ -3879,191 +4142,41 @@ msgstr "Mostrar vector velocidad"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Mostrar dirección al Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Mostrar grilla planetaria"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Mostrar terminador"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "Superficies &Alternativas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Naves espaciales"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objetos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Establecer fecha y hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Zona horaria: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Hora Universal"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Hora local"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Zona horaria"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Fecha"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Establecer fecha y hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Establecer fecha y hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Establecer fecha y hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Tiempo"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " horas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minutos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " segundos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Fecha Juliana"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Fecha Juliana"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Establecer fecha y hora..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Baricentro "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planeta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Planeta enano"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Satélites menores"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroide"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Cometa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Marcas de referencia"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Calcular"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Ir a la superficie"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Error desconocido abriendo script"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroides"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Marcas de referencia"
+msgid "Dwarf planets"
+msgstr "Planetas enanos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4071,67 +4184,235 @@ msgstr "&Marcas de referencia"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Satélites menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Naves espaciales"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objetos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Establecer fecha y hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Zona horaria: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Hora Universal"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Hora local"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Zona horaria"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Fecha"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Establecer fecha y hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Establecer fecha y hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Establecer fecha y hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Tiempo"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " horas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minutos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " segundos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Fecha Juliana"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Fecha Juliana"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Establecer fecha y hora..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Baricentro "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planeta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Planeta enano"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Satélites menores"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroide"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Cometa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Marcas de referencia"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Calcular"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Ir a la superficie"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Error desconocido abriendo script"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroides"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Marcas de referencia"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Otros"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planetas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Invertir tiempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x más lento\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " más lento"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Congelar tiempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " más rápido"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x más rápido\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Establecer hora actual"
@@ -4203,7 +4484,6 @@ msgstr "Latitud: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radios"
 
@@ -4224,7 +4504,7 @@ msgstr "Resolución: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizar marcadores"
 
@@ -4255,18 +4535,6 @@ msgstr "Preferencias de Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objetos"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Planetas enanos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4357,49 +4625,43 @@ msgstr "Trayectorias parciales"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Grillas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Ecuatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galáctica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Mostrar fronteras"
 
@@ -4433,7 +4695,6 @@ msgstr "Mostrar nombres de sitios"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Ciudades"
 
@@ -4447,21 +4708,18 @@ msgstr "Sitios de aterrizaje"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Volcanes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatorios"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Cráteres"
 
@@ -4496,7 +4754,6 @@ msgstr "Mares"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Otros"
 
@@ -4601,7 +4858,7 @@ msgstr "Pantalla"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Preferencias"
 
@@ -4848,21 +5105,21 @@ msgid "&About Celestia"
 msgstr "Acerca de Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4871,534 +5128,624 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2008, Equipo de Desarrollo de Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia es un programa gratis y se distribuye sin garantía alguna."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autores:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Seleccionar objeto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Objeto: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-#, fuzzy
-msgid "License"
-msgstr "Licencia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Controles"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Información OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Establecer hora"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formato: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Establecer hora actual"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Añadir señalador"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Crear en >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nueva carpeta..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navegador del Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "&Añadir carpeta de marcadores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Ir"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nombre de la carpeta"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Controles"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "Seleccione modo de visualización"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "Resolución"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Calcular"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Establecer fecha e ir al planeta"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Cerrar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Desde: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parámetros de búsqueda"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Seleccionar objeto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Objetos del Sistema Solar"
+msgid "Object Name"
+msgstr "Objeto: "
 
 #: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navegador estelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Más cercanas"
+msgid "OpenGL Driver Info"
+msgstr "Información OpenGL"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Más brillantes"
+msgid "Go to Object"
+msgstr "Ir a objeto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Con planetas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-#, fuzzy
-msgid "&Refresh"
-msgstr "Refrescar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Criterios de búsqueda estelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Máximo de estrellas en la lista"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Guía"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 #, fuzzy
 msgid "Go To"
 msgstr "&Ir"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Establezca su destino:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Ir a objeto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "Object"
 msgstr "Objeto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:124
 msgid "Long."
 msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:140
+#: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "Lat."
 msgstr "Lat."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Distance"
 msgstr "Distancia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Tamaño: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "Seleccione modo de visualización"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "Resolución"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
+#: ../src/celestia/win32/res/resource_strings.cpp:127
 #, fuzzy
-msgid "View Options"
-msgstr "Opciones"
+msgid "License"
+msgstr "Licencia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Mostrar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Pantalla"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Eclíptica"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Órbitas / Etiquetas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Nombres latinos"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Información"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Sucinta"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Completa"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Sitios de aterrizaje"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Mares"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Tierras"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Etiquetar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Mostrar items"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Etiquetar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Tamaño mínimo para etiquetar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "&Añadir carpeta de marcadores"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Tamaño: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nombre de la carpeta"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Renombrar..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Renombrar marcador o carpeta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nuevo nombre"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Buscador de eclipses"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Establecer hora"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Calcular"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formato: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Establecer fecha e ir al planeta"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Establecer hora actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Cerrar"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navegador del Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Desde: "
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Ir"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Objetos del Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navegador estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parámetros de búsqueda"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#, fuzzy
+msgid "&Refresh"
+msgstr "Refrescar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Eclipses solares"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Criterios de búsqueda estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Eclipses lunares"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Máximo de estrellas en la lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Guía"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Establezca su destino:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#, fuzzy
+msgid "View Options"
+msgstr "Opciones"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Mostrar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Pantalla"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Órbitas / Etiquetas"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Información"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "40a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Ene"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "May"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dic"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satélite"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Fecha"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Comenzar"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Proveedor: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Modo de ventana"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Visualizador: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invisibles"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "&Orbita sincrónica"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Información"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Mostrar ejes del cuerpo"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Mostrar ejes del marco"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Mostrar dirección al Sol"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Mostrar vector velocidad"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Mostrar grilla planetaria"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Mostrar terminador"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satélites"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Cuerpos en órbita"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Cargando: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "es"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Cargando URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versión: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Versión GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Máximas texturas simultáneas: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Máximo tamaño de textura: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Máximo tamaño de mapa cúbico: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Rango de tamaño de punto: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Extensiones aceptadas: "
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Modo de ventana"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invisibles"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "&Orbita sincrónica"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Información"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Mostrar ejes del cuerpo"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Mostrar ejes del marco"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Mostrar dirección al Sol"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Mostrar vector velocidad"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Mostrar grilla planetaria"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Mostrar terminador"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satélites"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Cuerpos en órbita"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Cargando: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "es"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Cargando URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Error abriendo script "
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Error cargando script"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Corriendo script"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Zona horaria"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Corrimiento UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Error abriendo archivo de script"
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Error desconocido abriendo script"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Error abriendo script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Falla de inicialización de co-rutina de script"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Error abriendo script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Error desconocido abriendo script"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Error abriendo"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Cargando el programa de fragmentos NV:"
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Error durante la carga del programa de fragmentos NV:"
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Error en el programa de fragmentos"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Inicialización del programa de fragmentos NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Todos los programas de fragmentos NV cargados correctamente.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Inicialización de los programas de fragmentos ARB . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": formato de imagen no reconocido o no soportado.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Cargando programa de vértices NV : "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Error cargando programa de vértices NV : "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Error en programa de vértices "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Cargando programa de vértices ARB : "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Error cargando programa de vértices ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", línea "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Initialización de programas de vértices NV . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Todos los programas de vértices NV cargados con éxito.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Initialización programas de vértices ARB . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Todos los programas de vértices ARB cargados con éxito.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Error desconocido abriendo script"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Copiar URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Copiar URL"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Modo Alt-Azimutal habilitado"
+
+#~ msgid "Nearest"
+#~ msgstr "Más cercanas"
+
+#~ msgid "Brightest"
+#~ msgstr "Más brillantes"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Con planetas"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Eclíptica"
+
+#~ msgid "Latin Names"
+#~ msgstr "Nombres latinos"
+
+#~ msgid "Terse"
+#~ msgstr "Sucinta"
+
+#~ msgid "Verbose"
+#~ msgstr "Completa"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Sitios de aterrizaje"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Mares"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Tierras"
+
+#~ msgid "Label Features"
+#~ msgstr "Etiquetar"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Eclipses solares"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Eclipses lunares"
+
+#~ msgid "Vendor: "
+#~ msgstr "Proveedor: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Versión GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Extensiones aceptadas: "
+
+#~ msgid "Error opening script"
+#~ msgstr "Error abriendo script "
+
+#~ msgid "Error loading script"
+#~ msgstr "Error cargando script"
+
+#~ msgid "Running script"
+#~ msgstr "Corriendo script"
 
 #~ msgid "Invisible"
 #~ msgstr "Invisible"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2019-02-14 21:33+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: French (https://www.transifex.com/celestia/teams/93131/fr/)\n"
@@ -29,12 +29,12 @@ msgstr "Mercure"
 msgid "Venus"
 msgstr "Vénus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Terre"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Lune"
 
@@ -50,140 +50,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Déimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthée"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europe"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymède"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturne"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prométhée"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandore"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Épiméthée"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encelade"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Téthys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dioné"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhéa"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hypérion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Japet"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phoebé"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uranus"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Obéron"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptune"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Protée"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Néréide"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluton-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluton"
 
@@ -192,1028 +192,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Nouméa"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthée"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxies"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "AMÉRIQUE DU NORD"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "AMÉRIQUE DU SUD"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIE"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIQUE"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIE"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARCTIQUE"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCÉAN ATLANTIQUE NORD"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCÉAN ATLANTIQUE SUD"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCÉAN PACIFIQUE NORD"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCÉAN PACIFIQUE SUD"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCÉAN INDIEN"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCÉAN ARCTIQUE"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis-Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Alger"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorre-la-Vieille"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Achgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Athènes"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Bakou"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Pékin"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beyrouth"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrade"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Berne"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bichkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruxelles"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Le Caire"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Le Cap"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damas"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Douchanbé"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Agana"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "La Haye"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoï"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "La Havane"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jérusalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kaboul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandou"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Koweït"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "Laâyoune"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisbonne"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lomé"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londres"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Malé"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoudzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manille"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexico"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moscou"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Mascate"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N’Djaména"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosie"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku‘alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port-Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Prague"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Rome"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George’s"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint-Hélier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John’s"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "Saint-Marin"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Saint Domingue"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tomé"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Séoul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapour"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tachkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilissi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Téhéran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Oulan-Bator"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "La Valette"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "La Vallée"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Cité du Vatican"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Vienne"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsovie"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Erevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Voie lactée"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Petit Nuage de Magellan"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Grand Nuage de Magellan"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Barycentre du Système solaire"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "heure d’été"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "heure d’hiver"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Erreur lors de l’ouverture du fichier d’astérismes."
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Erreur lors de la lecture du fichier de configuration."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1223,88 +1485,59 @@ msgstr "heure d’hiver"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr ""
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Chargement du programme de fragments NV : "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Erreur lors du chargement du programme de fragments NV : "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Erreur dans le programme de fragments"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Initialisation du programme de fragments NV...\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Tous les programmes de fragments NV correctement chargés.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Initialisation des programmes de fragments ARB...\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxie (type Hubble : %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Amas globulaire (rayon du noyau : %4.2f', distribution de King : %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, c-format
 msgid "Loading image from file %s\n"
 msgstr ""
 
-#: ../src/celengine/image.cpp:337
-#, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ""
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, c-format
 msgid "Error opening image file %s\n"
 msgstr ""
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr ""
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, c-format
 msgid "Loading model: %s\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, c-format
 msgid "Error loading model '%s'\n"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nébuleuse"
 
@@ -1312,92 +1545,92 @@ msgstr "Nébuleuse"
 msgid "Open cluster"
 msgstr "Amas ouvert"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "mauvaise surface alternative"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "mauvais point de repère"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "En-tête de l’index croisé invalide\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Mauvaise version de l’index croisé\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, c-format
 msgid "%d stars in binary database\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, c-format
 msgid "Total star count: %d\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Étoile invalide : type spectral invalide.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Étoile invalide : type spectral manquant.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Étoile invalide : ascension droite manquante\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Étoile invalide : déclinaison manquante.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Étoile invalide : distance manquante.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Étoile invalide : magnitude manquante.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1405,748 +1638,725 @@ msgstr ""
 "Étoile invalide : la magnitude absolue (et non pas apparente) doit être "
 "spécifiée pour les étoiles proches de l’origine\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr ""
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Chargement du programme de vertex NV : "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Erreur lors du chargement du programme de vertex NV : "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Erreur dans le programme de vertex "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Chargement du programme de vertex ARB : "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Erreur lors du chargement du programme de vertex ARB : "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", ligne "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Initialisation du programme de vertex NV...\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Tous les programmes de vertex NV correctement chargés.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Initialisation des programmes de vertex ARB...\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Tous les programmes de vertex ARB correctement chargés.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Erreur lors de l’ouverture du script"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Erreur lors de la lecture du fichier d’étoiles\n"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Erreur lors de l’ouverture du fichier de script."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erreur lors de l’ouverture du script '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Erreur inconnue lors de l’ouverture du script"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "L’initialisation de la co-routine de script a échoué"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Type de fichier invalide"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitude limite : %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marqueurs activés"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marqueurs désactivés"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Aller à la surface"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Mode Alt-Azimuthal activé"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Mode Alt-Azimuthal désactivé"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Style des étoiles : points flous"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Style des étoiles : points"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Style des étoiles : échelle de disques"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Queues des comètes activées"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Queues des comètes désactivées"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Chemin de rendu : OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 msgid "Anti-aliasing enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 msgid "Anti-aliasing disabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Magnitudes automatiques activées"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Magnitudes automatiques désactivées"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Temps et script en pause"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Temps en pause"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Reprendre"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 msgid "Star color: Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 msgid "Star color: Enhanced"
 msgstr ""
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Temps de trajet de la lumière : %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Temps de trajet de la lumière : %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Temps de trajet de la lumière inclus"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Temps de trajet de la lumière désactivé"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Temps de trajet de la lumière ignoré"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Utilisation des textures de surface normales"
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Utilisation des textures de surface du monde connu"
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Suivre"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Temps : Avancer"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Temps : Reculer"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, c-format
 msgid "Time rate: %.6g"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 msgid "Low res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 msgid "Medium res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 msgid "High res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Orbite synchrone"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Bloquer"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Pourchasser"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Magnitude automatique à 45° : %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Niveau de la lumière ambiante : %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Gain de luminosité"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Effet Bloom activé"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Effet Bloom désactivé"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Exposition lumineuse"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Erreur OpenGL :"
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vue trop petite pour être scindée"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Vue ajoutée"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "ua"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 msgid "minutes"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 msgid "seconds"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, c-format
 msgid "Rotation period: %s %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2821
-msgid "m/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2823
-msgid "km/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2827
-msgid "AU/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2829
-msgid "ly/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2456
 #, c-format
-msgid "Speed: %s %s\n"
+msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2458
 #, c-format
-msgid "Apparent diameter: %s\n"
+msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2908
-#, c-format
-msgid "Apparent magnitude: %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2912
-#, c-format
-msgid "Absolute magnitude: %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2992
-#, c-format
-msgid "%.6f%c %.6f%c %f km"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
-#, c-format
-msgid "Distance: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3022
-msgid "Star system barycenter\n"
-msgstr "Barycentre du système stellaire\n"
-
-#: ../src/celestia/celestiacore.cpp:3026
-#, c-format
-msgid "Abs (app) mag: %.2f (%.2f)\n"
-msgstr "Mag. abs (app) : %.2f (%.2f)\n"
-
-#: ../src/celestia/celestiacore.cpp:3032
-#, c-format
-msgid "Luminosity: %sx Sun\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3038
-msgid "Neutron star"
-msgstr "Étoile à neutrons"
-
-#: ../src/celestia/celestiacore.cpp:3041
-msgid "Black hole"
-msgstr "Trou noir"
-
-#: ../src/celestia/celestiacore.cpp:3046
-#, c-format
-msgid "Class: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3053
-#, c-format
-msgid "Surface temp: %s K\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3058
-#, c-format
-msgid "Radius: %s Rsun  (%s km)\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3064
-#, c-format
-msgid "Radius: %s km\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3080
-msgid "Planetary companions present\n"
-msgstr "Compagnons planétaires présents\n"
-
-#: ../src/celestia/celestiacore.cpp:3096
-#, c-format
-msgid "Distance from center: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
-#, c-format
-msgid "Radius: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3168
-#, c-format
-msgid "Phase angle: %.1f%s\n"
-msgstr "Angle de phase : %.1f%s\n"
-
-#: ../src/celestia/celestiacore.cpp:3180
+#: ../src/celestia/celestiacore.cpp:2460
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2471
+msgid "m/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2476
+msgid "km/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2486
+msgid "AU/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2491
+msgid "ly/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2494
+#, c-format
+msgid "Speed: %s %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2558
+#, c-format
+msgid "Apparent diameter: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2571
+#, c-format
+msgid "Apparent magnitude: %.1f\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2575
+#, c-format
+msgid "Absolute magnitude: %.1f\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2655
+#, c-format
+msgid "%.6f%c %.6f%c %f km"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
+#, c-format
+msgid "Distance: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Star system barycenter\n"
+msgstr "Barycentre du système stellaire\n"
+
+#: ../src/celestia/celestiacore.cpp:2689
+#, c-format
+msgid "Abs (app) mag: %.2f (%.2f)\n"
+msgstr "Mag. abs (app) : %.2f (%.2f)\n"
+
+#: ../src/celestia/celestiacore.cpp:2695
+#, c-format
+msgid "Luminosity: %sx Sun\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2701
+msgid "Neutron star"
+msgstr "Étoile à neutrons"
+
+#: ../src/celestia/celestiacore.cpp:2704
+msgid "Black hole"
+msgstr "Trou noir"
+
+#: ../src/celestia/celestiacore.cpp:2709
+#, c-format
+msgid "Class: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2716
+#, c-format
+msgid "Surface temp: %s K\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2721
+#, c-format
+msgid "Radius: %s Rsun  (%s km)\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2727
+#, c-format
+msgid "Radius: %s km\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2743
+msgid "Planetary companions present\n"
+msgstr "Compagnons planétaires présents\n"
+
+#: ../src/celestia/celestiacore.cpp:2759
+#, c-format
+msgid "Distance from center: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
+#, c-format
+msgid "Radius: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2831
+#, c-format
+msgid "Phase angle: %.1f%s\n"
+msgstr "Angle de phase : %.1f%s\n"
+
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, c-format
 msgid "Temperature: %.0f K\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Temps réel"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "- Temps réel"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Temps arrêté"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, c-format
 msgid "%.6g x faster"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, c-format
 msgid "%.6g x slower"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr "  (en pause)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, c-format
 msgid "Travelling (%s)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, c-format
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Soleil"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nom de la cible : "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Démarrer/Pause     F12 Arrêter"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Mode d’édition"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Erreur lors de la lecture du fichier de configuration."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "L’initialisation de la bibliothèque SPICE a échoué."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Impossible de lire la base de données des étoiles."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Erreur lors de l’ouverture du fichier de script."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Impossible de lire la base de données des étoiles."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Erreur lors de l’ouverture du fichier d’astérismes."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Erreur lors de l’ouverture du fichier des limites des constellations."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Échec de l’initialisation du moteur de rendu"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr ""
 "Erreur lors du chargement de la police de caractère ; le texte ne sera pas "
 "affiché.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, c-format
 msgid "Error reading cross index %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, c-format
 msgid "Loaded cross index %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Erreur lors de la lecture du fichier des noms d’étoiles\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, c-format
 msgid "Error opening %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Erreur lors de la lecture du fichier des noms d’étoiles\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Erreur lors de la lecture du fichier d’étoiles\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, c-format
 msgid "Error opening star catalog %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
+#, fuzzy, c-format
+msgid "%s Version: %s\n"
+msgstr "Version : "
+
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Fournisseur : "
+
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Moteur de rendu : "
+
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Nombre max de textures : "
+
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Taille de texture max. : "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Plage de taille de point : "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Plage de taille de point : "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Taille de texture cubique max. : "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid "Error opening LuaHook '%s'"
+msgid "Number of interpolators: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4976
-msgid "Unknown error loading hook script"
-msgstr ""
-
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
-
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:135
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2328,14 +2538,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Erreur lors de la création du fichier ogg %s pour l’acquisition.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 msgid "Internal Ogg library error.\n"
 msgstr ""
 
@@ -2353,45 +2563,36 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navigateur céleste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 msgid "Info Browser"
 msgstr ""
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Système solaire"
 
@@ -2401,20 +2602,19 @@ msgstr "Système solaire"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Étoiles"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 msgid "Deep Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr ""
 
@@ -2422,402 +2622,457 @@ msgstr ""
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Temps"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 msgid "Guides"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 msgid "Full screen"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 msgid "Shift+F11"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 msgid "Error opening bookmarks file"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 msgid "Error Saving Bookmarks"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 msgid "Save Image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 msgid "Images (*.png *.jpg)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Acquisition Vidéo"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 msgid "Video (*.avi)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 msgid "Video (*.ogv)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 msgid "Resolution:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Vitesse d’affichage : "
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL copiée"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 msgid "Pasting URL"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 msgid "Open Script"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 msgid "New bookmark"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
-msgid "<b>OpenGL version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1039
+msgid "Unknown compiler"
 msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+msgid "supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+msgid "not supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "À propos de Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Fournisseur : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "Moteur de rendu : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "Version : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Nombre max de textures : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Taille de texture max. : "
 
 #: ../src/celestia/qt/qtappwin.cpp:1105
-msgid "<b>Renderer: </b>"
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Plage de taille de point : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Plage de taille de point : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Taille de texture cubique max. : "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, qt-format
+msgid "<b>Number of interpolators</b>: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-msgid "<b>Maximum texture size: </b>"
-msgstr ""
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Extensions supportées : "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-msgid "<b>Extensions:</b><br>\n"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr ""
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Moteur de rendu : "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 msgid "&Grab image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 msgid "F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 msgid "Capture &video"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 msgid "Shift+F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 msgid "&Copy image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 msgid "Ctrl+Shift+C"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-msgid "Copy &URL"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-msgid "&Paste URL"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Ouvrir script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 msgid "&Preferences..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Quitter"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 msgid "Ctrl+Q"
 msgstr ""
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigation"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 msgid "Select Sun"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 msgid "Center Selection"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 msgid "Goto Selection"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Allez à ..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Temps"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 msgid "Set &time"
 msgstr ""
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 msgid "&Display"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 msgid "Dee&p Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 msgid "&Shadows"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "St&yle des étoiles"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 msgid "Texture &Resolution"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 msgid "&FPS control"
 msgstr ""
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr ""
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vue"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 msgid "&MultiView"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Split view vertically"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 msgid "Ctrl+R"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 msgid "Split view horizontally"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 msgid "Ctrl+U"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 msgid "Cycle views"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 msgid "Single view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 msgid "Ctrl+D"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 msgid "Delete view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 msgid "Frames visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 msgid "Active frame visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 msgid "Synchronize time"
 msgstr ""
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Aide"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 msgid "Celestia Manual"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "À propos de Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 msgid "Add Bookmark..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 msgid "Organize Bookmarks..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 msgid "Description"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 msgid "Bookmarks Menu"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 msgid "Bookmarks Toolbar"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 msgid "Error reading bookmarks file"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "&Signets"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 msgid "Current simulation time"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 msgid "Simulation time at activation"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 msgid "System time at activation"
 msgstr ""
 
@@ -2825,72 +3080,70 @@ msgstr ""
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 msgid "New Folder"
 msgstr ""
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 msgid "Equatorial coordinate grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 msgid "Galactic coordinate grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 msgid "Ecliptic coordinate grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 msgid "Horizontal coordinate grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 msgid "Ecliptic line"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 msgid "M"
 msgstr ""
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marqueurs"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 msgid "C"
 msgstr ""
 
@@ -2898,54 +3151,51 @@ msgstr ""
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Constellations"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 msgid "B"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 msgid "Constellation boundaries"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 msgid "O"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Orbites"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planètes"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planètes naines"
 
@@ -2955,19 +3205,17 @@ msgstr "Planètes naines"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Lunes"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Lunes mineures"
 
@@ -2977,12 +3225,12 @@ msgstr "Lunes mineures"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Astéroïdes"
 
@@ -2992,12 +3240,12 @@ msgstr "Astéroïdes"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Comètes"
 
@@ -3007,14 +3255,15 @@ msgstr "Comètes"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Astronefs"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 msgid "L"
 msgstr ""
 
@@ -3022,9 +3271,8 @@ msgstr ""
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Noms"
 
@@ -3032,20 +3280,18 @@ msgstr "Noms"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxies"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Amas globulaires"
 
@@ -3053,7 +3299,7 @@ msgstr "Amas globulaires"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 msgid "Open clusters"
 msgstr ""
@@ -3062,576 +3308,594 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nébuleuses"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Points de repère"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Amas ouverts"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nuages"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Lumières nocturnes"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Queues des comètes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosphères"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Ombres des anneaux"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Ombres des éclipses"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Ombres des nuages"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Basse"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Moyenne"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Haute"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 msgid "Auto Magnitude"
 msgstr ""
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 msgid "More Stars Visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 msgid "Fewer Stars Visible"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 msgid "Points"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 msgid "Fuzzy Points"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 msgid "Scaled Discs"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 msgid "Light Time Delay"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-msgid "Enable Vsync"
-msgstr ""
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, qt-format
 msgid "Magnitude limit: %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nom"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distance (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag. app."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag. abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Type"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 msgid "Closest Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 msgid "Brightest Stars"
 msgstr ""
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 msgid "Filter"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Avec planètes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 msgid "Multiple Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 msgid "Barycenters"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 msgid "Spectral Type"
 msgstr ""
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 msgid "Mark Selected"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 msgid "Mark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Démarquer &tous"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 msgid "Clear Markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Losange"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triangle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Carré"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Cercle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Flèche vers la gauche"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Flèche vers la droite"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Flèche vers le haut"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Flèche vers le bas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Select marker symbol"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 msgid "Select marker size"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 msgid "Click to select marker color"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Label"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, qt-format
 msgid "%1 objects found"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 msgid "Unmark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 msgid "Eclipsed body"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 msgid "Start time"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Durée"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 msgid "Solar eclipses"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 msgid "Lunar eclipses"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 msgid "All eclipses"
 msgstr ""
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 msgid "Search range"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 msgid "Find eclipses"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, qt-format
 msgid "%1 is not a valid object"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 msgid "Finding eclipses..."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 msgid "Set time to mid-eclipse"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, qt-format
 msgid "Near %1"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, qt-format
 msgid "From surface of %1"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, qt-format
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, qt-format
+msgid "<b>Start:</b> %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, qt-format
+msgid "<b>End:</b> %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 msgid "Classic colors"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 msgid "Local format"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 msgid "Time zone name"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 msgid "UTC offset"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Début"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
@@ -3651,21 +3915,21 @@ msgid "&Select"
 msgstr "&Sélectionner"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Aller à"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Suivre"
 
@@ -3678,210 +3942,87 @@ msgid "Visible"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Démarquer"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Sélection du mode d’affichage"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Carré plein"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disque"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marquer"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "Marques de &référence"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 msgid "Show &Body Axes"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 msgid "Show &Frame Axes"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 msgid "Show &Sun Direction"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 msgid "Show &Velocity Vector"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 msgid "Show S&pin Vector"
 msgstr ""
 
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, qt-format
 msgid "Show &Direction to %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 msgid "Show Planetographic &Grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 msgid "Show &Terminator"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "Surfaces &alternatives"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normale"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Astronefs"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
-msgid "Other objects"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-msgid "Set Time"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Fuseau horaire : "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Temps universel"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Heure locale"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-msgid "Select Time Zone"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-msgid "Date: "
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-msgid "Set Year"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-msgid "Set Month"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-msgid "Set Day"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-msgid "Time: "
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-msgid "Set Hours"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-msgid "Set Minutes"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-msgid "Set Seconds"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Date julienne : "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-msgid "Set Julian Date"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-msgid "Set time"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-msgid "Star"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planète"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-msgid "Dwarf planet"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-msgid "Minor moon"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Astéroïde"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Comète"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-msgid "Reference point"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-msgid "Component"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-msgid "Surface feature"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-msgid "Unknown"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-msgid "Asteroids & comets"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-msgid "Reference points"
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
+msgid "Dwarf planets"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
@@ -3890,58 +4031,202 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Astronefs"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+msgid "Other objects"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+msgid "Set Time"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Fuseau horaire : "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Temps universel"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Heure locale"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+msgid "Select Time Zone"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+msgid "Date: "
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+msgid "Set Year"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+msgid "Set Month"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+msgid "Set Day"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+msgid "Time: "
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+msgid "Set Hours"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+msgid "Set Minutes"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+msgid "Set Seconds"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Date julienne : "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+msgid "Set Julian Date"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+msgid "Set time"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+msgid "Star"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planète"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+msgid "Dwarf planet"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+msgid "Minor moon"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Astéroïde"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Comète"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+msgid "Reference point"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+msgid "Component"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+msgid "Surface feature"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+msgid "Unknown"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+msgid "Asteroids & comets"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+msgid "Reference points"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 msgid "Surface features"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+msgid "Planets and moons"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 msgid "Group objects by class"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 msgid "Reverse time"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "10x slower"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 msgid "2x slower"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 msgid "Pause time"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 msgid "2x faster"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 msgid "10x faster"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 msgid "Set to current time"
 msgstr ""
 
@@ -4004,7 +4289,6 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "rayons"
 
@@ -4023,7 +4307,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Réaranger les signets"
 
@@ -4052,17 +4336,6 @@ msgstr ""
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objets"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-msgid "Dwarf planets"
-msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4141,49 +4414,43 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Grilles"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Équatoriale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Écliptique"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galactique"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Lignes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Limites"
 
@@ -4214,7 +4481,6 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Villes"
 
@@ -4227,21 +4493,18 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Volcans"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatoires"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Cratères"
 
@@ -4272,7 +4535,6 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Autres"
 
@@ -4364,7 +4626,7 @@ msgstr ""
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Configuration"
 
@@ -4601,21 +4863,21 @@ msgid "&About Celestia"
 msgstr "À propos de &Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4624,527 +4886,588 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
-msgid "Copyright (C) 2001-2019, Celestia Development Team"
+msgid "1.7.0"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:74
-msgid "https://celestia.space/"
+msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:75
+msgid "https://celestia.space/"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia est un logiciel libre et est fourni sans aucune garantie."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Auteurs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Sélectionner un objet"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Nom de l’objet"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licence"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Commande de Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informations OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Définir l’heure de simulation"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Format : "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Mettre à l’heure courante"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Ajouter un signet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Créer dans >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nouveau dossier..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navigateur de Système solaire"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Ajouter un répertoire de signets"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Aller à"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nom du répertoire"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Objets du Système solaire"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Commande de Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navigateur céleste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Plus proches"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Plus brillantes"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Rafraîchir"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Critères de recherche d’étoiles"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Nombre maximum d’étoiles à afficher"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Guide de découverte"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Aller à"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Sélectionner votre destination :"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Aller à l’objet"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objet"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Distance"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Taille : "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Sélection du mode d’affichage"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Résolution"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Découvreur d’éclipses"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Calculer"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Changer la date et aller à la planète"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Fermer"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "du :"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Paramètres de la recherche"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Sélectionner un objet"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Nom de l’objet"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Informations OpenGL"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Aller à l’objet"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Aller à"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objet"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Distance"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licence"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "Afficher les marqueurs"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+msgid "Show Label"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "Taille minimum des points de repère"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Taille : "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "Renommer..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "Renommer le signet ou le répertoire"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "Nouveau nom"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Définir l’heure de simulation"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Format : "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Mettre à l’heure courante"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navigateur de Système solaire"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Aller à"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Objets du Système solaire"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navigateur céleste"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Rafraîchir"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Critères de recherche d’étoiles"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Nombre maximum d’étoiles à afficher"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Guide de découverte"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Sélectionner votre destination :"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
 msgid "View Options"
 msgstr "Options"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 #, fuzzy
 msgid "Show:"
 msgstr "Afficher"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:173
 #, fuzzy
 msgid "Display:"
 msgstr "Affichage"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Ligne de l’écliptique"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:175
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbites et noms"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Noms en latin"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Information Text"
 msgstr "Texte d’information"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Concis"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Complet"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Sites d'atterrissage"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Montagnes)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (mers)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (vallées)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (continents)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Noms"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "Afficher les marqueurs"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-msgid "Show Label"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "Taille minimum des points de repère"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Ajouter un répertoire de signets"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nom du répertoire"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "Renommer..."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "Renommer le signet ou le répertoire"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "Nouveau nom"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Découvreur d’éclipses"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Calculer"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Changer la date et aller à la planète"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Fermer"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "du :"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Paramètres de la recherche"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Éclipses solaires"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Éclipses de lunes"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "40c"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Avr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Fév"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Juin"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Août"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Déc"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Juil"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satellite"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Date"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Début"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Fournisseur : "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Mode fenêtré"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Moteur de rendu : "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invisibles"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Orbite s&ynchrone"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Afficher les axes de l’objet"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Afficher les axes du repère"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Afficher la direction du Soleil"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Afficher le vecteur vitesse"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Afficher la grille planétographique"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Afficher le terminateur"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satellites"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Objets en orbite"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Chargement : "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "fr"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Chargement de l’URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Version : "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Version GLSG : "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Nombre max de textures : "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Taille de texture max. : "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Taille de texture cubique max. : "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Plage de taille de point : "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Extensions supportées : "
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Mode fenêtré"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invisibles"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Orbite s&ynchrone"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Afficher les axes de l’objet"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Afficher les axes du repère"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Afficher la direction du Soleil"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Afficher le vecteur vitesse"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Afficher la grille planétographique"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Afficher le terminateur"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satellites"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Objets en orbite"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Chargement : "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "fr"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Chargement de l’URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Erreur lors de l’ouverture du script"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Erreur lors du chargement du script"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Exécution du script"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Nom du fuseau horaire"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Décalage UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Erreur lors de l’ouverture du fichier de script."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Erreur inconnue lors de l’ouverture du script"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Erreur lors de l’ouverture du script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "L’initialisation de la co-routine de script a échoué"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:223
+msgid "Unknown error loading hook script"
+msgstr ""
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Erreur lors de l’ouverture du script"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Chargement du programme de fragments NV : "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Erreur lors du chargement du programme de fragments NV : "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Erreur dans le programme de fragments"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Initialisation du programme de fragments NV...\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Tous les programmes de fragments NV correctement chargés.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Initialisation des programmes de fragments ARB...\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Chargement du programme de vertex NV : "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Erreur lors du chargement du programme de vertex NV : "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Erreur dans le programme de vertex "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Chargement du programme de vertex ARB : "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Erreur lors du chargement du programme de vertex ARB : "
+
+#~ msgid ", line "
+#~ msgstr ", ligne "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Initialisation du programme de vertex NV...\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Tous les programmes de vertex NV correctement chargés.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Initialisation des programmes de vertex ARB...\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Tous les programmes de vertex ARB correctement chargés.\n"
+
+#~ msgid "Nearest"
+#~ msgstr "Plus proches"
+
+#~ msgid "Brightest"
+#~ msgstr "Plus brillantes"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Ligne de l’écliptique"
+
+#~ msgid "Latin Names"
+#~ msgstr "Noms en latin"
+
+#~ msgid "Terse"
+#~ msgstr "Concis"
+
+#~ msgid "Verbose"
+#~ msgstr "Complet"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Sites d'atterrissage"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Montagnes)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (mers)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (vallées)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (continents)"
+
+#~ msgid "Label Features"
+#~ msgstr "Noms"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Éclipses solaires"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Éclipses de lunes"
+
+#~ msgid "GLSL version: "
+#~ msgstr "Version GLSG : "
+
+#~ msgid "Error opening script"
+#~ msgstr "Erreur lors de l’ouverture du script"
+
+#~ msgid "Error loading script"
+#~ msgstr "Erreur lors du chargement du script"
+
+#~ msgid "Running script"
+#~ msgstr "Exécution du script"
 
 #~ msgid "License file 'License.txt' is missing!"
 #~ msgstr "Le fichier de licence 'Licence.txt' est absent !"

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:46+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Mercurio"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Terra"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Lúa"
 
@@ -47,140 +47,140 @@ msgstr "Fobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Xúpiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amaltea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Ío"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganimedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Calisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturno"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prométeo"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epiméteo"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Xano"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encelado"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tetis"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titán"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hiperión"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapeto"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Febe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Urano"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberón"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptuno"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larisa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteo"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tritón"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Plutón-Caronte"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plutón"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Caronte"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amaltea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Calisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Xan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxias"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "NORTEAMERICA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "SURAMERICA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRICA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARCTICA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO DO ATLANTICO NORTE"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO DO ATLANTICO SUR"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO DO PACIFICO NORTE"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO DO PACIFICO SUR"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCEANO INDICO"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ARTICO"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Ababa"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Alxer"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ashgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Atenas"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Baghdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Beijing"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruselas"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Bos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Cairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Camberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Cidade do Cabo"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damasco"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibuti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "The Hague"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "La'youn"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "London"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Male"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexico DF"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadisio"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Mónaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moscova"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Muscat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Nova Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panamá"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Puerto España"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Prague"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San José"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Saraxevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seúl"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapore"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "T'bilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teherán"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Cidade do Vaticano"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Viena"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsovia"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Vía Láctea"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Centro de Masas do Sistema Solar"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Erro abrindo o arquivo da imaxe "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Erro lendo o arquivo de configuración."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,88 +1482,59 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " obxecto do espazo profundo"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Cargando o programa de fragmentos NV:"
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Erro durante a carga do programa de fragmentos NV:"
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Erro no programa de fragmentos"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Inicializando o programa de fragmentos NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Tódolos programas de fragmentos NV foron cargados correctamente.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Inicializando os programas de fragmentos ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxia (Tipo Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Cúmulo globular (radio do núcleo: %4.2f', concentración segundo King: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Cargando imaxe dende o arquivo"
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": tipo do arquivo de imaxe non recoñecido ou non soportado.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Erro abrindo o arquivo da imaxe "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " non é un arquivo PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Erro lendo o arquivo PNG"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Cargando modelo:"
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Erro ó carga-lo modelo '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebulosa"
 
@@ -1309,92 +1542,92 @@ msgstr "Nebulosa"
 msgid "Open cluster"
 msgstr "Cúmulo aberto"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Erro no arquivo .ssc (liña"
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "aviso de definición duplicada de"
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "Superficie alternativa de mala calidade"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "punto de referencia erróneo."
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Encabezamento corrupto do índice cruzado\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Versión errónea do índice cruzado\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "A carga del índice cruzado fallou no rexistro "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " estrelas na base de datos binaria\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Número total de estrelas:"
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Erro no arquivo .stc (liña"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrela non válida: tipo espectral erróneo.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrela non válida: falta o tipo espectral.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " non existe.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrela non válida: falta a ascensión recta\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrela non válida: falta a declinación.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrela non válida: falta a distancia.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrela non válida: falta a magnitude.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1402,770 +1635,744 @@ msgstr ""
 "Estrela non válida: a magnitude absoluta (non a aparente) debe ser "
 "especificada para a estrela preto da orixe\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Creando textura tipo mosaico. Ancho="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Creando unha textura tí­pica:"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Cargando programa de vértices NV:"
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Erro cargando o programa de vértices NV:"
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Erro no programa de vértices "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Cargando o programa de vértices ARB:"
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Erro cargando o programa de vértices ARB:"
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", liña"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Inicializando os programas de vértices NV . . . \n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Tódolos programas de vértices NV foron cargados con éxito.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Inicializando os programas de vértices ARB . . . \n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Tódolos programas de vértices ARB foron cargados con éxito.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Erro na apertura"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Erro lendo o arquivo PNG"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Erro lendo o arquivo de favoritos"
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Erro abrindo o arquivo do script."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erro abrindo o script '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Erro descoñecido ó abri-lo script"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Fallou a  inicialización da corutina do script"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Tipo de arquivo inválido "
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Límite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marcadores habilitados"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marcadores deshabilitados"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Ir á superficie"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo Alt-acimut activado"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo Alt-acimut desactivado"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Estilo das estrelas: puntos difusos"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Estilo das estrelas: puntos"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Estilo das estrelas: discos a escala"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Colas dos cometas habilitadas"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Colas dos cometas deshabilitadas"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Procesador gráfico: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Marcadores habilitados"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Marcadores deshabilitados"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Auto-magnitude habilitada"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Auto-magnitude deshabilitada"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "O tempo e o script están detidos"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Tempo en pausa"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Continuar"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "&Navegador Estelar"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "&Navegador Estelar"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Viaxar á velocidade da luz: %.4f an"
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Viaxar á velocidade da luz: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Viaxar á velocidade da luz: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Viaxar á velocidade da luz con demora temporal incluí­da"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Desactiva-la demora temporal ó viaxar á velocidade da luz"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Inora-la demora temporal ó viaxar á velocidade da luz"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Usa-las texturas normais das superficies."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Usar ata o límite do coñecemento as texturas das superficies."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tempo: Cara adiante"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tempo: Cara atrás"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Taxa do tempo"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Órbita Sinc"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Bloquear"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Perseguir"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Límite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Límite da auto magnitude a 45 graos:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiental: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Ganancia de luz"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Bloom activado"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Bloom desactivado"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Exposición"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Erro GL:"
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "A vista é demasiado pequena para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Vista engadida"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "ua"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " días"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "Establecer"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Período de rotación:"
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Velocidade:"
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diámetro aparente:"
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitude aparente:"
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitude absoluta:"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distancia: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Centro de masas do sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs (ap): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Estrela de neutróns"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Burato negro"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clase:"
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Temp. superficial:"
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Radio:"
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Radio:"
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Compañeiros planetarios presentes\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distancia dende o centro:"
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radio:"
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Taxa do tempo"
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " máis rápido"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " máis lento"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Viaxando"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Viaxando"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rastrexar"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Seguir"
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Sincrónica"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Perseguir"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sol"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nome do destino:"
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "   Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Grabando"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Deter"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Modo de edición"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Cargando o catálogo do Sistema Solar:"
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Cargando o catálogo do Sistema Solar:"
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Erro lendo o arquivo de configuración."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "A inicialización da librerí­a SPICE fallou."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Non se puido le-la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Erro o abri-lo arquivo do catálogo de obxectos do espazo profundo."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Non se puido le-la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Erro o abri-lo arquivo do catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Erro o abri-lo arquivo de asterismos."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Erro o abri-los arquivos dos bordes das constelacións."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Erro o tentar inicia-lo procesado gráfico"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Erro o carga-la fonte; o texto non será visible.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Erro o le-lo índice cruzado "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Índice cruzado cargado "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Erro o le-lo arquivo dos nomes das estrelas\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Erro na apertura"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Erro o le-lo arquivo dos nomes das estrelas\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Erro o le-lo arquivo das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Erro o abri-lo catálogo de estrelas"
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Erro abrindo o script '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versión:"
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Erro descoñecido ó abri-lo script"
-
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
-
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:108
 #, fuzzy, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Vendor: %s\n"
+msgstr "Provedor:"
+
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Visualizador:"
+
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Nº max. de texturas simultáneas: "
+
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Tamaño max. da textura:"
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Rango de tamaño do punto:"
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Rango de tamaño do punto:"
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Tamaño max. do mapa cúbico:"
+
+#: ../src/celestia/helper.cpp:132
+#, c-format
+msgid "Number of interpolators: %s\n"
 msgstr ""
-"Celestia non puido inicializa-las extensións OpenGL. A calidade dos gráficos "
-"poderase ver reducida. Só está dispoñible a ruta para o procesador básico"
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
+msgstr ""
 
 #. if (glGetError())
 #. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
@@ -2361,14 +2568,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Erro o crea-lo arquivo ogg %s para a captura.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Erro interno na librería Ogg."
@@ -2387,48 +2594,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - %d fotogramas capturados\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, fuzzy, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-"Celestia non puido inicializa-las extensións OpenGL. A calidade dos gráficos "
-"poderase ver reducida. Só está dispoñible a ruta para o procesador básico"
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navegador Celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navegador Celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -2438,21 +2634,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " obxecto do espazo profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
@@ -2461,7 +2656,7 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 #, fuzzy
 msgid "Time"
 msgstr "&Hora"
@@ -2469,455 +2664,506 @@ msgstr "&Hora"
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Guía do Tour"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Pantalla Completa"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar &Vídeo...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Erro o abri-lo arquivo de asterismos."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Gravar Imaxe"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " non é un arquivo PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolución:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Taxa de fotogramas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL Copiada"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Cargando URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Abri-lo Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crear un novo cartafol de marcadores neste menú"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>OpenGL 1.1 sen extensións</b>"
+msgid "Unknown compiler"
+msgstr "Erro descoñecido ó abri-lo script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
+#: ../src/celestia/qt/qtappwin.cpp:1043
 #, fuzzy
-msgid "<b>Renderer: </b>"
-msgstr "<b>OpenGL 1.1 sen extensións</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
-msgstr "Versión do GLSL:"
-
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
-msgstr "Tamaño max. da textura:"
-
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-#, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "supported"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "Información OpenGL"
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Extensións aceptadas:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Acerca de Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>OpenGL 1.1 sen extensións</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Provedor:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>OpenGL 1.1 sen extensións</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "Versión do GLSL:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Nº max. de texturas simultáneas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Tamaño max. da textura:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Rango de tamaño do punto:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Rango de tamaño do punto:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Tamaño max. do mapa cúbico:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Ecuatorial"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Extensións aceptadas:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Visualizador:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Gravar Imaxe"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Capturar &Imaxe...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar &Vídeo...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "&Centrase sobre a Selección\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Copiar URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL Copiada"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Abri-lo Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferencias de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Saír"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Anti-aliasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegación"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrase sobre a Selección\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selección:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir o Obxecto..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Hora"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Escolle-la Hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Pantalla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Obxectos marcados"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Sombras dos Aneis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Estilo das Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Resolución da Textura"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controis"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vista"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "&Vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividi-la Vista Verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir &Horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividi-la Vista Horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "&Dividir Verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Vista Cí­clica"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Vista Simple"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Vista Simple\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Borra-la Vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Marcos Visibles"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Marco Activo Visible"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Tempo Sincronizado"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "A&xuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Acerca de Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Engadir Marcador"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organiza-los Marcadores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Cargando"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Duración"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Erro lendo o arquivo de favoritos"
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Escolle-la Hora da Simulación"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Escolle-la Hora da Simulación"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "&Hora"
@@ -2926,79 +3172,77 @@ msgstr "&Hora"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Novo Cartafol..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Amosa-la Grella Ecuatorial"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galáctica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Eclíptica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr ", liña"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Copyright (C) 2001-2009, Celestia Development Team"
@@ -3007,57 +3251,54 @@ msgstr "Copyright (C) 2001-2009, Celestia Development Team"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Constelacións"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>Combinadores NVIDIA, sen programas de vértices</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Bordes das Constelacións"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Órbitas"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planetas Ananos"
 
@@ -3067,19 +3308,17 @@ msgstr "Planetas Ananos"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Lúas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Lúas Menores"
 
@@ -3089,12 +3328,12 @@ msgstr "Lúas Menores"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroides"
 
@@ -3104,12 +3343,12 @@ msgstr "Asteroides"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Cometas"
 
@@ -3119,14 +3358,15 @@ msgstr "Cometas"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Sondas Espaciais"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x &Máis Rápido\tL"
@@ -3135,9 +3375,8 @@ msgstr "10x &Máis Rápido\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Nomes"
 
@@ -3145,20 +3384,18 @@ msgstr "Nomes"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxias"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Cúmulos Globulares"
 
@@ -3166,7 +3403,7 @@ msgstr "Cúmulos Globulares"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3176,617 +3413,634 @@ msgstr "Cúmulos Abertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulosas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Lugares"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Cúmulos Abertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nubes"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Contaminación Lumí­nica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Colas dos Cometas "
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosferas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Sombras dos Aneis"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Sombras dos Eclipses "
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Sombras das Nubes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Baixa"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Medio"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Alta"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Auto Magnitude\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Máis Estrelas Visibles\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Menos Estrelas Visibles\t]"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Puntos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Puntos Di&fusos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&Discos a Escala"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Desactiva-la demora temporal ó viaxar á velocidade da luz"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Modo Alt-acimut activado"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Límite da auto magnitude a 45 graos:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Límite de magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distancia (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag. ap."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag. abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "A máis brillante"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 #, fuzzy
 msgid "With Planets"
 msgstr "Con planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Centro de masas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 #, fuzzy
 msgid "Refresh"
 msgstr "Ac&tualizar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Nº Máximo de Estrelas Amosadas na Lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Ningún"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triángulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Cadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Frecha Esquerda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Frecha Dereita"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Frecha Arriba"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Frecha Abaixo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamaño:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Características dos Nomes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "' non atopado.\n"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "corpo primario '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Comezo"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Duración"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Eclipses Lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Desmarcar &Todo"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Parámetros de procura"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Obxecto:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Escolle-la Hora Actual"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Dende:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Duración: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotación:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Distancia: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Tamaño: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotación:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "&Estilo das Estrelas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Formato Local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Zona Horaria"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Ver en UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Comezo"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3805,21 +4059,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Ir a"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -3833,50 +4087,55 @@ msgid "Visible"
 msgstr "Marco Activo Visible"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Selecciona-lo Modo da Pantalla"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Cadrado Recheado"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "&Vectores de Referencia"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Amosa-los Eixos do Corpo"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Amosa-los Eixos do Marco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Amosa-la Dirección do Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Amosa-lo Vector da Velocidade"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Amosa-lo Vector da Velocidade"
@@ -3884,191 +4143,41 @@ msgstr "Amosa-lo Vector da Velocidade"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Amosa-la Dirección do Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Amosa-la Grella Planetaria"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Amosa-lo Terminador"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "Superficies &Alternativas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Sonda espacial"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Outros"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Escolle-la Hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Zona Horaria:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Hora Universal"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Hora Local"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Zona Horaria:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Data"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Establecer"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Establecer"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Establecer"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Hora"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " horas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minutos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "Establecer"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Data Xuliana:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Data Xuliana:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Escolle-la Hora..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Centro de masas"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planeta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Planeta anano"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Lúas Menores"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroide"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Cometa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Vectores de Referencia"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Computar"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Ir á superficie"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Erro descoñecido ó abri-lo script"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroides"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Vectores de Referencia"
+msgid "Dwarf planets"
+msgstr "Planetas Ananos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4076,67 +4185,235 @@ msgstr "&Vectores de Referencia"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Lúas Menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Sonda espacial"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Outros"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Escolle-la Hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Zona Horaria:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Hora Universal"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Hora Local"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Zona Horaria:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Data"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Establecer"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Establecer"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Establecer"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Hora"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " horas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minutos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "Establecer"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Data Xuliana:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Data Xuliana:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Escolle-la Hora..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Centro de masas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planeta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Planeta anano"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Lúas Menores"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroide"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Cometa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Vectores de Referencia"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Computar"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Ir á superficie"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Erro descoñecido ó abri-lo script"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroides"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Vectores de Referencia"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Outras características"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planetas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Clase:"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Inverte-lo Tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x Máis &Lento\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " máis lento"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Pausar Tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " máis rápido"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x &Máis Rápido\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Escolle-la Hora Actual"
@@ -4208,7 +4485,6 @@ msgstr "Latitude:"
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radios"
 
@@ -4229,7 +4505,7 @@ msgstr "Resolución:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizar marcadores"
 
@@ -4261,18 +4537,6 @@ msgstr "Preferencias de Celestia"
 #, fuzzy
 msgid "Objects"
 msgstr " obxecto do espazo profundo"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Planetas Ananos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4363,49 +4627,43 @@ msgstr "Traxectorias Parciais"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Grella"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Ecuatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galáctica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Bordes"
 
@@ -4439,7 +4697,6 @@ msgstr "punto de referencia erróneo."
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Cidades"
 
@@ -4453,21 +4710,18 @@ msgstr "Lugares de Aterraxe"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Volcáns"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatorios"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Cráteres"
 
@@ -4502,7 +4756,6 @@ msgstr "Maria (Mares)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Outras características"
 
@@ -4607,7 +4860,7 @@ msgstr "Pantalla"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Preferencias"
 
@@ -4849,21 +5102,21 @@ msgid "&About Celestia"
 msgstr "&Acerca de Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4872,531 +5125,639 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2009, Celestia Development Team"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 #, fuzzy
 msgid "https://celestia.space/"
 msgstr "http://celestiaproject.net/"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia é un programa libre e non ven con garantía incluída."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Seleccionar Obxecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Nome do Obxecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licenza"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Controis de Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Información do Driver do OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Escolle-la Hora da Simulación"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formato:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Escolle-la Hora Actual"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Engadir Marcador"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Crear en >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Novo Cartafol..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navegador do Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Engadir un Novo Cartafol de Marcadores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Ir a"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nome do Cartafol"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Obxectos do Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Controis de Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navegador Estelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "A máis próxima"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "A máis brillante"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "Con planetas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "Ac&tualizar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Criterio para a Procura de Estelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Nº Máximo de Estrelas Amosadas na Lista"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Guía do Tour"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Ir a"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Escolle o teu destino:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Ir o obxecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Obxecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Lonx."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Distancia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Tamaño:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Selecciona-lo Modo da Pantalla"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Resolución"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Opcións da Vista"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Amosar"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Computar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Pantalla"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Escoller Data e Ir o Planeta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#, fuzzy
-msgid "Ecliptic Line"
-msgstr ", liña"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Pechar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Órbitas / Nomes"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Dende:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Nomes en Latín"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Texto Informativo"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Reducida"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parámetros de procura"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Completa"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Seleccionar Obxecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Lugares de Aterraxe"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Nome do Obxecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Montes)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Información do Driver do OpenGL"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Mares)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Ir o obxecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Vales)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Ir a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Chairas)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Obxecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Características dos Nomes"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Lonx."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Distancia"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licenza"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Amosa-las Características"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Características dos Nomes"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Tamaño mínimo para etiquetar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Engadir un Novo Cartafol de Marcadores"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Tamaño:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nome do Cartafol"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Renomea-lo Marcador ou o Cartafol"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Novo Nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Buscador de eclipses"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Escolle-la Hora da Simulación"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Computar"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formato:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Escoller Data e Ir o Planeta"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Escolle-la Hora Actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Pechar"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navegador do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Dende:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Ir a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Obxectos do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navegador Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parámetros de procura"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "Ac&tualizar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Eclipses Solares"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Criterio para a Procura de Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Eclipses Lunares"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Nº Máximo de Estrelas Amosadas na Lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Guía do Tour"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Escolle o teu destino:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Opcións da Vista"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Amosar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Pantalla"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Órbitas / Nomes"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Texto Informativo"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "0456"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Xan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Xuñ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Xul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Out"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Set"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satélite"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Data"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Comezo"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Provedor:"
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Modo de Xanelas"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Visualizador:"
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invisibles"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "&Orbita Sinc"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Amosa-los Eixos do Corpo"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Amosa-los Eixos do Marco"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Amosa-la Dirección do Sol"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Amosa-lo Vector da Velocidade"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Amosa-la Grella Planetaria"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Amosa-lo Terminador"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satélites"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Corpos en Órbita"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Cargando:"
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "gl"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Cargando URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versión:"
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Versión do GLSL:"
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Nº max. de texturas simultáneas: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Tamaño max. da textura:"
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Tamaño max. do mapa cúbico:"
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Rango de tamaño do punto:"
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Extensións aceptadas:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Modo de Xanelas"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invisibles"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "&Orbita Sinc"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Amosa-los Eixos do Corpo"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Amosa-los Eixos do Marco"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Amosa-la Dirección do Sol"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Amosa-lo Vector da Velocidade"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Amosa-la Grella Planetaria"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Amosa-lo Terminador"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satélites"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Corpos en Órbita"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Cargando:"
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "gl"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Cargando URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Erro o abri-lo script"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Erro o carga-lo script"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Script en curso"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Zona Horaria"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Ver en UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Erro abrindo o arquivo do script."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Erro descoñecido ó abri-lo script"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Erro abrindo o script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Fallou a  inicialización da corutina do script"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Erro abrindo o script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Erro descoñecido ó abri-lo script"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Erro na apertura"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Cargando o programa de fragmentos NV:"
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Erro durante a carga do programa de fragmentos NV:"
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Erro no programa de fragmentos"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Inicializando o programa de fragmentos NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Tódolos programas de fragmentos NV foron cargados correctamente.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Inicializando os programas de fragmentos ARB . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": tipo do arquivo de imaxe non recoñecido ou non soportado.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Cargando programa de vértices NV:"
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Erro cargando o programa de vértices NV:"
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Erro no programa de vértices "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Cargando o programa de vértices ARB:"
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Erro cargando o programa de vértices ARB:"
+
+#~ msgid ", line "
+#~ msgstr ", liña"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Inicializando os programas de vértices NV . . . \n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Tódolos programas de vértices NV foron cargados con éxito.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Inicializando os programas de vértices ARB . . . \n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Tódolos programas de vértices ARB foron cargados con éxito.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Erro descoñecido ó abri-lo script"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia non puido inicializa-las extensións OpenGL. A calidade dos "
+#~ "gráficos poderase ver reducida. Só está dispoñible a ruta para o "
+#~ "procesador básico"
+
+#, fuzzy, qt-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia non puido inicializa-las extensións OpenGL. A calidade dos "
+#~ "gráficos poderase ver reducida. Só está dispoñible a ruta para o "
+#~ "procesador básico"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Copiar URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL Copiada"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Modo Alt-acimut activado"
+
+#~ msgid "Nearest"
+#~ msgstr "A máis próxima"
+
+#~ msgid "Brightest"
+#~ msgstr "A máis brillante"
+
+#~ msgid "With planets"
+#~ msgstr "Con planetas"
+
+#, fuzzy
+#~ msgid "Ecliptic Line"
+#~ msgstr ", liña"
+
+#~ msgid "Latin Names"
+#~ msgstr "Nomes en Latín"
+
+#~ msgid "Terse"
+#~ msgstr "Reducida"
+
+#~ msgid "Verbose"
+#~ msgstr "Completa"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Lugares de Aterraxe"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Montes)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Mares)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Vales)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Chairas)"
+
+#~ msgid "Label Features"
+#~ msgstr "Características dos Nomes"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Eclipses Solares"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Eclipses Lunares"
+
+#~ msgid "Vendor: "
+#~ msgstr "Provedor:"
+
+#~ msgid "GLSL version: "
+#~ msgstr "Versión do GLSL:"
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Extensións aceptadas:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Erro o abri-lo script"
+
+#~ msgid "Error loading script"
+#~ msgstr "Erro o carga-lo script"
+
+#~ msgid "Running script"
+#~ msgstr "Script en curso"
 
 #~ msgid "Invisible"
 #~ msgstr "Invisible"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:47+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Merkúr"
 msgid "Venus"
 msgstr "Vénusz"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Föld"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Hold"
 
@@ -47,140 +47,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Európa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganümédész"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Kallisztó"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Szaturnusz"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prométheusz"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tethys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titán"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phoebe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uránusz"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptunusz"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Plútó-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plútó"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamakó"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Kallisztó"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxisok"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "ÉSZAK AMERIKA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "DÉL AMERIKA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURÁZSIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSZTRÁLIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARKTISZ"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ÉSZAK-ATLANTI ÓCEÁN"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "DÉL ATLANTI ÓCEÁN"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ÉSZAKI CSENDES ÓCEÁN"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "DÉLI CSENDES ÓCEÁN"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "INDIAI ÓCEÁN"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "ÉSZAKI ÓCEÁN"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu-Dabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addisz-Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Algír"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Asgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Aszmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Asztana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción "
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Athén"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamakó"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bender Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Peking"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Bejrut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrád"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brazília"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Pozsony"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Brüsszel"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bukarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumburai"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Kairó"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Fokváros"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castriest"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Kisinyov"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombó"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Koppenhága"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damaszkusz"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Dzsibuti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "A Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltár"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Hága"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havanna"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Iszlamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Dzsakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jeruzsálem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Kartúm"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kijev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuvait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiun"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisszabon"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "London"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Male"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputó"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexikóváros"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minszk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moróni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moszkva"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Maszkat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Újdelhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Párizs"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Pénh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Prága"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quitó"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Róma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Szanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Szarajevó"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Szöul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Szingapúr"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Szkopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Szófia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Tajvan"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Taskent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbiliszi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teherán"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Timpu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokió"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunisz"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulán Bátor"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vatikánváros"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Viktória"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Bécs"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientián"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsó"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D. C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren kerület"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Jereván"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zágráb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Tejút"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Kis Magellán Felhő"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Nagy Magellán Felhő"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Csillagrendszer tömegközéppontja"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Nyári idő"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "Téli idő"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Hiba a képfájl megnyitásakor"
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Hiba a konfigurációs fájl olvasásakor."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "Téli idő"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr "Mélyég objektumok"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "NV fragment program betöltése: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Hiba az NV fragment program betöltésekor: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Hiba a fragment programban "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "NV fragment programok inicializációja...\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Minden NV fragment program sikeresen betöltődött.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "ARB fragment programok inicializálása . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxis (Hubble type: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Gömbhalmaz (mag sugara: %4.2f', King koncentráció: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Kép betöltése fájlból"
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": ismeretlen, vagy nem támogatott képfájl típus.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Hiba a képfájl megnyitásakor"
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "nem PNG fájl.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Hiba a PNG képfájlban"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Modell betöltése: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Hiba a modell betöltésekor '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebula"
 
@@ -1308,92 +1541,92 @@ msgstr "Nebula"
 msgid "Open cluster"
 msgstr "Nyílt galaxishalmazok"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Hiba az .ssc fájlban (sor"
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Vigyázat,duplikált definíció "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "hibás alternatív felületek"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "Hibás hely"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Bad header for cross index\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Rossz keresztindex verzió\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Hiba a rekord keresztindex betöltésekor"
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Rossz spektráltípus a csillag adatbázisban "
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr "csillagok a bináris adatbázisban\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Csillagok száma: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Hiba az .stc fájlban (sor"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Érvénytelen csillag: hibás spektrál típus.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Érvénytelen csillag: hibás spektrális típus.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr "nem létező.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Érvénytelen csillag: missing right ascension\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Érvénytelen csillag: hiányzó deklináció. \n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Érvénytelen csillag: hiányzó távolság. \n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Érvénytelen csillag: hiányzó magnitúdó.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "Érvénytelen csillag: az abszolút (nem a látszó fényesség) magnitúdot meg "
 "kell adni a közelli csillagnál\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Darabolt textúra készítése. Szélesség="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Textúra készítése:"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "NV vertex program betöltése:"
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Hiba az NV vertex program betöltésekor:"
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Hiba a vertex programban: "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "ARB vertex program betöltése"
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Hiba az ARB vertex program betöltésekor:"
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", sor"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "NV vertex programok inicializálása...\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Az összes NV vertex program sikeresen betöltődött.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "ARB vertex programik inicializálása...\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Minden ARB vertex program sikeresen betöltődött.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Hiba a megnyitáskor"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Hiba a PNG képfájlban"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Hiba a \"favorites\" fájl olvasásakor."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Hiba a szkript fájl megnyitásakor."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Hiba a szkript megnyitásakor '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Ismeretlen hiba a szkript megnyitásakor"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Hiba a co-routin szkript inicializálásánál"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Érvénytelen fájltípus"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudó korlát: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Jelölők bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Jelölők kikapcsolva"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Ugrás a felszínre"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Aizmuth mód be"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Aizmuth mód ki"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Csillagok megjelenítése: elmosódott pontok"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Csillagok megjelenítése: pontok"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Csillagok megjelenítése: méretarányos pöttyök"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Üstököscsóvák bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Üstököscsóvák kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Megjelenítési mód: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Jelölők bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Jelölők kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Önműködő fényességállítás be"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Önműködő fényességállítás ki"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Vissza"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Idő és szkript megállítása"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Idő megállítva"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Tovább"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Csillag &böngésző..."
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Csillag &böngésző..."
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Utazási idő fénysebességgel:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Utazás ideje fénysebességgel:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Utazás fénysebességgel:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Utazás fénysebességgel: bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Utazás fénysebességgel: kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Utazás fénysebességgel: mellőzve "
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Normál felületi textúrák alkalmazása."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Ismereteink határa textúrák "
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Követ"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Idő: Előre"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Idő: Vissza"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Idő múlása: "
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Textúrák"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Textúrák"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Textúrák"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Pálya szinkr."
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Rögzít"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Követés"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudó korlát: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Önműködő fényességállítás 45 foknál:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Környező fények:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Megvilágítás javulása"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Bloom hatás bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Bloom hatás kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Megvilágítottság"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "OpenGL hiba: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "A felosztáshoz túl kicsi nézet"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Hozzáadott nézet"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "fényév"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "CSE"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr "nap"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr "óra"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr "perc"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "másodpercek"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " fényév/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Sebesség:  "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Látszólagos átmérő: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Látszólagos fényesség"
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Abszolút fényesség: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Távolság: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Csillagrendszer tömegközéppontja\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Absz. (látszó) fényesség: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Fényesség: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Neutroncsillag"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Fekete lyuk"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Osztály:"
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Felszíni hőm.: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Kapcsolódó égitestek\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Távolság a középponttól:  "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fázisszög: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Hőmérséklet: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Helyi idő"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Helyi idő"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Idő leállítva"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "gyorsabb"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "lassabb"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr "Idő megállítása"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Utazás"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Utazás"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Vontat"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Követ "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Pálya szinkr."
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Üldöz"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Nap"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Cél neve: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " Szünet"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "Felvétel"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Szünet    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Edit Mode"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Naprendszer katalógus betöltése:"
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Naprendszer katalógus betöltése:"
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Hiba a konfigurációs fájl olvasásakor."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Hiba a SPICE könyvtár inicializálásakor."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Csillag adatbázis nem olvasható."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Hiba a mélyég katalógus megnyitásakor"
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Csillag adatbázis nem olvasható."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Hiba a naprendszer katalógus megnyitásakor.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Hiba az asterisms fájl megnyitásakor."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Hiba a constellation boundaries fájl megnyitásakor."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Hiba a renderelő inicializálásánál"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Hiba a font betöltésekor, a szöveg nem jeleníthető meg.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Hiba a keresztindex olvasásakor"
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Cross index betöltve"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Hiba a csillagok nevét tartalmazó fájl megnyitásakor\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Hiba a megnyitáskor"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Hiba a csillagok nevét tartalmazó fájl megnyitásakor\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Hiba a stars fájl olvasásakor\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Hiba a csillag katalógus megnyitásakor"
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Hiba a szkript megnyitásakor '%s'"
+msgid "%s Version: %s\n"
+msgstr "Verzió:"
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Ismeretlen hiba a szkript megnyitásakor"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Forgalmazó:"
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Megjelenítés"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Max simultaneous textures: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Max texture size: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Point size range: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Point size range: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Max cube map size: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Error in creating ogg file %s for capture.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Internal Ogg library error."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Égi objektumok"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Égi objektumok"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Naprendszer"
 
@@ -2433,21 +2633,20 @@ msgstr "Naprendszer"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Csillagok"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "Mélyég objektumok"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Fogyatkozás-kereső"
@@ -2456,464 +2655,515 @@ msgstr "Fogyatkozás-kereső"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Idő"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Idegenvezetés"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Tejles képernyő"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "&Mozgókép felvétele...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Hiba az asterisms fájl megnyitásakor."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Könyvjelzők"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Mentés másként:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "nem PNG fájl.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Felbontás:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Képkocka/másodperc: "
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL másolása"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "URL betöltése:"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Szkript megnyitása..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Új könyvjelzőmappa létrehozása ebben a menüben"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
+msgid "Unknown compiler"
+msgstr "Ismeretlen hiba a szkript megnyitásakor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
+#: ../src/celestia/qt/qtappwin.cpp:1043
 #, fuzzy
-msgid "<b>Renderer: </b>"
-msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
-msgstr "GLSL verzió:"
-
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
-msgstr "Max texture size: "
-
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-#, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "supported"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1045
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "OpenGL adatok"
+msgid "not supported"
+msgstr "Supported Extensions:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Celestia névjegye"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Forgalmazó:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "GLSL verzió:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Max simultaneous textures: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Max texture size: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Point size range: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Point size range: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Max cube map size: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Egyenlítői"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Supported Extensions:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Megjelenítés"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Kép elmentése"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Képernyő-fényképezés...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "&Mozgókép felvétele...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "URL másolása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "URL másolása"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL másolása"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Szkript megnyitása..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia beállítások"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Kilépés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Élsimítás (Antialiasing)\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigáció"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "Kiválaszt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "Kijelölt égitest középre\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Kijelölés: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ugrás a kijelölt égitesthez..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "Idő "
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Idő beállítása..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Megjelenítés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Égitestek"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Gyűrűárnyékok"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Csillagok megjelenítése"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Textúra felbontás"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "Gyorsbillentyűk"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 #, fuzzy
 msgid "&Bookmarks"
 msgstr "Könyvjelzők"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Nézet"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Több Nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Nézet vízszintes felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Nézet vízszintes felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Nézet függőleges felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Nézet függőleges felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Következő nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Egyablakos nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Egyablako&s nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Nézet törlése"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Keret mutatása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktív nézet kerete látható"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Idő szinkronizálása"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Súgó"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Celestia névjegye"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "OpenGL adatok"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Könyvjelzők hozzáadása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "Könyvjelzők rendezése..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Betöltés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Szkriptek"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Időtartam"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Könyvjelzők"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Fő eszköztár"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Hiba a \"favorites\" fájl olvasásakor."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Könyvjelzők"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Szimuláció idő beállítása"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Szimuláció idő beállítása"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Idő"
@@ -2922,79 +3172,77 @@ msgstr "Idő"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Új mappa..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Égi háló mutatása"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galaktikus"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Ekliptikus"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Nézet függőleges felosztása"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Ekliptikus vonal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Jelölők"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Kijelölt égitest középre\tC"
@@ -3003,57 +3251,54 @@ msgstr "Kijelölt égitest középre\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Csillagképek"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, vertex program nélkül</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Csillagképek határai"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Pályák"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Bolygók"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Törpe bolygók"
 
@@ -3063,19 +3308,17 @@ msgstr "Törpe bolygók"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Holdak"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Kis holdak"
 
@@ -3085,12 +3328,12 @@ msgstr "Kis holdak"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Kisbolygók"
 
@@ -3100,12 +3343,12 @@ msgstr "Kisbolygók"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Üstökösök"
 
@@ -3115,14 +3358,15 @@ msgstr "Üstökösök"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Űrhajók"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Gyorsabb\tL"
@@ -3131,9 +3375,8 @@ msgstr "10x Gyorsabb\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Címkék"
 
@@ -3141,20 +3384,18 @@ msgstr "Címkék"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxisok"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Gömbhalmazok"
 
@@ -3162,7 +3403,7 @@ msgstr "Gömbhalmazok"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3172,615 +3413,632 @@ msgstr "Nyílt galaxishalmazok"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulák"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Helyek"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Nyílt galaxishalmazok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Felhők"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Éjjeli oldal fényei"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Üstököscsóvák"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Légkör"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Gyűrűárnyékok"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Fogyatkozás-árnyékok"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Felhőárnyékok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Alacsony"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Közepes "
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Nagy"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Fényesség automatikus beállítása\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Több látható csillag\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Kevesebb látható csillag\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Pontok"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Elmosódott pontok"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Méretarányos korongok"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Utazás fénysebességgel: kikapcsolva"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Alt-Aizmuth mód be"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Önműködő fényességállítás 45 foknál:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudó korlát: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Név"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Távolság (fényév): "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Látsz. magn."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Absz. magn."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Típus"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Csillagok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Legfényesebb"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Csillagok szűrése"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Bolygókkal"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Csillagok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Tömegközéppont"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Rossz spektráltípus a csillag adatbázisban "
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "Jelöl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "A listázandó csillagok maximális száma"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Jelöl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Jelölők"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Semmi"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Gyémánt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Háromszög"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Négyzet"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plusz"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Kör"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Balra nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Jobbra nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Felfelé nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Lefelé nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Kiválaszt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Méret:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Kiválaszt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Tereptárgyak címkéi"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Égitestek"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "Jelöl"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "fő égitest '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Indítás"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Időtartam"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Napfogyatkozások"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Holdfogyatkozások"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "&Megjelölések megszűntetése"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Keresés"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Holdfogyatkozások"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Égitest: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Napfogyatkozások"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Pillanatnyi időre állítás"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Mettől:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Időtartam: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Távolság: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Méret: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "CSE"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Csillagok megjelenítése"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Helyi formátum"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Időzóna neve: "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC eltérés"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Indítás"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3799,21 +4057,21 @@ msgid "&Select"
 msgstr "Kiválaszt"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "Középre"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "U&grás"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 #, fuzzy
 msgid "&Follow"
 msgstr "Követ "
@@ -3828,49 +4086,54 @@ msgid "Visible"
 msgstr "Aktív nézet kerete látható"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "Jelölés törlése"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Képernyő üzemmód kiválasztása"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Teli négyzet"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Korong"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "Jelöl"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Referencia vektorok"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Objektumok tengelyének mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Váz tegelyeinek mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Nap irányának mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Sebességvektor mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Sebességvektor mutatása"
@@ -3878,191 +4141,41 @@ msgstr "Sebességvektor mutatása"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Nap irányának mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Planetáris háló mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Lezáró mutatása"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternatív Felületek"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Alap"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Űrhajók"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Égitestek"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Idő beállítása..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Időzóna: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Csillagidő"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Helyi idő"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Időzóna: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Dátum"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Beállítás"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Beállítás"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Beállítás"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "Idő "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr "óra"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr "perc"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "másodpercek"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Julián dátum:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Julián dátum:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Idő beállítása..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Tömegközéppont"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Rossz spektráltípus a csillag adatbázisban "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Bolygó"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Törpe bolygó"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Kis holdak"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Kisbolygó"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Üstökös"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Referencia vektorok"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Számítás"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Ugrás a felszínre"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Ismeretlen hiba a szkript megnyitásakor"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Kisbolygók"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Referencia vektorok"
+msgid "Dwarf planets"
+msgstr "Törpe bolygók"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4070,67 +4183,235 @@ msgstr "&Referencia vektorok"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Kis holdak"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Űrhajók"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Égitestek"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Idő beállítása..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Időzóna: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Csillagidő"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Helyi idő"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Időzóna: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Dátum"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Beállítás"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Beállítás"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Beállítás"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "Idő "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr "óra"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr "perc"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "másodpercek"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Julián dátum:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Julián dátum:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Idő beállítása..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Tömegközéppont"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Rossz spektráltípus a csillag adatbázisban "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Bolygó"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Törpe bolygó"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Kis holdak"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Kisbolygó"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Üstökös"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Referencia vektorok"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Számítás"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Ugrás a felszínre"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Ismeretlen hiba a szkript megnyitásakor"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Kisbolygók"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Referencia vektorok"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Egyéb tereptárgyak"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Bolygók"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Égitestek"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Idő visszafelé halad"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x La&ssabb\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr "lassabb"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Idő megállítása"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr "gyorsabb"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Gyorsabb\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Helyi idő beállítása"
@@ -4202,7 +4483,6 @@ msgstr "Szélesség: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radii"
 
@@ -4223,7 +4503,7 @@ msgstr "Felbontás:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Könyvjelzők rendezése"
 
@@ -4254,18 +4534,6 @@ msgstr "Celestia beállítások"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Égitestek"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Törpe bolygók"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4356,49 +4624,43 @@ msgstr "Részleges pályák"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Rácsok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Egyenlítői"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptikus"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktikus"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Nézet függőleges felosztása"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagrammok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Határok"
 
@@ -4432,7 +4694,6 @@ msgstr "Hibás hely"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Városok"
 
@@ -4446,21 +4707,18 @@ msgstr "Leszállóhelyek"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulkánok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Csillagvizsgálók"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Kráterek"
 
@@ -4495,7 +4753,6 @@ msgstr "Maria (Tengerek)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Egyéb tereptárgyak"
 
@@ -4600,7 +4857,7 @@ msgstr "Megjelenítés"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Beállítások"
 
@@ -4844,21 +5101,21 @@ msgid "&About Celestia"
 msgstr "&Celestia névjegye"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4867,533 +5124,623 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2008, Celestia Development Team"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "A Celestia egy szabadon használható szoftver, szavatosság nélkül"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Szerzők"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Égitest kiválasztása: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Égitest neve"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licensz"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Celestia gyorsbillentyűk"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL adatok"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Szimuláció idő beállítása"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formátum:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Helyi idő beállítása"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Könyvjelző hozzáadása"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Létrehoz >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Új mappa..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Naprendszer böngésző"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Ugrás"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Égitestek a Naprendszerben"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Csillag böngésző"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Legközelebbi"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Legfényesebb"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Bolygókkal"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "F&rissítés"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Csillag keresése"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "A listázandó csillagok maximális száma"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Idegenvezetés"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Ugrás"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Úticél kiválasztása"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Ugrás az égitesthez: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-#, fuzzy
-msgid "Object"
-msgstr "Égitest: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Hossz."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Szélesség"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-#, fuzzy
-msgid "Distance"
-msgstr "Távolság: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Méret:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "Képernyő üzemmód kiválasztása"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "Felbontás"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Megjelenítési beállítások"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Mutat"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Megjelenítés"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Ekliptikus vonal"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Pályák / Címkék"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Latin nevek"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Adatok"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Tömör"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Bőséges"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Leszállóhelyek"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Hegységek)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Tengerek)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Völgyek)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Szárazföldek)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Tereptárgyak címkéi"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "Tereptárgyak mutatása"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-#, fuzzy
-msgid "Show Label"
-msgstr "Tereptárgyak címkéi"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "Legkisebb megjelenített tereptárgy mérete"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:96
 msgid "Add New Bookmark Folder"
 msgstr "Új könyvjelzőmappa "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:99
 msgid "Folder Name"
 msgstr "Mappa neve"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "Átnevezés..."
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Celestia gyorsbillentyűk"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "Könyvjelző/Mappa átnevezése"
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "Képernyő üzemmód kiválasztása"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "Új név"
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "Felbontás"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/win32/res/resource_strings.cpp:106
 msgid "Eclipse Finder"
 msgstr "Fogyatkozás-kereső"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:107
 msgid "Compute"
 msgstr "Számítás"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:108
 msgid "Set Date and Go to Planet"
 msgstr "Dátum beállítása és ugrás a bolygóra"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:109
 #, fuzzy
 msgid "Close"
 msgstr "Bezár"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:110
 msgid "From:"
 msgstr "Mettől:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:111
 msgid "To:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:112
 msgid "On:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:113
 msgid "Search parameters"
 msgstr "Keresési beállítások"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Napfogyatkozások"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Égitest kiválasztása: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Holdfogyatkozások"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Égitest neve"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL adatok"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Ugrás az égitesthez: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Ugrás"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+#, fuzzy
+msgid "Object"
+msgstr "Égitest: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Hossz."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Szélesség"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+#, fuzzy
+msgid "Distance"
+msgstr "Távolság: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licensz"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "Tereptárgyak mutatása"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+#, fuzzy
+msgid "Show Label"
+msgstr "Tereptárgyak címkéi"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "Legkisebb megjelenített tereptárgy mérete"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Méret:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "Átnevezés..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "Könyvjelző/Mappa átnevezése"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "Új név"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Szimuláció idő beállítása"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formátum:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Helyi idő beállítása"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Naprendszer böngésző"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Ugrás"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Égitestek a Naprendszerben"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Csillag böngésző"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "F&rissítés"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Csillag keresése"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "A listázandó csillagok maximális száma"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Idegenvezetés"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Úticél kiválasztása"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Megjelenítési beállítások"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Mutat"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Megjelenítés"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Pályák / Címkék"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Adatok"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "40e"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Ápr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Febr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jún"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Márc"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Máj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Júl"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Szept"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Égitest"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Dátum"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Indítás"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Forgalmazó:"
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Ablakos mód"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Megjelenítés"
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Láthatatlan objektumok"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Pálya szinkronizálása"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Adatok"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Objektumok tengelyének mutatása"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Váz tegelyeinek mutatása"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Nap irányának mutatása"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Sebességvektor mutatása"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Planetáris háló mutatása"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Lezáró mutatása"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "Mellékbolygók"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Keringő Égitestek"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Betöltés: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "hu"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "URL betöltése:"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Verzió:"
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL verzió:"
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Max simultaneous textures: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Max texture size: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Max cube map size: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Point size range: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Supported Extensions:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Ablakos mód"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Láthatatlan objektumok"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Pálya szinkronizálása"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Adatok"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Objektumok tengelyének mutatása"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Váz tegelyeinek mutatása"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Nap irányának mutatása"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Sebességvektor mutatása"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Planetáris háló mutatása"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Lezáró mutatása"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "Mellékbolygók"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Keringő Égitestek"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Betöltés: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "hu"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "URL betöltése:"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Hiba a szkript betöltésekor"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Hiba a szkript betöltésekor"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Szkript futtatása"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Időzóna neve: "
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "UTC eltérés"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Hiba a szkript fájl megnyitásakor."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Ismeretlen hiba a szkript megnyitásakor"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Hiba a szkript megnyitásakor '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Hiba a co-routin szkript inicializálásánál"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Hiba a szkript megnyitásakor '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Ismeretlen hiba a szkript megnyitásakor"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Hiba a megnyitáskor"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "NV fragment program betöltése: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Hiba az NV fragment program betöltésekor: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Hiba a fragment programban "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "NV fragment programok inicializációja...\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Minden NV fragment program sikeresen betöltődött.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "ARB fragment programok inicializálása . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": ismeretlen, vagy nem támogatott képfájl típus.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "NV vertex program betöltése:"
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Hiba az NV vertex program betöltésekor:"
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Hiba a vertex programban: "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "ARB vertex program betöltése"
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Hiba az ARB vertex program betöltésekor:"
+
+#~ msgid ", line "
+#~ msgstr ", sor"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "NV vertex programok inicializálása...\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Az összes NV vertex program sikeresen betöltődött.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "ARB vertex programik inicializálása...\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Minden ARB vertex program sikeresen betöltődött.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Ismeretlen hiba a szkript megnyitásakor"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "URL másolása"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL másolása"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Alt-Aizmuth mód be"
+
+#~ msgid "Nearest"
+#~ msgstr "Legközelebbi"
+
+#~ msgid "Brightest"
+#~ msgstr "Legfényesebb"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Bolygókkal"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Ekliptikus vonal"
+
+#~ msgid "Latin Names"
+#~ msgstr "Latin nevek"
+
+#~ msgid "Terse"
+#~ msgstr "Tömör"
+
+#~ msgid "Verbose"
+#~ msgstr "Bőséges"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Leszállóhelyek"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Hegységek)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Tengerek)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Völgyek)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Szárazföldek)"
+
+#~ msgid "Label Features"
+#~ msgstr "Tereptárgyak címkéi"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Napfogyatkozások"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Holdfogyatkozások"
+
+#~ msgid "Vendor: "
+#~ msgstr "Forgalmazó:"
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL verzió:"
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Supported Extensions:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Hiba a szkript betöltésekor"
+
+#~ msgid "Error loading script"
+#~ msgstr "Hiba a szkript betöltésekor"
+
+#~ msgid "Running script"
+#~ msgstr "Szkript futtatása"
 
 #~ msgid "Invisible"
 #~ msgstr "Láthatatlan"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2020-05-17 14:47+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: \n"
@@ -27,12 +27,12 @@ msgstr "Mercurio"
 msgid "Venus"
 msgstr "Venere"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Terra"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Luna"
 
@@ -48,140 +48,140 @@ msgstr "Fobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Giove"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amaltea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganimede"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturno"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometeo"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimeteo"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Giano"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encelado"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tetide"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titano"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Iperione"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Giapeto"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Febe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Urano"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Nettuno"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteo"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tritone"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereide"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Plutone-Caronte"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plutone"
 
@@ -190,1028 +190,1290 @@ msgid "Charon"
 msgstr "Caronte"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amaltea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Gen"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galassie"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "NORD AMERICA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "SUD AMERICA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRICA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARTIDE"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLANTICO DEL NORD"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLANTICO DEL SUD"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO PACIFICO DEL NORD"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO PACIFICO DEL SUD"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCEANO INDIANO"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ARTICO"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Algeri"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Aşgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción "
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Atene"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Baghdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Pechino"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlino"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Berna"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruxelles"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Il Cairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Città del Capo"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Copenaghen"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Dimasco"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Gibuti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublino"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibilterra"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "The Hague"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "L'Avana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Giacarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Gerusalemme"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiun"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisbona"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Lubiana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londra"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Lussemburgo"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Maschile"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Città del Messico"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Mosca"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Muscat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Nuova Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praga"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seoul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapore"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayawardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stoccolma"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Tehran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv-Giaffa"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunisi"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "La Valle"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Città del Vaticano"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Vienna"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsavia"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagabria "
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Via Lattea"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Baricentro del sistema solare"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Ora legale"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Errore nell'apertura del file di immagine "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Errore di lettura del file di configurazione."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1221,89 +1483,61 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " oggetti dello spazio profondo"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Caricamento del frammento di programma NV: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Errore nel caricamento del frammento di programma NV: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Errore nel frammento di programma "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Inizializzazione dei frammenti di programma NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Tutti i frammenti di programma NV sono stati caricati con successo.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Inizializzazione dei frammenti di programma ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galassia (Tipo Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Ammasso globulare (raggio del nucleo: %4.2f', distribuzione di King: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Sto caricando l'immagine dal file "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": tipo di file di immagine non riconosciuto o non supportato.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Errore nell'apertura del file di immagine "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " non è un file PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Errore di lettura del file di immagine PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Caricamento del modello: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
-"   Statistiche del modello: %u vertici, %u primitivi, %u materiali (%u unico)\n"
+"   Statistiche del modello: %u vertici, %u primitivi, %u materiali (%u "
+"unico)\n"
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Errore nel caricamento del modello '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebulosa"
 
@@ -1311,92 +1545,92 @@ msgstr "Nebulosa"
 msgid "Open cluster"
 msgstr "Ammasso aperto"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Errore nel file .ssc (linea "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "corpo principale '%s' di '%s' non trovato.\n"
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "attenzione, definizione duplicata di "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "Superficie alternativa errata"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "luogo errato"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Intestazione errata per l'indice incrociato\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Versione errata per l'indice incrociato\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Il caricamento dell'indice incrociato è fallito al record "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Tipo spettrale errato nel database delle stelle, stella nº"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " stelle nel database binario\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Numero totale di stelle: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Errore nel file .stc (linea "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Stella non valida: tipo spettrale errato.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Stella non valida: manca il tipo spettrale.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " non esiste.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Stella non valida: manca l'ascensione retta.\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Stella non valida: manca la declinazione.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Stella non valida: manca la distanza.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Stella non valida: manca la magnitudine\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1404,786 +1638,744 @@ msgstr ""
 "Stella non valida: deve essere specificata la magnitudine assoluta (non "
 "apparente) per stelle vicine all'origine\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr "Livello %i,% .5f ly, %i nodi, %i stelle\n"
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Creazione di mappa a mosaico. Larghezza="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Creazione di mappa ordinaria:"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Caricamento del programma vertici NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Errore nel caricamento del programma vertici NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Errore nel programma vertici "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Caricamento del programma vertici ARB: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Errore nel caricamento del programma vertici ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", linea "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Inizializzazione dei programmi vertici NV . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Tutti i programmi vertici NV sono stati caricati con successo.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Inizializzazione dei programmi vertici ARB . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Tutti i programmi vertici ARB sono stati caricati con successo.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Errore in apertura di "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Errore di lettura del file di immagine PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr "File binario xyzv errato %s.\n"
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr "Ordine byte previsto %i, non supportato%i.\n"
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr "Numero previsto di cifre %i, non supportato%i.\n"
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Errore di lettura dei file preferiti."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-"%s\n"
-"Orientamento: [%f,%f,% f], %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Errore di apertura del file script."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Errore di apertura dello script '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Errore sconosciuto in apertura dello script"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Inizializzazione fallita della coroutine dello script"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Tipo di file non valido"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudine limite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marcatori abilitati"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marcatori disabilitati"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Vai alla superficie"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Modalità altazimutale abilitata"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Modalità altazimutale disabilitata"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Stile stelle: punti sfocati"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Stile stelle: punti"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Stile stelle: dischi in scala"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Code delle comete abilitate"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Code delle comete disabilitate"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Tipo di Render: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Marcatori abilitati"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Marcatori disabilitati"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Auto-magnitudine abilitata"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Auto-magnitudine disabilitata"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Tempo e script sono in pausa"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Tempo in pausa"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Riparti"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Navigatore stellare... (&r)"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Navigatore stellare... (&r)"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tempo di viaggio della luce:  %.4f anni "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tempo di viaggio della luce:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tempo di viaggio della luce:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Ritardo per il tempo di viaggio della luce incluso"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Ritardo per il tempo di viaggio della luce eliminato"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Ritardo per il tempo di viaggio della luce ignorato"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Mappe di superfici normali in uso."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Mappe di superficie al limite della conoscenza in uso."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Segui"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tempo: avanti"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tempo: indietro"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Rateo del tempo"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Mappe"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Mappe"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Mappe"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Sincronizza l'orbita"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Blocca"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Insegui"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudine limite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Limite automatico di magnitudine a 45 gradi:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Livello luce ambientale: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Guadagno di luminosità"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Effetto Bloom abilitato"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Effetto Bloom disabilitato"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Esposizione"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Errore GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vista troppo piccola per poterla dividere"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Vista aggiunta"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "ua"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "Km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " giorni"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " ore"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minuti"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " secondi"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Periodo di rotazione: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, fuzzy, c-format
+msgid "Mass: %.6g kg\n"
+msgstr "Massa: %.2f Me\n"
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, fuzzy, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr "Massa: %.2f Me\n"
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr "Massa: %.2f Me\n"
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " Km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Velocità: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diametro apparente: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitudine apparente: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitudine assoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distanza: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Baricentro del sistema stellare\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Magnitudine assoluta (app.): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Luminosità: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Stella di neutroni"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Buco nero"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Temp. superf.: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Raggio: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Raggio: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Sistema planetario presente\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distanza dal centro: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raggio: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Angolo di fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr "Massa: %.2f Me\n"
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Densità: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  Tempo Locale"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo reale"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Tempo reale"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tempo arrestato"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " più veloce "
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " più lento"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (In Pausa)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "In viaggio "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "In viaggio "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Aggancia "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Segui "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sincronizza Orbita"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "BloccA %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Insegui "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sole"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nome dell'obiettivo: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "In pausa"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  In registrazione"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 avvia/pausa    F12 Ferma"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Modifica modalità"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Caricamento del catalogo del sistema solare: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Caricamento del catalogo del sistema solare: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Errore di lettura del file di configurazione."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Inizializzazione della libreria SPICE fallita."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Impossibile leggere il database delle stelle."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Errore di apertura del catalogo Deepsky."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Impossibile leggere il database delle stelle."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Errore in apertura del catalogo del sistema solare.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Errore in apertura del file asterismi."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Errore in apertura del file dei confini delle costellazioni."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Inizializzazione del renderer fallita"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Errore nel caricamento del font. Il testo non sarà visibile.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Errore di lettura dell'indice incrociato "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Indice incrociato caricato "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Errore di lettura del file dei nomi delle stelle\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Errore in apertura di "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Errore di lettura del file dei nomi delle stelle\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Errore di lettura del file delle stelle\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Errore di apertura del catalogo delle stelle "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Errore di apertura dello script '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versione: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Errore sconosciuto in apertura dello script"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Produttore: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
-"ATTENZIONE:\n"
-"\n"
-"Questo script richiede l'autorizzazione a leggere/scrivere file\n"
-"ed esegui programmi esterni. Consentire questo può essere\n"
-"Pericoloso.\n"
-"Ti fidi dello script e vuoi permetterlo?\n"
-"\n"
-"y = sì, ESC = annulla script, qualsiasi altra chiave = no"
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Renderer:"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-"ATTENZIONE:\n"
-"\n"
-"Questo script richiede l'autorizzazione a leggere/scrivere file\n"
-"ed esegui programmi esterni. Consentire questo può essere\n"
-"Pericoloso.\n"
-"Ti fidi dello script e vuoi eseguirlo?"
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Numero max mappe simultanee: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Dimensione max mappa: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Gamma della dimensione dei punti: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Gamma della dimensione dei punti: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Dim. max mappa cubica: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
 msgstr ""
-"Celestia non è stato in grado di inizializzare le estensioni OpenGL (errore i). Grafica "
-"la qualità sarà ridotta."
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
+msgstr ""
 
 #. if (glGetError())
 #. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
@@ -2262,8 +2454,8 @@ msgid ""
 "It appears you are running Celestia on %s hardware. Do you wish to install a "
 "workaround?"
 msgstr ""
-"Sembra che tu stia eseguendo Celestia su% s hardware. Desideri installarlo isoluzione"
-"Alternativa?"
+"Sembra che tu stia eseguendo Celestia su% s hardware. Desideri installarlo "
+"isoluzioneAlternativa?"
 
 #: ../src/celestia/macosx/CelestiaController.m:324
 #, objc-format
@@ -2271,8 +2463,8 @@ msgid ""
 "A shell script will be run to modify your %@, adding an IgnoreGLExtensions "
 "directive. This can prevent freezing issues."
 msgstr ""
-"Verrà eseguito uno script di shell per modificare il tuo %@, aggiungendo un Ignora "
-"GLExtensions. Questo può prevenire problemi di freezing."
+"Verrà eseguito uno script di shell per modificare il tuo %@, aggiungendo un "
+"Ignora GLExtensions. Questo può prevenire problemi di freezing."
 
 #: ../src/celestia/macosx/CelestiaController.m:325
 msgid "Yes"
@@ -2296,8 +2488,9 @@ msgid ""
 "There was a problem installing the workaround. You can attempt to perform "
 "the workaround manually by following the instructions in the README."
 msgstr ""
-"Si è verificato un problema durante l'installazione della soluzione alternativa. Puoi provare a eseguire"
-"la soluzione alternativa manualmente seguendo le istruzioni nel file README."
+"Si è verificato un problema durante l'installazione della soluzione "
+"alternativa. Puoi provare a eseguirela soluzione alternativa manualmente "
+"seguendo le istruzioni nel file README."
 
 #: ../src/celestia/macosx/CelestiaController.m:467
 msgid "Quit Celestia?"
@@ -2318,7 +2511,8 @@ msgstr "Errore nel caricamento del font. Il testo non sarà visibile.\n"
 
 #: ../src/celestia/macosx/CelestiaController.m:797
 msgid "Movie capture is not available in this version of Celestia."
-msgstr "L'acquisizione di filmati non è disponibile in questa versione di Celestia."
+msgstr ""
+"L'acquisizione di filmati non è disponibile in questa versione di Celestia."
 
 #. Remove following line to enable movie capture...
 #: ../src/celestia/macosx/CelestiaController.m:797
@@ -2383,14 +2577,14 @@ msgstr "Formato data o ora non corretto"
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr "Inserisci la data come \"mm/gg/aaaa\" e l'ora come \"hh:mm:ss\"."
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Errore nella creazione del file di cattura Ogg %s.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Errore interno nella libreria Ogg."
@@ -2409,52 +2603,40 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::pulizia() - ha scritto %d fotogrammi\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr "Automatico"
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
+#, fuzzy
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
-"Impossibile eseguire Celestia perché la directory di dati non è stata trovata, probabilmente"
-"a causa di installazione errata."
+"Impossibile eseguire Celestia perché la directory di dati non è stata "
+"trovata, probabilmentea causa di installazione errata."
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
-"Impossibile eseguire Celestia perché la cartella CelestiaResources non è stata"
-"trovato, probabilmente a causa di un'installazione errata."
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-"Celestia non è stato in grado di inizializzare le estensioni OpenGL (errore% 1). Grafica"
-"la qualità sarà ridotta."
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navigatore celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navigatore celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sistema solare"
 
@@ -2464,21 +2646,20 @@ msgstr "Sistema solare"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Stelle"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " oggetti dello spazio profondo"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Cercatore di eclissi"
@@ -2487,464 +2668,518 @@ msgstr "Cercatore di eclissi"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Tempo"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Visita guidata"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Schermo intero"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Cattura video... (&M)\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Errore in apertura del file asterismi."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Segnalibri (&b)"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Salva come:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " non è un file PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Risoluzione:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Fotogrammi/secondo:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL copiato"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Caricamento dell'URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "Apri Script... (&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crea una nuova cartella di segnalibri in questo menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>OpenGL 1.1 non esteso</b>"
+msgid "Unknown compiler"
+msgstr "Sconosciuto"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
+#: ../src/celestia/qt/qtappwin.cpp:1043
 #, fuzzy
-msgid "<b>Renderer: </b>"
-msgstr "<b>OpenGL 1.1 non esteso</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
-msgstr "Versione GLSL: "
-
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
-msgstr "Dimensione max mappa: "
-
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-#, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "supported"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1045
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Informazioni su OpenGL"
+msgid "not supported"
+msgstr "Estensioni supportate:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "A proposito di Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>OpenGL 1.1 non esteso</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Produttore: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>OpenGL 1.1 non esteso</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "Versione GLSL: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Numero max mappe simultanee: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Dimensione max mappa: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Gamma della dimensione dei punti: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Gamma della dimensione dei punti: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Dim. max mappa cubica: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Equatoriale"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Estensioni supportate:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Renderer:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "File (&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Cattura immagine"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Cattura immagine...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Cattura video... (&M)\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copia l'URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Copia l'URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL copiato"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Apri Script... (&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferenze Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Esci (&x)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "Navigazione (&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "Seleziona (&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "Centra la selezione (&C)\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selezione: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Vai all'oggetto..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "Tempo (&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Imposta l'ora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Display"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Oggetti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Ombre degli anelli"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Stile delle stelle (&y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Risoluzione mappe (&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "Controlli (&C)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "Segnalibri (&b)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Vista (&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vista multipla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividi lo schermo verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividi orizzontalmente (&H)\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividi lo schermo orizzontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividi verticalmente (&V)\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Vista successiva"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Vista singola"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "vista singola (&S)\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Cancella la vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Cancella"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Bordi visibili"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Visualizza bordo vista attiva"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizza il tempo"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Aiuto (&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "A proposito di Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Informazioni su OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Aggiungi un segnalibro (&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "Organizza i segnalibri... (&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr "Impostazione predefinita FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr "ValorE FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Caricamento "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr "Titolo"
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Durata"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Segnalibri (&b)"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
-msgstr "Aggiungi i segnalibri a questa cartella per vederli nel menu dei segnalibri."
+msgstr ""
+"Aggiungi i segnalibri a questa cartella per vederli nel menu dei segnalibri."
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Barra strumenti principale"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
-msgstr "Aggiungi i segnalibri a questa cartella per vederli nella barra degli strumenti dei segnalibri"
+msgstr ""
+"Aggiungi i segnalibri a questa cartella per vederli nella barra degli "
+"strumenti dei segnalibri"
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Errore di lettura del file delle stelle\n"
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Segnalibri"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Imposta il tempo di simulazione"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Imposta il tempo di simulazione"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Tempo"
@@ -2953,79 +3188,77 @@ msgstr "Tempo"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Nuova cartella..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Mostra la griglia equatoriale"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galattico"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Eclittica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Orizzontale"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Eclittica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marcatori"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Centra la selezione (&C)\tC"
@@ -3034,57 +3267,54 @@ msgstr "Centra la selezione (&C)\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Costellazioni"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, senxa programmi vertex</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Confini delle costellazioni"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Orbite"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Pianeti"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Pianeti nani"
 
@@ -3094,19 +3324,17 @@ msgstr "Pianeti nani"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Lune"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Lune minori"
 
@@ -3116,12 +3344,12 @@ msgstr "Lune minori"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroidi"
 
@@ -3131,12 +3359,12 @@ msgstr "Asteroidi"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Comete"
 
@@ -3146,14 +3374,15 @@ msgstr "Comete"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Veicoli Spaziali"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x più veloce (&F)\tL"
@@ -3162,9 +3391,8 @@ msgstr "10x più veloce (&F)\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Nomi"
 
@@ -3172,20 +3400,18 @@ msgstr "Nomi"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galassie"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Ammassi globulari"
 
@@ -3193,7 +3419,7 @@ msgstr "Ammassi globulari"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3203,615 +3429,632 @@ msgstr "Ammassi aperti"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulose"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Luoghi"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Ammassi aperti"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nubi"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Luci notturne"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Code delle comete"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosfere"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Ombre degli anelli"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Ombre delle eclissi"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Ombre delle nubi"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Bassa"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Media"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Alta"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Magnitudine automatica\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Visualizza più stelle\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Visualizza meno stelle\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "Punti (&P)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Punti sfocati (&f)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Dischi in scala (&D)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Ritardo per il tempo di viaggio della luce eliminato"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Modalità altazimutale abilitata"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Limite automatico di magnitudine a 45 gradi:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudine limite: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distanza (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag. app."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag. ass."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Stelle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Più brillanti"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtro stelle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Con pianeti"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Stelle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tipo spettrale errato nel database delle stelle, stella nº"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "Marca (&M) "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Numero massimo di stelle in lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Marca (&M) "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr "Deseleziona le stelle selezionate nella vista elenco"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcatori"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr "Rimuovi tutti i marcatori esistenti"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Nessuno"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Losanga"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triangolo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Quadrato"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Più"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Cerchio"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Freccia sinistra"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Freccia destra"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Freccia su"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Freccia giù"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Seleziona (&S)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Dimensione:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Seleziona (&S)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Etichetta le caratteristiche"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Oggetti"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr "Contrassegna i DSO selezionati nella vista elenco"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "Marca (&M) "
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "oggetto genitore '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr "Nascondi"
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Avvio"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Durata"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Eclissi solari"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Eclissi lunari"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Rimuovi tutti i marcatori (&A)"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Cerca"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Eclissi lunari"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Oggetto: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr "La data di fine è precedente alla data di inizio."
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Eclissi solari"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Imposta l'ora a questo istante"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Da:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Durata: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr "Errore: nessun oggetto selezionato!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "Informazioni (&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informazioni (&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatoriale"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr "<B> schiacciamento:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Periodo di rotazione: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distanza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr "anni"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Distanza: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Dimensione: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Testo informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Elementi oscillanti per %1"
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatoriale"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distanza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distanza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distanza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distanza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatoriale"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Periodo di rotazione: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Stile delle stelle (&y)"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Formato locale"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Nome fuso orario: "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Differenza tempo civile"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Avvio"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3830,21 +4073,21 @@ msgid "&Select"
 msgstr "Seleziona (&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "Centra (&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "Vai a (&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "Segui (&F)"
 
@@ -3858,49 +4101,54 @@ msgid "Visible"
 msgstr "Visualizza bordo vista attiva"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "Rimuovi il marcatore (&u) "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Seleziona la modalità video"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Quadrato pieno"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "Marca (&M) "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "Marchi di riferimento (&R)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Mostra gli assi dei Corpi"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Mostra gli assi dei bordi"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Mostra la direzione del Sole"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Mostra il vettore velocità"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Mostra il vettore velocità"
@@ -3908,183 +4156,41 @@ msgstr "Mostra il vettore velocità"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Mostra la direzione del Sole"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Mostra la griglia planetografica"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Mostra il terminatore"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "Superfici alternative (&A)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normale"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Veicoli Sspaziali"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Oggetti"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Imposta l'ora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Fuso orario: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Tempo Universale"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Ora locale"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Fuso orario: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Data"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Imposta"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Imposta"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Imposta"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-msgid "Time: "
-msgstr "Tempo:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-msgid "Set Hours"
-msgstr "Imposta Ore"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ":"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-msgid "Set Minutes"
-msgstr " Imposta Minuti"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-msgid "Set Seconds"
-msgstr " Imposta Secondi"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Data Giuliana: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-msgid "Set Julian Date"
-msgstr "imposta Data Giuliana: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Imposta l'ora..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Baricentro"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-msgid "Star"
-msgstr "Stella"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Pianeta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Pianeta nano"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Lune minori"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroide"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Cometa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "Marchi di riferimento (&R)"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Calcola"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Vai alla superficie"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-msgid "Unknown"
-msgstr "Sconosciuto"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroidi"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "Marchi di riferimento (&R)"
+msgid "Dwarf planets"
+msgstr "Pianeti nani"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4092,67 +4198,227 @@ msgstr "Marchi di riferimento (&R)"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Lune minori"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Veicoli Sspaziali"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Oggetti"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Imposta l'ora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Fuso orario: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Tempo Universale"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Ora locale"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Fuso orario: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Data"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Imposta"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Imposta"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Imposta"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+msgid "Time: "
+msgstr "Tempo:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+msgid "Set Hours"
+msgstr "Imposta Ore"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ":"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+msgid "Set Minutes"
+msgstr " Imposta Minuti"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+msgid "Set Seconds"
+msgstr " Imposta Secondi"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Data Giuliana: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+msgid "Set Julian Date"
+msgstr "imposta Data Giuliana: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Imposta l'ora..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Baricentro"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+msgid "Star"
+msgstr "Stella"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Pianeta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Pianeta nano"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Lune minori"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroide"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Cometa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "Marchi di riferimento (&R)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Calcola"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Vai alla superficie"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroidi"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "Marchi di riferimento (&R)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr "Componenti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Altre caratteristiche"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Pianeti"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Oggetti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr "Contrassegna i corpi selezionati nella vista elenco"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Inverti il tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x più lento (&S)\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " più lento"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Ferma il tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " più veloce "
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x più veloce (&F)\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Imposta all'ora corrente"
@@ -4224,7 +4490,6 @@ msgstr "Latitudine: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "raggi"
 
@@ -4245,7 +4510,7 @@ msgstr "Risoluzione:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizza i segnalibri"
 
@@ -4276,18 +4541,6 @@ msgstr "Preferenze Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Oggetti"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Pianeti nani"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4378,49 +4631,43 @@ msgstr "Traiettorie parziali"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Griglie"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Equatoriale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Eclittica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galattico"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Orizzontale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagrammi"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Confini"
 
@@ -4454,7 +4701,6 @@ msgstr "luogo errato"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Città"
 
@@ -4468,21 +4714,18 @@ msgstr "Zone d'atterraggio"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulcani"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Osservatori"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Crateri"
 
@@ -4517,7 +4760,6 @@ msgstr "Mari"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Altre caratteristiche"
 
@@ -4622,7 +4864,7 @@ msgstr "Display"
 msgid "Not an XBEL version 1.0 file."
 msgstr "Non è un file XBEL versione 1.0."
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -4863,21 +5105,21 @@ msgid "&About Celestia"
 msgstr "A proposito di Celestia (&A)"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4886,532 +5128,671 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Diritti (C) 2001-2009, gruppo di sviluppo Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr ""
 "Celestia è un programma gratuito e viene fornito assolutamente senza "
 "garanzie."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autori"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Seleziona Oggetto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Nome dell'Oggetto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licenza"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Controlli di Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informazioni Driver OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Imposta il tempo di simulazione"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formato:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Imposta all'ora corrente"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Aggiungi segnalibro"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Crea in >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nuova cartella..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navigatore del sistema solare"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Aggiungi nuova cartella segnalibri"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "Vai a (&G)"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nome della cartella"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Oggetti del sistema solare"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Controlli di Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navigatore stellare"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Più vicini"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Più brillanti"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Con pianeti"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "Aggiorna (&R)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Criteri di ricerca delle stelle"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Numero massimo di stelle in lista"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Visita guidata"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Vai a"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Seleziona la destinazione:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Vai all'Oggetto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Oggetto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Distanza"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Dimensione:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Seleziona la modalità video"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Risoluzione"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Opzioni di visualizzazione"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Cercatore di eclissi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Visualizza"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Calcola"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Display"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Imposta la data e vai al pianeta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Eclittica"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Chiudi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Orbite / Nomi"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Da:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Nomi latini"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr "a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Testo informativo"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr "Su:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Conciso"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parametri di ricerca"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Dettagliato"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Seleziona Oggetto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Zone d'atterraggio"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Nome dell'Oggetto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Monti"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Informazioni Driver OpenGL"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Mari"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Vai all'Oggetto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valli"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Vai a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terre"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Oggetto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Etichetta le caratteristiche"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Distanza"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licenza"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Mostra le caratteristiche"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Etichetta le caratteristiche"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Dimensione minima caratteristiche etichettate"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Aggiungi nuova cartella segnalibri"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Dimensione:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nome della cartella"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Rinomina..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Rinomina il segnalibro o la cartella"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nuovo nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Cercatore di eclissi"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Imposta il tempo di simulazione"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Calcola"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formato:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Imposta la data e vai al pianeta"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Imposta all'ora corrente"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Chiudi"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navigatore del sistema solare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Da:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "Vai a (&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr "a"
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Oggetti del sistema solare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr "Su:"
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navigatore stellare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parametri di ricerca"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "Aggiorna (&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Eclissi solari"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Criteri di ricerca delle stelle"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Eclissi lunari"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Numero massimo di stelle in lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Visita guidata"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Seleziona la destinazione:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Opzioni di visualizzazione"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Visualizza"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Display"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Orbite / Nomi"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Testo informativo"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "410"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Gen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Giu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mag"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dic"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Lug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Ott"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Set"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satellite"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Data"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Avvio"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Produttore: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Modalità finestra"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Renderer:"
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invisibili"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Sincronizza l'orbita (&Y)"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "Informazioni (&I)"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Mostra gli assi dei Corpi"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Mostra gli assi dei bordi"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Mostra la direzione del Sole"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Mostra il vettore velocità"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Mostra la griglia planetografica"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Mostra il terminatore"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "Satelliti (&S)"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Corpi orbitanti"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+#, fuzzy
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+"Il tuo sistema non lo supporta\n"
+"%@"
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Caricamento di: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "it"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Caricamento dell'URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versione: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Versione GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Numero max mappe simultanee: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Dimensione max mappa: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Dim. max mappa cubica: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Gamma della dimensione dei punti: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Estensioni supportate:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Modalità finestra"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invisibili"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Sincronizza l'orbita (&Y)"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "Informazioni (&I)"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Mostra gli assi dei Corpi"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Mostra gli assi dei bordi"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Mostra la direzione del Sole"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Mostra il vettore velocità"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Mostra la griglia planetografica"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Mostra il terminatore"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "Satelliti (&S)"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Corpi orbitanti"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Caricamento di: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "it"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Caricamento dell'URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Errore durante l'apertura dello script"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Errore durante il caricamento dello script"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Script in esecuzione"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Nome fuso orario: "
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Differenza tempo civile"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Errore di apertura del file script."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Errore sconosciuto in apertura dello script"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+"ATTENZIONE:\n"
+"\n"
+"Questo script richiede l'autorizzazione a leggere/scrivere file\n"
+"ed esegui programmi esterni. Consentire questo può essere\n"
+"Pericoloso.\n"
+"Ti fidi dello script e vuoi permetterlo?\n"
+"\n"
+"y = sì, ESC = annulla script, qualsiasi altra chiave = no"
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+"ATTENZIONE:\n"
+"\n"
+"Questo script richiede l'autorizzazione a leggere/scrivere file\n"
+"ed esegui programmi esterni. Consentire questo può essere\n"
+"Pericoloso.\n"
+"Ti fidi dello script e vuoi eseguirlo?"
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Errore di apertura dello script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Inizializzazione fallita della coroutine dello script"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Errore di apertura dello script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Errore sconosciuto in apertura dello script"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Errore in apertura di "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Caricamento del frammento di programma NV: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Errore nel caricamento del frammento di programma NV: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Errore nel frammento di programma "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Inizializzazione dei frammenti di programma NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr ""
+#~ "Tutti i frammenti di programma NV sono stati caricati con successo.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Inizializzazione dei frammenti di programma ARB . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": tipo di file di immagine non riconosciuto o non supportato.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Caricamento del programma vertici NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Errore nel caricamento del programma vertici NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Errore nel programma vertici "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Caricamento del programma vertici ARB: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Errore nel caricamento del programma vertici ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", linea "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Inizializzazione dei programmi vertici NV . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Tutti i programmi vertici NV sono stati caricati con successo.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Inizializzazione dei programmi vertici ARB . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Tutti i programmi vertici ARB sono stati caricati con successo.\n"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Orientation: [%f, %f, %f], %.1f\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Orientamento: [%f,%f,% f], %.1f\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Errore sconosciuto in apertura dello script"
+
+#, c-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia non è stato in grado di inizializzare le estensioni OpenGL "
+#~ "(errore i). Grafica la qualità sarà ridotta."
+
+#~ msgid ""
+#~ "Celestia is unable to run because the CelestiaResources folder was not "
+#~ "found, probably due to improper installation."
+#~ msgstr ""
+#~ "Impossibile eseguire Celestia perché la cartella CelestiaResources non è "
+#~ "statatrovato, probabilmente a causa di un'installazione errata."
+
+#, qt-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia non è stato in grado di inizializzare le estensioni OpenGL "
+#~ "(errore% 1). Graficala qualità sarà ridotta."
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Copia l'URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL copiato"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Modalità altazimutale abilitata"
+
+#~ msgid "Nearest"
+#~ msgstr "Più vicini"
+
+#~ msgid "Brightest"
+#~ msgstr "Più brillanti"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Con pianeti"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Eclittica"
+
+#~ msgid "Latin Names"
+#~ msgstr "Nomi latini"
+
+#~ msgid "Terse"
+#~ msgstr "Conciso"
+
+#~ msgid "Verbose"
+#~ msgstr "Dettagliato"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Zone d'atterraggio"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Monti"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Mari"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valli"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terre"
+
+#~ msgid "Label Features"
+#~ msgstr "Etichetta le caratteristiche"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Eclissi solari"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Eclissi lunari"
+
+#~ msgid "Vendor: "
+#~ msgstr "Produttore: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Versione GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Estensioni supportate:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Errore durante l'apertura dello script"
+
+#~ msgid "Error loading script"
+#~ msgstr "Errore durante il caricamento dello script"
+
+#~ msgid "Running script"
+#~ msgstr "Script in esecuzione"
 
 #~ msgid "Invisible"
 #~ msgstr "Invisibile"
@@ -6293,7 +6674,6 @@ msgstr "Errore in apertura di "
 #~ "Mauro Santandrea \n"
 #~ "Pierluigi Panunzi\n"
 #~ "Albano Battistella"
-
 
 #, fuzzy
 #~ msgid "Manual Celestia"

--- a/po/ja.po
+++ b/po/ja.po
@@ -815,6 +815,10 @@ msgstr "ハバナ"
 msgid "Helsinki"
 msgstr "ヘルシンキ"
 
+#: ??
+msgid "Hong Kong"
+msgstr "香港"
+
 #: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "ホニアラ"
@@ -1058,6 +1062,10 @@ msgstr "ヌーメア"
 #: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "ヌクアロファ"
+
+#: ??
+msgid "Nur-Sultan"
+msgstr "ヌルスルタン"
 
 #: ../data/data.cpp:259
 msgid "Nuuk"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:48+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "수성"
 msgid "Venus"
 msgstr "금성"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "지구"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "달"
 
@@ -47,140 +47,140 @@ msgstr "포보스"
 msgid "Deimos"
 msgstr "데이모스"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "목성"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "아말테아"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "이오"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "유로파"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "가니메데"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "칼리스토"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "토성"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "프로메테우스"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "판도라"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "에피메테우스"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "야누스"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "미마스"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "엔셀라두스"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "테티스"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "디오네"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "레아"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "타이탄"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "히페리온"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "이아페투스"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "포에베"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "천왕성"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "미란다"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "아리엘"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "움브리엘"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "티타니아"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "오베론"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "해왕성"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "라리사"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "프로테우스"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "트리톤"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "네레이드"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "플루토-카론"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "명왕성"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "카론"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "누메아"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "바마코"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "아말테아"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "칼리스토"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "1"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "셀레스티아"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "포트빌라"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "은하"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "북아메리카"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "남아메리카"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "유라시아"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "아프리카"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "오스트레일리아"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "남극"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "북대서양"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "남대서양"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "북태평양"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "남태평양"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "인도양"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "북극해"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "아부다비"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "아부자"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "아크라"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "아담스타운"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "아디스아바바"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "알제"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "알로피"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "암만"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "암스테르담"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "안도라라베야"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "앙카라"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "안타나나리보"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "아피아"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "아시가바트"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "아스마라"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "아스타나"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "아순시온"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "아테네"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "아바루아"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "바그다드"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "바쿠"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "바마코"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "반다르스리브가완"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "방콕"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "방기"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "반줄"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "바스테르"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "바스테르"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "베이징"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "베이루트"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "베오그라드"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "벨모판"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "베를린"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "베른"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "비슈케크"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "비사우"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "블룸 폰 테인"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "보고타"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "브라질리아"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "블라티슬라바"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "브라자빌"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "비리지타운"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "브뤼셀"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "부카레스트"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "부다페스트"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "부에노스아이레스"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "부줌부라"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "카이로"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "캔버라"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "케이프타운"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "카라카스"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "캐스트리스"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "카옌"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "샬롯아말리에"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "키시나우"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "콜롬보"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "코나크리"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "코펜하겐"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "코토누"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "다카르"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "다마스쿠스"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "다르에스살람"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "다카"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "딜리"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "지부티"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "도하"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "더글라스"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "더블린"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "두샨베"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "퐁아팔레"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "포르드프랑스"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "프리타운"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "가보로네"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "조지타운"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "조지타운"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "지브롤터"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "그랜드터크"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "과테말라"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "하갓냐"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "헤이그"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "해밀턴"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "하노이"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "하라레"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "하바나"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "헬싱키"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "호니아라"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "이슬라마바드"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "자카르타"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "제임스타운"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "예루살렘"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "카불"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "캄팔라"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "카트만두"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "카르툼"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "키예프"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "키갈리"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "킹스턴"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "킹스타운"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "킨샤사"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "코로르"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "쿠알라룸푸르"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "쿠웨이트"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "엘아윤"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "라파스"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "리브르빌"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "릴롱궤"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "리마"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "리스본"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "류블랴나"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "로밤바"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "로메"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "런던"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "롱위에아르비엔"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "루안다"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "루사카"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "룩셈부르크"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "마드리드"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "마주로"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "말라보"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "멀레"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "마무주"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "마나과"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "마나나"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "마닐라"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "마푸토"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "마세루"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "마타우투"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "음바바네"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "멕시코 시티"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "민스크"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "모가디슈"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "모나코"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "몬로비아"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "몬테비데오"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "모로니"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "모스크바"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "무스카트"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "나이로비"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "나소"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "은자메나"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "뉴델리"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "니아메"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "니코시아"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "누악쇼트"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "누메아"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "누쿠알로파"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "누크"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "오란예스타트"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "오슬로"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "오타와"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "와가두구"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "파고파고"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "팔라키르"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "파나마"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "파페에테"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr ""
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "파리"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "프놈펜"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "플리머스"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "포트루이스"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "포트모르즈비"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "포토프린스"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "포트오브스페인"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "포르토노보"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "포트빌라"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "프라하"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "프라이아"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "프레토리아"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "평양"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "퀴토"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "라바트"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "양곤"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "레이캬비크"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "리가"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "리야드"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "로드타운"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "로마"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "로조"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "세인트조지스"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "세인트헬리어"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "세인트존스"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "세인트피터포트"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "생드니"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "쌩삐에르"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "사이판"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "산호세"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "산후안"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "산마리노"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "산살바도르"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "사나"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "산티아고"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "산토도밍고"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "상투메"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "사라예보"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "서울"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "더세틀먼트"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "싱가폴"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "스코페"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "소피아"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "스리자야와르데네푸라코테"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "스탠리"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "스톡홀름"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "수크레"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "수바"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "타이베이"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "탈린"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "타라와"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "타슈켄트"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "트빌리시"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "테구시갈파"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "테헤란"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "텔아비브"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "팀푸"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "티라나"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "도쿄"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "토르스하운"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "트리폴리"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "튀니스"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "울란바토르"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "파두츠"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "발레타"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "더밸리"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "비티칸 시국"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "빅토리아"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "빈"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "비엔티안"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "빌니우스"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "바르샤바"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "워싱턴 DC"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "웰링턴"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "웨스트아일랜드"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "빌렘스타트"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "빈트후크"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "야무수크로"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "야운데"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "야렌 지구"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "예레반"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "자그레브"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "은하수"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "태양계 중심"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "일광절약시간"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "표준시간"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "이미지 파일 에러: "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "표준시간"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " 먼 우주 천체(DSO)"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "NV 프레그먼트 프로그램 읽는 중:"
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "NV 프레그먼트 프로그램 읽기 오류: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "프레그먼트 프로그램에서 에러가 발생했습니다: "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "NV 프레그먼트 프로그램을 초기화 합니다\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "모든 NV 프레그먼트 프로그램을 읽었습니다\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "ARB 프레그먼트 프로그램을 초기화 합니다\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "은하(형태: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "구상 성단 (핵 반경: %4.2f', King 집중도: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "이미지 파일 읽는 중: "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": 지원하지 않거나 알수없는 파일입니다.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "이미지 파일 에러: "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " 는 PNG파일이 아닙니다.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "PNG파일 읽기 오류: "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "모델 읽는 중: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "모델 읽기 오류: "
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "성운"
 
@@ -1308,92 +1541,92 @@ msgstr "성운"
 msgid "Open cluster"
 msgstr "산개성단"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr ". ssc 파일에 에러가 있습니다. (행 "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "중복 정의: "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "AltSurface 오류"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "지명 오류"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "크로스 인덱스 헤더 오류\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "크로스 인덱스 버젼 오류\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "크로스 인덱스 읽기 실패:레코드 "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "잘못된 항성 분광형, 항성 #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " 개 항성을 읽었습니다.\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "항성 총수: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr ".stc 파일 오류 (행 "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "잘못된 항성: 분광형 오류\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "잘못된 항성: 분광형이 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " 파일을 찾을 수 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "잘못된 항성: 적경이 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "잘못된 항성: 적위가 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "잘못된 항성: 거리가 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "잘못된 항성: 등급이 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "잘못된 항성: 원점부근의 항성은 겉보기 등급이 아니라 절대등급이 설정되어 있어"
 "야 합니다.\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "타일 텍스처 생성중. 폭="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "일반 텍스처 생성중: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "NV 버텍스 프로그램 읽는 중: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "NV 버텍스 프로그램 읽기 오류: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "NV 버텍스 프로그램 오류: "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "ARB 버텍스 프로그램 읽는 중: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "ARB 버텍스 프로그램 읽기 오류: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", 행 "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "NV 버텍스 프로그램을 초기화 합니다.\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "모든 NV 버텍스 프로그램을 읽었습니다.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "ARB 버텍스 프로그램을 초기화 합니다.\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "모든 ARB 버텍스 프로그램을 읽었습니다.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "파일 열기 오류: "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "PNG파일 읽기 오류: "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "북마크 파일 읽는 중 오류가 발생하였습니다."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "스크립트 파일 여는 중 오류가 발생하였습니다."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "스크립트 coroutine의 초기화에 실패하였습니다."
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "잘못된 파일형식"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "한계등급: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "마커: ON"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "마커: OFF"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "천체 표면으로 이동"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "고도각·방위각 모드 켜기"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "고도각·방위각 모드 끄기"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "항성표시: 희미한 점"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "항성표시: 점"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "항성표시: 등급에 따른 원"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "혜성꼬리: ON"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "혜성꼬리: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "렌더링 패스: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "고도각·방위각 모드 켜기"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "고도각·방위각 모드 끄기"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "자동 한계등급 조정: ON"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "자동 한계등급 조정: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "취소"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "시간·스크립트: 정지"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "시간: 정지"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "계속"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "항성 총수: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "항성 총수: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "광속도달시간: %.4f 년"
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "광속도달시간: %d 분  %.1f 초"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "광속도달시간: %d 시간  %d 분  %.1f 초"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "광속고려: ON"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "광속고려: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "광속고려는 무시됩니다."
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "일반 텍스처를 사용"
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "limit of knowledge 텍스처를 사용"
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "천체 추적"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "시간흐름: 순방향"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "시간흐름: 역방향"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "초당 프레임수:"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "보통"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "보통"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "보통"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "자전 동기"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "2천체 참조 동기"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "공전 동기"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "한계등급: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "시야 45°에서의 한계 등급: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "주변빛의 세기:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "광도 이득"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "블룸 필터 적용"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "블룸 필터 해제"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "노출"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL에러: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "화면이 너무 작습니다."
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "화면 분할"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "광년"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "AU"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " 일"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " 시간"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " 분"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " 초"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "자전주기: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "속도: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "시직경: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "겉보기 등급: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "절대등급: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "거리: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "중심\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "절대등급: %.2f 겉보기 등급: %.2f\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "밝기: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "중성자 별"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "블랙홀"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "분광형: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "표면온도: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "반지름: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "반지름: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "행성 존재\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "중심에서의 거리: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "반지름: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "위상각: : %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "온도: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  광속"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "실시간"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-실시간"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "시간멈춤"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " 배속"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " 분의 1배속"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr "(멈춤)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "이동중 "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "이동중 "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "화면중앙에 유지: "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "추적: "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "자전 동기: "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "공전 동기: "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "태양"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "천체명을 입력하세요: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " 멈춤"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr " 동영상 저장중"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 녹화시작/일시정지    F12 정지"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "편집 모드"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "항성계 카탈로그 로딩중: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "항성계 카탈로그 로딩중: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE 라이브러리 초기화에 실패했습니다."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "항성 데이타베이스를 읽을 수 없습니다."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "항성 카탈로그 파일 읽는 중 에러: "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "항성 데이타베이스를 읽을 수 없습니다."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "항성계 카탈로그의 여는 중 오류 발생.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "별자리 파일 여는 중 오류가 발생했습니다."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "별자리 경계선 파일을 여는 중 오류가 발생"
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "렌더링 엔진 초기화 실패"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "폰트 읽기 에러, 텍스트가 표시되지 않습니다.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "크로스 인덱스 파일 읽기 에러: "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "크로스 인덱스 파일 읽음: "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "항성이름 파일 읽는 중 에러\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "파일 열기 오류: "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "항성이름 파일 읽는 중 에러\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "항성 파일 읽는 중 에러\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "항성 카탈로그 파일 읽는 중 에러: "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
+msgid "%s Version: %s\n"
+msgstr "버전: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "제조사: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "렌더링 엔진:"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "최대 동시 텍스처수"
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "최대 텍스처 크기: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "포인트 크기 범위"
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "포인트 크기 범위"
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "최대 큐브 맵 크기: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Ogg파일 생성 중 오류 발생: %s\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "내부 Ogg 라이브러리 오류 발생."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - %d 프레임 저장되었습니다.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "천체브라우저"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "천체브라우저"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "태양계"
 
@@ -2433,21 +2633,20 @@ msgstr "태양계"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "항성"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " 먼 우주 천체(DSO)"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "식 찾기"
@@ -2456,464 +2655,515 @@ msgstr "식 찾기"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "현재 시각"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "길잡이"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "전체화면"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "동영상 캡춰(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "별자리 파일 여는 중 오류가 발생했습니다."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "북마크 추가(&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "다른 이름으로 저장:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " 는 PNG파일이 아닙니다.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "해상도"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "초당 프레임수:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL 복사"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "URL 로딩중"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "스크립트 열기(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "메뉴에 새 폴더 추가"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "지원되는 확장"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "지원되는 확장"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "셀레스티아에 대하여"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Language</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "제조사: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL 버전: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "최대 동시 텍스처수"
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "최대 텍스처 크기: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "포인트 크기 범위"
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "포인트 크기 범위"
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "최대 큐브 맵 크기: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "적도"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "OpenGL정보"
+msgid "Renderer Info"
+msgstr "렌더링 엔진:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "파일(&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "이미지 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "이미지 캡춰(&I)...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "동영상 캡춰(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "URL 복사"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "URL 복사"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL 복사"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "스크립트 열기(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "셀레스티아 설정"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "종료(&X)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "앤티앨리어싱\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "네비게이션(&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "천체 선택(&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "선택한 천체를 가운데로(&C)\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "선택: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "천체로 이동"
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "시간(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "시간 설정..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "표시"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "선택한 천체"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "구름 그림자 보기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "항성 모양(&Y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "해상도"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "사용법(&C)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "북마크(&B)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "창(&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "멀티뷰"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "수직분할"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "수평분할(&H)\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "수평분할"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "수직분할(&V)\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "화면 전환"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "단일창"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "단일 창(&S)\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "활성창 닫기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "삭제"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "분할선 보기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "활성창 분할선 보기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "시간 동기화"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "도움말(&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "셀레스티아 설정"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "셀레스티아에 대하여"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "OpenGL정보"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "북마크 추가(&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "북마크 구성(&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "로딩중: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "스크립트"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "기간"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "북마크(&B)"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "메인툴바"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "북마크"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "시간 설정"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "시간 설정"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "현재 시각"
@@ -2922,79 +3172,77 @@ msgstr "현재 시각"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "새폴더..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "천구좌표 보기"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "은하"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "천구좌표"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "수평분할"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "황도"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "마커"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "선택한 천체를 가운데로(&C)\tC"
@@ -3003,57 +3251,54 @@ msgstr "선택한 천체를 가운데로(&C)\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "별자리"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, no vertex programs</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "별자리 경계선"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "확인"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "궤도"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "행성"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "왜소행성"
 
@@ -3063,19 +3308,17 @@ msgstr "왜소행성"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "위성"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "소 위성"
 
@@ -3085,12 +3328,12 @@ msgstr "소 위성"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "소행성"
 
@@ -3100,12 +3343,12 @@ msgstr "소행성"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "혜성"
 
@@ -3115,14 +3358,15 @@ msgstr "혜성"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "인공위성"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x 빠르게(&F)\tL"
@@ -3131,9 +3375,8 @@ msgstr "10x 빠르게(&F)\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "이름"
 
@@ -3141,20 +3384,18 @@ msgstr "이름"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "은하"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "구상성단"
 
@@ -3162,7 +3403,7 @@ msgstr "구상성단"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3172,615 +3413,632 @@ msgstr "산개성단"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "성운"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "지명"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "산개성단"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "구름"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "야간맵"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "혜성꼬리"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "대기"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "고리 그림자"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "식 그림자"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "구름 그림자"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "낮음"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "중간"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "높음"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "자동 등급 조정\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "항성을 많이 보이게\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "항성을 적게 보이게\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "점(&P)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "희미한 점(&F)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "등급에 따른 원(&D)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "광속고려: OFF"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "고도각·방위각 모드 켜기"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "시야 45°에서의 한계 등급: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "한계등급: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "이름"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "겉보기 등급"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "절대 등급"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "분광형"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "항성 보기"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "항성"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "항성 표시 조정"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "행성 존재"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "항성 보기"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "무게중심"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "잘못된 항성 분광형, 항성 #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "새로고침"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "마커(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "표시 항성수"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "마커(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "마커"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "없음"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "마름모(◇)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "삼각형(△)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "사각형(□)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "십자"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X자"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "원(○)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "왼쪽화살표(←)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "오른쪽화살표(→)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "위쪽화살표(↑)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "아랫쪽화살표(↓)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "천체 선택(&O)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "동영상 크기:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "천체 선택(&O)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "지명 보기"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "천체"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "마커(&M)"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "모천체 '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "전체화면 표시"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "기간"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "일식"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "월식"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "전체 해제(&A)"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "포인트 크기 범위"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "월식"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "천체 선택(&O)"
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "일식"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "현재시간으로 설정"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "이미지 파일 읽는 중: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "천체정보(&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL정보"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "거리(광년)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "크기: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "천체 정보 표시"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "항성 모양(&Y)"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "현지 시간"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "표준시간대"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC 오프셋"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "시작"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3799,21 +4057,21 @@ msgid "&Select"
 msgstr "천체 선택(&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "가운데로(&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "이동(&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "추적(&F)"
 
@@ -3827,49 +4085,54 @@ msgid "Visible"
 msgstr "활성창 분할선 보기"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "마커 해제(&U)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "화면모드 선택"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "사각형(■)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "원(●)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "마커(&M)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "벡터 참조(&R)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "천체 축 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "프레임 축 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "태양 방향 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "속도 벡터 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "속도 벡터 보기"
@@ -3877,191 +4140,41 @@ msgstr "속도 벡터 보기"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "태양 방향 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "행성그리드 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "밤낮 경계선 보기"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "표면 교체(&A)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "일반"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "우주선"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "천체"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "시간 설정..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "시간대: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "세계표준시"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "현지 시간"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "표준시간대"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "날짜"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "시간 설정..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "시간 설정..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "시간 설정..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "시간(&T)"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " 시간"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " 분"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " 초"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "쥴리안 일자"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "쥴리안 일자"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "시간 설정..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "무게중심"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "잘못된 항성 분광형, 항성 #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "행성"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
+msgid "Dwarf planets"
 msgstr "왜소행성"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "소 위성"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "소행성"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "혜성"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "벡터 참조(&R)"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "계산"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "천체 표면으로 이동"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "소행성"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "벡터 참조(&R)"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4069,67 +4182,235 @@ msgstr "벡터 참조(&R)"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "소 위성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "우주선"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "천체"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "시간 설정..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "시간대: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "세계표준시"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "현지 시간"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "표준시간대"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "날짜"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "시간 설정..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "시간 설정..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "시간 설정..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "시간(&T)"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " 시간"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " 분"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " 초"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "쥴리안 일자"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "쥴리안 일자"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "시간 설정..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "무게중심"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "잘못된 항성 분광형, 항성 #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "행성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "왜소행성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "소 위성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "소행성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "혜성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "벡터 참조(&R)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "계산"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "천체 표면으로 이동"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "소행성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "벡터 참조(&R)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "기타"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "행성"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "천체"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "시간흐름을 반대로"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x 느리게(&S)\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " 분의 1배속"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "시간 멈춤"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " 배속"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x 빠르게(&F)\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "현재시간으로 설정"
@@ -4201,7 +4482,6 @@ msgstr "위도: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "반경"
 
@@ -4222,7 +4502,7 @@ msgstr "해상도"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "북마크 구성"
 
@@ -4253,18 +4533,6 @@ msgstr "셀레스티아 설정"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "천체"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "왜소행성"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4355,49 +4623,43 @@ msgstr "부분 궤적"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "그리드"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "적도"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "황도"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "은하"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "수평분할"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "도형"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "별자리 경계선 보기"
 
@@ -4431,7 +4693,6 @@ msgstr "지명 이름 보기"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "도시"
 
@@ -4445,21 +4706,18 @@ msgstr "착륙지점"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "행성"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "관측소·천문대"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "크레이터"
 
@@ -4494,7 +4752,6 @@ msgstr "바다"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "기타"
 
@@ -4599,7 +4856,7 @@ msgstr "표시"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "설정"
 
@@ -4841,21 +5098,21 @@ msgid "&About Celestia"
 msgstr "셀레스티아에 대하여(&A)"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 #, fuzzy
 msgid "OK"
 msgstr "확인"
@@ -4865,533 +5122,623 @@ msgid "Celestia"
 msgstr "셀레스티아"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2008, 셀레스티아 개발팀"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "셀레스티아는 공개소프트이며, 보증을 제공하지 않습니다."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "저자"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "천체 선택"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "천체 이름"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "라이센스"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "셀레스티아 사용법"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL 드라이버 정보"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "시간 설정"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "초당 프레임수:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "현재시간으로 설정"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "북마크 추가"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "위치지정 >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "새폴더..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "태양계 브라우저"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "새 폴더 만들기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "이동(&G)"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "폴더 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "천체 이름"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "셀레스티아 사용법"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "항성 브라우저"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "거리순"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "등급순"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "행성존재"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "새로고침(&R)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "항성 검색 기준"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "표시 항성수"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "길잡이"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "이동"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "목적지를 선택하세요:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "천체로 이동"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "천체이름"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "경도"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "위도"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "거리"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "동영상 크기:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 #, fuzzy
 msgid "Select Display Mode"
 msgstr "화면모드 선택"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 #, fuzzy
 msgid "Resolution"
 msgstr "해상도"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-#, fuzzy
-msgid "View Options"
-msgstr "보기설정"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "식 찾기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "표시"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "계산"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "표시"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "시간 설정 및 이동"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "황도"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "닫기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "궤도 / 이름"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "기간:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "라틴 별자리명"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "천체 정보 표시"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "보통"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "파라미터 검색"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "많이"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "천체 선택"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "착륙지점"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "천체 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "산"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL 드라이버 정보"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "바다"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "천체로 이동"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "계곡"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "이동"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "육지"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "천체이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "지명 보기"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "경도"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "위도"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "거리"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "라이센스"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "지명 보기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "지명 보기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "최소표시"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "새 폴더 만들기"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "동영상 크기:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "폴더 이름"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "이름 바꾸기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "북마크, 폴더 이름 바꾸기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "새 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "식 찾기"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "시간 설정"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "계산"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "초당 프레임수:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "시간 설정 및 이동"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "현재시간으로 설정"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "닫기"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "태양계 브라우저"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "기간:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "이동(&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "천체 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "항성 브라우저"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "파라미터 검색"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "새로고침(&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "일식"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "항성 검색 기준"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "월식"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "표시 항성수"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "길잡이"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "목적지를 선택하세요:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#, fuzzy
+msgid "View Options"
+msgstr "보기설정"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "표시"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "표시"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "궤도 / 이름"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "천체 정보 표시"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "412"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "4"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "2"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "1"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "6"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "3"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "5"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "8"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "12"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "7"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "11"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "10"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "9"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "위성"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "날짜"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "시작"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "제조사: "
-
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "렌더링 엔진:"
-
-#. string s;
-#. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
-#: ../src/celestia/win32/winsplash.cpp:138
-msgid "Version: "
-msgstr "버전: "
-
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL 버전: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "최대 동시 텍스처수"
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "최대 텍스처 크기: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "최대 큐브 맵 크기: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "포인트 크기 범위"
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "지원되는 확장"
-
-#: ../src/celestia/win32/winmain.cpp:1401
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
 msgid "Windowed Mode"
 msgstr "윈도우 모드"
 
-#: ../src/celestia/win32/winmain.cpp:1527
+#: ../src/celestia/win32/winmain.cpp:1445
 msgid "Invisibles"
 msgstr "안보임"
 
-#: ../src/celestia/win32/winmain.cpp:1625
+#: ../src/celestia/win32/winmain.cpp:1543
 msgid "S&ync Orbit"
 msgstr "자전 동기(&Y)"
 
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
 msgid "&Info"
 msgstr "천체정보(&I)"
 
-#: ../src/celestia/win32/winmain.cpp:1629
+#: ../src/celestia/win32/winmain.cpp:1547
 msgid "Show Body Axes"
 msgstr "천체 축 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1548
 msgid "Show Frame Axes"
 msgstr "프레임 축 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1549
 msgid "Show Sun Direction"
 msgstr "태양 방향 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1632
+#: ../src/celestia/win32/winmain.cpp:1550
 msgid "Show Velocity Vector"
 msgstr "속도 벡터 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1551
 msgid "Show Planetographic Grid"
 msgstr "행성그리드 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1634
+#: ../src/celestia/win32/winmain.cpp:1552
 msgid "Show Terminator"
 msgstr "밤낮 경계선 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1648
+#: ../src/celestia/win32/winmain.cpp:1566
 msgid "&Satellites"
 msgstr "위성"
 
-#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1599
 msgid "Orbiting Bodies"
 msgstr "순환 천체"
 
-#: ../src/celestia/win32/winmain.cpp:3194
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
 #, fuzzy
 msgid "Loading: "
 msgstr "로딩중: "
 
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
 msgid "LANGUAGE"
 msgstr "ko"
 
-#: ../src/celestia/win32/winmain.cpp:3994
+#: ../src/celestia/win32/winmain.cpp:3838
 msgid "Loading URL"
 msgstr "URL 로딩중"
 
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "스크립트 파일 열기 오류"
+#. string s;
+#. s += UTF8ToCurrentCP(_("Version: "));
+#: ../src/celestia/win32/winsplash.cpp:138
+msgid "Version: "
+msgstr "버전: "
 
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "스크립트 파일 로딩 오류"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "스크립트 실행"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "표준시간대"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "UTC 오프셋"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "스크립트 파일 여는 중 오류가 발생하였습니다."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "스크립트 coroutine의 초기화에 실패하였습니다."
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "파일 열기 오류: "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "NV 프레그먼트 프로그램 읽는 중:"
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "NV 프레그먼트 프로그램 읽기 오류: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "프레그먼트 프로그램에서 에러가 발생했습니다: "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "NV 프레그먼트 프로그램을 초기화 합니다\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "모든 NV 프레그먼트 프로그램을 읽었습니다\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "ARB 프레그먼트 프로그램을 초기화 합니다\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": 지원하지 않거나 알수없는 파일입니다.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "NV 버텍스 프로그램 읽는 중: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "NV 버텍스 프로그램 읽기 오류: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "NV 버텍스 프로그램 오류: "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "ARB 버텍스 프로그램 읽는 중: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "ARB 버텍스 프로그램 읽기 오류: "
+
+#~ msgid ", line "
+#~ msgstr ", 행 "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "NV 버텍스 프로그램을 초기화 합니다.\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "모든 NV 버텍스 프로그램을 읽었습니다.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "ARB 버텍스 프로그램을 초기화 합니다.\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "모든 ARB 버텍스 프로그램을 읽었습니다.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "URL 복사"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL 복사"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "고도각·방위각 모드 켜기"
+
+#~ msgid "Nearest"
+#~ msgstr "거리순"
+
+#~ msgid "Brightest"
+#~ msgstr "등급순"
+
+#~ msgid "With planets"
+#~ msgstr "행성존재"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "황도"
+
+#~ msgid "Latin Names"
+#~ msgstr "라틴 별자리명"
+
+#~ msgid "Terse"
+#~ msgstr "보통"
+
+#~ msgid "Verbose"
+#~ msgstr "많이"
+
+#~ msgid "Landing Sites"
+#~ msgstr "착륙지점"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "산"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "바다"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "계곡"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "육지"
+
+#~ msgid "Label Features"
+#~ msgstr "지명 보기"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "일식"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "월식"
+
+#~ msgid "Vendor: "
+#~ msgstr "제조사: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL 버전: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "지원되는 확장"
+
+#~ msgid "Error opening script"
+#~ msgstr "스크립트 파일 열기 오류"
+
+#~ msgid "Error loading script"
+#~ msgstr "스크립트 파일 로딩 오류"
+
+#~ msgid "Running script"
+#~ msgstr "스크립트 실행"
 
 #~ msgid "Invisible"
 #~ msgstr "안보임"

--- a/po/lt.po
+++ b/po/lt.po
@@ -809,6 +809,10 @@ msgstr "Havana"
 msgid "Helsinki"
 msgstr "Helsinkis"
 
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
 #: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
@@ -1052,6 +1056,10 @@ msgstr "Numėja"
 #: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nukalofa"
+
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
 
 #: ../data/data.cpp:259
 msgid "Nuuk"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:49+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -27,12 +27,12 @@ msgstr "Merkūrs"
 msgid "Venus"
 msgstr "Venera"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Zeme"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Mēness"
 
@@ -48,140 +48,140 @@ msgstr "Foboss"
 msgid "Deimos"
 msgstr "Deimoss"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiters"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalteja"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Jo"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Eiropa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganimēds"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Kalisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturns"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometejs"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetejs"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Jānuss"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimass"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encelads"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tētija"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Diona"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Reja"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titāns"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hiperions"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Japets"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Fēbs"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Urāns"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariels"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriels"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titānija"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberons"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptūns"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Lārisa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Protejs"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tritons"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereīda"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Harons"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plutons"
 
@@ -190,1036 +190,1298 @@ msgid "Charon"
 msgstr "Harons"
 
 #: ../data/data.cpp:42
-msgid "NORTH AMERICA"
-msgstr "ZIEMEĻAMERIKA"
-
-#: ../data/data.cpp:43
-msgid "SOUTH AMERICA"
-msgstr "DIENVIDAMERIKA"
-
-#: ../data/data.cpp:44
-msgid "EURASIA"
-msgstr "EIRĀZIJA"
-
-#: ../data/data.cpp:45
-msgid "AFRICA"
-msgstr "ĀFRIKA"
-
-#: ../data/data.cpp:46
-msgid "AUSTRALIA"
-msgstr "AUSTRĀLIJA"
-
-#: ../data/data.cpp:47
-msgid "ANTARCTICA"
-msgstr "ANTARKTIKA"
-
-#: ../data/data.cpp:48
-msgid "NORTH ATLANTIC OCEAN"
-msgstr "ATLANTIJAS OKEĀNA ZIEMEĻI"
-
-#: ../data/data.cpp:49
-msgid "SOUTH ATLANTIC OCEAN"
-msgstr "ATLANTIJAS OKEĀNA DIENVIDI"
-
-#: ../data/data.cpp:50
-msgid "NORTH PACIFIC OCEAN"
-msgstr "KLUSĀ OKEĀNA ZIEMEĻI"
-
-#: ../data/data.cpp:51
-msgid "SOUTH PACIFIC OCEAN"
-msgstr "KLUSĀ OKEĀNA DIENVIDI"
-
-#: ../data/data.cpp:52
-msgid "INDIAN OCEAN"
-msgstr "INDIJAS OKEĀNS"
-
-#: ../data/data.cpp:53
-msgid "ARCTIC OCEAN"
-msgstr "ZIEMEĻU LEDUS OKEĀNS"
-
-#: ../data/data.cpp:54
-msgid "Abu Dhabi"
-msgstr "Abū Dabī"
-
-#: ../data/data.cpp:55
-msgid "Abuja"
-msgstr "Abudža"
-
-#: ../data/data.cpp:56
-msgid "Accra"
-msgstr "Akra"
-
-#: ../data/data.cpp:57
-msgid "Adamstown"
-msgstr "Adamstauna"
-
-#: ../data/data.cpp:58
-msgid "Addis Ababa"
-msgstr "Adis Abeba"
-
-#: ../data/data.cpp:59
-msgid "Algiers"
-msgstr "Alžīra"
-
-#: ../data/data.cpp:60
-msgid "Alofi"
-msgstr "Alofi"
-
-#: ../data/data.cpp:61
-msgid "Amman"
-msgstr "Ammāna"
-
-#: ../data/data.cpp:62
-msgid "Amsterdam"
-msgstr "Amsterdama"
-
-#: ../data/data.cpp:63
-msgid "Andorra la Vella"
-msgstr "Andora la Velje"
-
-#: ../data/data.cpp:64
-msgid "Ankara"
-msgstr "Ankara"
-
-#: ../data/data.cpp:65
-msgid "Antananarivo"
-msgstr "Antananarivu"
-
-#: ../data/data.cpp:66
-msgid "Apia"
-msgstr "Apia"
-
-#: ../data/data.cpp:67
-msgid "Ashgabat"
-msgstr "Ašgabata"
-
-#: ../data/data.cpp:68
-msgid "Asmara"
-msgstr "Asmera"
-
-#: ../data/data.cpp:69
-msgid "Astana"
-msgstr "Astana"
-
-#: ../data/data.cpp:70
-msgid "Asuncion"
-msgstr "Asunsjona"
-
-#: ../data/data.cpp:71
-msgid "Athens"
-msgstr "Atēnas"
-
-#: ../data/data.cpp:72
-msgid "Avarua"
-msgstr "Avarua"
-
-#: ../data/data.cpp:73
-msgid "Baghdad"
-msgstr "Bagdāde"
-
-#: ../data/data.cpp:74
-msgid "Baku"
-msgstr "Baku"
-
-#: ../data/data.cpp:75
-msgid "Bamako"
-msgstr "Bamako"
-
-#: ../data/data.cpp:76
-msgid "Bandar Seri Begawan"
+msgid "Styx"
 msgstr ""
 
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Niameja"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalteja"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Kalisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
 #: ../data/data.cpp:77
-msgid "Bangkok"
-msgstr "Bankoka"
+msgid "Atlas"
+msgstr ""
 
 #: ../data/data.cpp:78
-msgid "Bangui"
-msgstr "Bangi"
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
 
 #: ../data/data.cpp:79
-msgid "Banjul"
-msgstr "Bandžula"
+msgid "Calypso"
+msgstr ""
 
 #: ../data/data.cpp:80
-msgid "Basse-Terre"
-msgstr "Bastēra"
+msgid "Helene"
+msgstr ""
 
 #: ../data/data.cpp:81
-msgid "Basseterre"
-msgstr "Bastēra"
+msgid "Cordelia"
+msgstr ""
 
 #: ../data/data.cpp:82
-msgid "Beijing"
-msgstr "Pekina"
+msgid "Ophelia"
+msgstr ""
 
 #: ../data/data.cpp:83
-msgid "Beirut"
-msgstr "Beirūta"
+msgid "Bianca"
+msgstr ""
 
 #: ../data/data.cpp:84
-msgid "Belgrade"
-msgstr "Belgrada"
+msgid "Cressida"
+msgstr ""
 
 #: ../data/data.cpp:85
-msgid "Belmopan"
-msgstr "Belmopāna"
+msgid "Desdemona"
+msgstr ""
 
 #: ../data/data.cpp:86
-msgid "Berlin"
-msgstr "Berlīne"
+msgid "Juliet"
+msgstr ""
 
 #: ../data/data.cpp:87
-msgid "Bern"
-msgstr "Berne"
+#, fuzzy
+msgid "Portia"
+msgstr "Portvila"
 
 #: ../data/data.cpp:88
-msgid "Bishkek"
-msgstr "Biškeka"
+msgid "Rosalind"
+msgstr ""
 
 #: ../data/data.cpp:89
-msgid "Bissau"
-msgstr "Bissava"
+msgid "Belinda"
+msgstr ""
 
 #: ../data/data.cpp:90
-msgid "Bloemfontein"
+msgid "Puck"
 msgstr ""
 
 #: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaktikas"
+
+#: ../data/data.cpp:100
+msgid "NORTH AMERICA"
+msgstr "ZIEMEĻAMERIKA"
+
+#: ../data/data.cpp:101
+msgid "SOUTH AMERICA"
+msgstr "DIENVIDAMERIKA"
+
+#: ../data/data.cpp:102
+msgid "EURASIA"
+msgstr "EIRĀZIJA"
+
+#: ../data/data.cpp:103
+msgid "AFRICA"
+msgstr "ĀFRIKA"
+
+#: ../data/data.cpp:104
+msgid "AUSTRALIA"
+msgstr "AUSTRĀLIJA"
+
+#: ../data/data.cpp:105
+msgid "ANTARCTICA"
+msgstr "ANTARKTIKA"
+
+#: ../data/data.cpp:106
+msgid "NORTH ATLANTIC OCEAN"
+msgstr "ATLANTIJAS OKEĀNA ZIEMEĻI"
+
+#: ../data/data.cpp:107
+msgid "SOUTH ATLANTIC OCEAN"
+msgstr "ATLANTIJAS OKEĀNA DIENVIDI"
+
+#: ../data/data.cpp:108
+msgid "NORTH PACIFIC OCEAN"
+msgstr "KLUSĀ OKEĀNA ZIEMEĻI"
+
+#: ../data/data.cpp:109
+msgid "SOUTH PACIFIC OCEAN"
+msgstr "KLUSĀ OKEĀNA DIENVIDI"
+
+#: ../data/data.cpp:110
+msgid "INDIAN OCEAN"
+msgstr "INDIJAS OKEĀNS"
+
+#: ../data/data.cpp:111
+msgid "ARCTIC OCEAN"
+msgstr "ZIEMEĻU LEDUS OKEĀNS"
+
+#: ../data/data.cpp:112
+msgid "Abu Dhabi"
+msgstr "Abū Dabī"
+
+#: ../data/data.cpp:113
+msgid "Abuja"
+msgstr "Abudža"
+
+#: ../data/data.cpp:114
+msgid "Accra"
+msgstr "Akra"
+
+#: ../data/data.cpp:115
+msgid "Adamstown"
+msgstr "Adamstauna"
+
+#: ../data/data.cpp:116
+msgid "Addis Ababa"
+msgstr "Adis Abeba"
+
+#: ../data/data.cpp:117
+msgid "Algiers"
+msgstr "Alžīra"
+
+#: ../data/data.cpp:118
+msgid "Alofi"
+msgstr "Alofi"
+
+#: ../data/data.cpp:119
+msgid "Amman"
+msgstr "Ammāna"
+
+#: ../data/data.cpp:120
+msgid "Amsterdam"
+msgstr "Amsterdama"
+
+#: ../data/data.cpp:121
+msgid "Andorra la Vella"
+msgstr "Andora la Velje"
+
+#: ../data/data.cpp:122
+msgid "Ankara"
+msgstr "Ankara"
+
+#: ../data/data.cpp:123
+msgid "Antananarivo"
+msgstr "Antananarivu"
+
+#: ../data/data.cpp:124
+msgid "Apia"
+msgstr "Apia"
+
+#: ../data/data.cpp:125
+msgid "Ashgabat"
+msgstr "Ašgabata"
+
+#: ../data/data.cpp:126
+msgid "Asmara"
+msgstr "Asmera"
+
+#: ../data/data.cpp:127
+msgid "Astana"
+msgstr "Astana"
+
+#: ../data/data.cpp:128
+msgid "Asuncion"
+msgstr "Asunsjona"
+
+#: ../data/data.cpp:129
+msgid "Athens"
+msgstr "Atēnas"
+
+#: ../data/data.cpp:130
+msgid "Avarua"
+msgstr "Avarua"
+
+#: ../data/data.cpp:131
+msgid "Baghdad"
+msgstr "Bagdāde"
+
+#: ../data/data.cpp:132
+msgid "Baku"
+msgstr "Baku"
+
+#: ../data/data.cpp:133
+msgid "Bamako"
+msgstr "Bamako"
+
+#: ../data/data.cpp:134
+msgid "Bandar Seri Begawan"
+msgstr ""
+
+#: ../data/data.cpp:135
+msgid "Bangkok"
+msgstr "Bankoka"
+
+#: ../data/data.cpp:136
+msgid "Bangui"
+msgstr "Bangi"
+
+#: ../data/data.cpp:137
+msgid "Banjul"
+msgstr "Bandžula"
+
+#: ../data/data.cpp:138
+msgid "Basse-Terre"
+msgstr "Bastēra"
+
+#: ../data/data.cpp:139
+msgid "Basseterre"
+msgstr "Bastēra"
+
+#: ../data/data.cpp:140
+msgid "Beijing"
+msgstr "Pekina"
+
+#: ../data/data.cpp:141
+msgid "Beirut"
+msgstr "Beirūta"
+
+#: ../data/data.cpp:142
+msgid "Belgrade"
+msgstr "Belgrada"
+
+#: ../data/data.cpp:143
+msgid "Belmopan"
+msgstr "Belmopāna"
+
+#: ../data/data.cpp:144
+msgid "Berlin"
+msgstr "Berlīne"
+
+#: ../data/data.cpp:145
+msgid "Bern"
+msgstr "Berne"
+
+#: ../data/data.cpp:146
+msgid "Bishkek"
+msgstr "Biškeka"
+
+#: ../data/data.cpp:147
+msgid "Bissau"
+msgstr "Bissava"
+
+#: ../data/data.cpp:148
+msgid "Bloemfontein"
+msgstr ""
+
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brazilja"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazavila"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridžtauna"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Brisele"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bukareste"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapešta"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenosairesa"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bužumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Kaira"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Kanbera"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Keiptauna"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Karakasa"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr ""
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Kajēnas"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr ""
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Kišiņeva"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Kolombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Konrakrī"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Kopenhāgena"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr ""
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakāra"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damaska"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dāresalāma"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Daka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Džibutija"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Duglāzija"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublina"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dušanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr ""
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr ""
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Frītauna"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gabarone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "Džordžtauna"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Džordžtauna"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltāra"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr ""
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Gvatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr ""
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Hāga"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamiltona"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoja"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harāre"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr ""
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabada"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Džakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Džeimstauna"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jeruzāleme"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabula"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Kartūma"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kijeva"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingstona"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr ""
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinšasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr ""
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpura"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuveita"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "Ajūna"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 #, fuzzy
 msgid "La Paz"
 msgstr "Andora la Velje"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Librevila"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongve"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisabona"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ļubļana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr ""
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr ""
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londona"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr ""
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luksemburga"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madride"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr ""
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr ""
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Male"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr ""
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr ""
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr ""
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr ""
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr ""
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mehiko"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minska"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadīšu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monako"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovija"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Maskava"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Maskata"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Naso"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Ndžamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Jaundelī"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niameja"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nikosija"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nuakšota"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Niameja"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nukualofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuka"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr ""
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Otava"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Vagadugu"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr ""
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr ""
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Parīze"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Pnompeņa"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plimuta"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 #, fuzzy
 msgid "Port Louis"
 msgstr "Portvila"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 #, fuzzy
 msgid "Port Moresby"
 msgstr "Portvila"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 #, fuzzy
 msgid "Port-au-Prince"
 msgstr " AU/s"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 #, fuzzy
 msgid "Port-of-Spain"
 msgstr "Portvila"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr ""
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Portvila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Prāga"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr ""
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Phenjana"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Čita"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabāta"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Jangona"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reikjavīka"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Rīga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Rijāda"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 #, fuzzy
 msgid "Road Town"
 msgstr "Keiptauna"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr ""
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 #, fuzzy
 msgid "Saint George's"
 msgstr "Džordžtauna"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr ""
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr ""
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 #, fuzzy
 msgid "Saint Peter Port"
 msgstr "Portvila"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr ""
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr ""
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipana"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Džozē"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Huana"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "Sanmarīno"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "Sansalvadora"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sana"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santjago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr ""
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr ""
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajeva"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seula"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr ""
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapūra"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofija"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stenlija"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stokholma"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sukre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipeja"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallina"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Taravā"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Taškenta"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegučigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teherāna"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Telaviva"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Timpu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirāna"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokija"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Toršavna"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripole"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunisa"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulanbatora"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduca"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valeta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr ""
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vatikāns"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Viktorija"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Vīne"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vjančana"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Viļņa"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varšava"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Vašingtona"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Velingtona"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "Vestailenda"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Villemsteda"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Vindhuka"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Jamasukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Jaunde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr ""
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Eerevāna"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreba"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Piena Ceļš"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Zvaigžņu sistēmas baricentrs"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Kļūda atverot attēla failu"
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Kļūda nolasot konfigurācijas failu."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1229,87 +1491,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " dziļā kosmosa objekti"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Ielādē NV fragmentprogrammu: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Kļūda ielādējot NV fragmentprogrammu:"
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Kļūda fragmentprogrammā"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Inicializē NV fragmentprogrammas . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Visas NV fragmentprogrammas ielādējās veiksmīgi.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Inicializē ARB fragmentprogrammas . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaktika (Habla tips: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Lodveida (kodola radiuss: %4.2f', Kinga koncetrācija: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Ielādē attēlu no faila"
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": neatpazīts vai neatbalstīts attēla faila tips.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Kļūda atverot attēla failu"
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " nav PNG fails. \n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Kļūda ielādējot PNG attēla failu"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Ielādē modeli: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Kļūda ielādējot modeli '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Miglājus"
 
@@ -1317,92 +1550,92 @@ msgstr "Miglājus"
 msgid "Open cluster"
 msgstr "Vaļējās kopas"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Kļūda .ssc filā(līnijā "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "uzmanību dubulta definīcija "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "nederīga alternatīvā virsma"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "nederīga vieta"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Kopējam indeksam bojāta galvane\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Kopējam indekstam nederīga versija\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Kopējā indeksa ielāde apstājās pie ieraksta "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " zvaizgnes binārajā datubāzē\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Kopējais zvaigzņu skaits: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Kļūda .stc failā (līnijā "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Kļūdaina zvaigzne: nederīga spektra klase.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Kļūdaina zvaigzne: nav norādīta spektra klase.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " neeksistē.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Nederīga zvaigznes: trūkst rektascensijas\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Nederīga zvaigzne: trūkst deklinācijas.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Nederīga zvaigzne: trūkst distances.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Nederīga zvaigzne: trūkst zvaigžņlieluma.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1410,767 +1643,743 @@ msgstr ""
 "Nederīga zvaigzne: jānorāda absolūtais nevis redzamais zvaigžņlielums "
 "zvaigznej izvelsmes vietas tuvumā\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Tiek veidota sadalīta tekstūra. Platums="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Tiek veidota parasta tekstūra: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Ielādē NV verteksu programmu: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Kļūda ielādējot NV verteksu programmu: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Kļūda verteksu programmā "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Ielādē ARB verteksu programmu: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Kļūda ielādējot ARB verteksu programmu: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", līnijā "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Inicializēt NV verteksu programmas . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Visas NV verteksu programmas veiksmīgi ielādētas.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Inicializēt ARB verteksu programmas . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Visas ARB verteksu programmas veiksmīgi ielādētas.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Kļūda atverot "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Kļūda ielādējot PNG attēla failu"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Visas NV verteksu programmas veiksmīgi ielādētas."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Kļūda atverot skripta failu."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Kļūda atverot skriptu '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Nenosakāma kļūda atverot skriptu"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Skripta korutīnas inicializācija neizdevās"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Nepareizs faila veids"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limitējošais zvaigžņlielums iestādīts uz: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marķieri aktivizēti"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marķieri izslēgti"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Nolaisties uz virsmas"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Azimutālais režīms ieslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Azimutālais režīms izslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Zvaigznes: kā izplūduši punktiņi"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Zvaigznes: kā punkti"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Zvaigznes: kā mērogoti diski"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Komētu astes aktivizētas"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Komētu astes deaktivizētas"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Renderēšanas ceļš: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Azimutālais režīms ieslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Azimutālais režīms izslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Automātiskie zvaigžņlielumi aktivizēti"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Automātiskie zvaigžņlielumi atslēgti"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Laiks un skripts apturēti (pauze)"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Laiks ir apstādināts (pauze)"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Turpināt"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Kopējais zvaigzņu skaits: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Kopējais zvaigzņu skaits: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Gaismas ceļošanas ilgums:  %.4f gadi "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Gaismas ceļošanas ilgums: %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Gaismas ceļošanas ilgums:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Ierēķināts gaismas ceļošanas ilgums"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Gaismas ceļošanas ilgums atslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Gaismas ceļošanas ilgums ignorēts"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Izmanto normālās virsmu tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Izmanto zināmā robežu tekstūras."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Sekot"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Laiks: uz priekšu"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Laiks: atpakaļ"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Laika ātrums"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Sinhronizēt orbītu"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Sabloķēt"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Novērot"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Limitējošais zvaigžņlielums iestādīts uz: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automātiskais magnitūdas limits ir 45 grādi: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Fona gaismas daudzums:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Gaismas pastiprinājums"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Nerādīt komētu astes"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Rādīt jomētu astes"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Ekspozīcija"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL kļūda: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Skats par mazu lai sadalītu"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Pievienots skatījums"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "ly"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "au"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " dienas"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " stundas"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minūtes"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " sekundes"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Ātrums: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Redzamais diametrs: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Redzamais spožums: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolūtais spožums: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distance: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Zvaigžņu sistēmas baricentrs\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Absolūtais (redz.) spožums: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Starjauda: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Neitronu zvaigzne"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Melnais caurums"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klase: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Virsmas temperatūra: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Šai sistēmā ir planētas\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Attālums no centra:"
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fāzes lenķis: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatūra: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Reālais laiks"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Reālais laiks"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Laiks apturēts"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "ātrāk"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "lēnāk"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pauze)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Ceļā"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Ceļā"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Tur skatu uz objektu "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seko objektam"
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sinhronajā orbītītā ap objektu "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Novēro objektu "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Saule"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Izvēlamā objekta nosaukums: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "Pauze"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "Ieraksta"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Sākt/Pauze    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Rediģēšanas režīms"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Ielādē zvaigžņu sistēmas katalogu: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Ielādē zvaigžņu sistēmas katalogu: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Kļūda nolasot konfigurācijas failu."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE bibliotēkas inicializācija neizdevās."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Nevar ielasīt zvaigžņu datubāzi."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Kļūda atverot deespky kataloga failu."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Nevar ielasīt zvaigžņu datubāzi."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Kļūda atverot zvaigžņu sistēmas katalogu.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Kļūda atverot asterismu failu."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Kļūda atverot zvaigznāju robežu failus."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Nevarēja inicializēt renderētāju"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Kļūda ielādējot fontus; teksts nebūs redzams.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Kļuda lasot kopējo indeksu "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Kopējais indekss ielādēts "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Kļūda ielasot zvaigžņu nosaukumu failu\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Kļūda atverot "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Kļūda ielasot zvaigžņu nosaukumu failu\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Kļūda ielasot zvaigžņu failu\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Kļūda atverot zvaigžņu katalogu "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Kļūda atverot skriptu '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versija: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Nenosakāma kļūda atverot skriptu"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Ražotājs: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Renderētājs: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Maksimālais tekstūru skaits vienlaicīgi: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Maksimālais tekstūras izmērs: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Punktu mērogošanas attālums: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Punktu mērogošanas attālums: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Maksimālais tekstūras izmērs: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2367,14 +2576,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Kļūda atverot ogg failu %s ierakstam.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Internālā Ogg bibliotēkas kļūda."
@@ -2393,46 +2602,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - ierakstīja %d kadrus\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Debesu pārlūks"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Debesu pārlūks"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Saules sistēma"
 
@@ -2442,21 +2642,20 @@ msgstr "Saules sistēma"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Zvaigznes"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " dziļā kosmosa objekti"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Aptumsumu meklētājs"
@@ -2465,464 +2664,515 @@ msgstr "Aptumsumu meklētājs"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Laiks"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Ceļojumu gids"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Pilns ekrāns"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Uzņemt filmu &filmu...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Kļūda atverot asterismu failu."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Pievienot grāmatzīmes"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Saglabāt kā:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " nav PNG fails. \n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Izšķirtspēja: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Kadru skaits:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Iekopēja URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Ielādē URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Atvērt scenāriju..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Radīt jaunu grāmatzīmju mapi šai izvēlnē"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Nenosakāma kļūda atverot skriptu"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Atbalstītie paplašinājumi:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Atbalstītie paplašinājumi:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Par Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 ēnojuma valoda</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Ražotājs: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL Versija: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Maksimālais tekstūru skaits vienlaicīgi: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maksimālais tekstūras izmērs: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Punktu mērogošanas attālums: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Punktu mērogošanas attālums: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Maksimālais tekstūras izmērs: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Ekvatoriālais"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "OpenGL informācija"
+msgid "Renderer Info"
+msgstr "Renderētājs: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Faili"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Paņemt attēlu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Saglabāt ekrāna &attēlu...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Uzņemt filmu &filmu...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Iekopēt URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Iekopēt URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Iekopēja URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Atvērt scenāriju..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia iestatījumi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "I&ziet no programmas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Kropļojumnovērse\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigācija"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Izvēlēties"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "Iecentrēt izvēlēto\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Izvēlēts: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Iet uz objektu"
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Laiks"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Iestādīt laiku..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Rādīt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Marķētie objekti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Rādīt mākoņu ēnas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Zvaigznes izskatās kā"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Izšķirtspēja"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Kontroles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Grāmatzīmes"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Skats"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "MultiView"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Sadalīt skatu vertikāli"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Sadalīt &horizontāli\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Sadalīt skatu horizontāli"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Sadalīt &vertikāli\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Cikliskais skats"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Viens skatījums"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Viens skatījums\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Izdzēst skatījumu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Dzēst"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Redzamie rāmji"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktīvais rāmis redzams"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sinhronizēt laiku"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Palīdzība"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia iestatījumi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Par Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "OpenGL informācija"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Pievienot grāmatzīmi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizēt grāmatzīmes"
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Ielādē "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scenāriji"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Ilgums"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Grāmatzīmes"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Galvenā rīkjosla"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Visas NV verteksu programmas veiksmīgi ielādētas."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Grāmatzīme"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Iestādīt simlācijas laiku"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Iestādīt simlācijas laiku"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Laiks"
@@ -2931,79 +3181,77 @@ msgstr "Laiks"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Jauna mape..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Parādīt ekvatoriālo tīklu"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galaktiskās"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Koordinātu tīkls"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Sadalīt skatu horizontāli"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Ekliptika"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marķierus"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Iecentrēt izvēlēto\tC"
@@ -3012,57 +3260,54 @@ msgstr "Iecentrēt izvēlēto\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Zvaigznājus"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA kombinators, bez verteksu programmām</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Zvaigznāju ēnas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "Labi"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Orbītas"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planētām"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Pundurplanētas"
 
@@ -3072,19 +3317,17 @@ msgstr "Pundurplanētas"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Pavadoņiem"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Pavadoņiem"
 
@@ -3094,12 +3337,12 @@ msgstr "Pavadoņiem"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroīdiem"
 
@@ -3109,12 +3352,12 @@ msgstr "Asteroīdiem"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Komētām"
 
@@ -3124,14 +3367,15 @@ msgstr "Komētām"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Kosmiskos aparātus"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Ā&trāk\tL"
@@ -3140,9 +3384,8 @@ msgstr "10x Ā&trāk\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Nosaukumus"
 
@@ -3150,20 +3393,18 @@ msgstr "Nosaukumus"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaktikas"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Lodveida"
 
@@ -3171,7 +3412,7 @@ msgstr "Lodveida"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3181,615 +3422,632 @@ msgstr "Vaļējās kopas"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Miglājus"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Vietas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Vaļējās kopas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Mākoņus"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Pilsētu gaismas ēnas pusē"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Komētu astes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosfēras"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Rinķu ēnas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Aptumsumu ēnas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Mākoņu ēnas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "&nedaudz"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "&vidēji daudz"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "daudz"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Automātiskie zvaigžņlielumi\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Rādīt vairāk zvaigžņu\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Rādīt mazāk zvaigžņu\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&punkti"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&izplūduši punkti"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&mērogoti diskveida objekti"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Gaismas ceļošanas ilgums atslēgts"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Azimutālais režīms ieslēgts"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Automātiskais magnitūdas limits ir 45 grādi: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Limitējošais zvaigžņlielums iestādīts uz: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nosaukums"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Redz.spož."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs.spož."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tips"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Rādīt zvaigznes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Zvaigznes"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrēt zvaigznes no"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Ar planētām"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Rādīt zvaigznes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentrs"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Atjaunināt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Iezīmēt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maksimālais zvaigžņu skaits sarakstā"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Iezīmēt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marķierus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "nav"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Rombs"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Trijstūris"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Kvadrāts"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Pluss"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Rinķis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Kreisā bulta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Labā bulta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Bulta uz augšu"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Bulta uz leju"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Izvēlēties &objektu..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Izmērs:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Izvēlēties &objektu..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Nosaukt struktūras"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objekti"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Iezīmēt"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "cilmes objektā '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Sākt pa pilnu ekrānu"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Ilgums"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Saules aptumsumi"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Mēness aptumsumi"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "&Nemarķēt visus"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Punktu mērogošanas attālums: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Mēness aptumsumi"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Izvēlēties &objektu..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Saules aptumsumi"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Iestādīt šobrīdējo laiku"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Ielādē attēlu no faila"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Informācija"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL informācija"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Attālums(ly)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Izmērs: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informatīvais teksts"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Zvaigznes izskatās kā"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Vietējais formāts"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Laika zona"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC nobīde"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Sākt"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3808,21 +4066,21 @@ msgid "&Select"
 msgstr "&Izvēlēties"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Iecentrēt"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Doties uz"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Sekot"
 
@@ -3836,49 +4094,54 @@ msgid "Visible"
 msgstr "Aktīvais rāmis redzams"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Atcelt iezīmēto"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Izvēlēties displeja režīmu"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Aizpildīts kvadrāts"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disks"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Iezīmēt"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Atskaites vietas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Rādīt ķermeņu asis"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Rādīt &rāmju asis"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Rādīt Saules virzienu"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Rādīt ātruma vektoru"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Rādīt ātruma vektoru"
@@ -3886,191 +4149,41 @@ msgstr "Rādīt ātruma vektoru"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Rādīt Saules virzienu"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Rādīt planetogrāfisko tīklu"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Show Terminator"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternatīvās virsmas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normāls"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Mākslīgie pavadoņi"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objekti"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Iestādīt laiku..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Laika zona: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Universālais Laiks"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Vietējais laiks"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Laika zona"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Datums"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Iestādīt laiku..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Iestādīt laiku..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Iestādīt laiku..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Laiks"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " stundas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minūtes"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " sekundes"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Juliāna diena: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Juliāna diena: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Iestādīt laiku..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Baricentrs"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planēta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Pundurplanēta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Pavadoņiem"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroīds"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Komēta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Atskaites vietas"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Aprēķināt"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Nolaisties uz virsmas"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Nenosakāma kļūda atverot skriptu"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroīdiem"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Atskaites vietas"
+msgid "Dwarf planets"
+msgstr "Pundurplanētas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4078,67 +4191,235 @@ msgstr "&Atskaites vietas"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Pavadoņiem"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Mākslīgie pavadoņi"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objekti"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Iestādīt laiku..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Laika zona: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Universālais Laiks"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Vietējais laiks"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Laika zona"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Datums"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Iestādīt laiku..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Iestādīt laiku..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Iestādīt laiku..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Laiks"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " stundas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minūtes"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " sekundes"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Juliāna diena: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Juliāna diena: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Iestādīt laiku..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Baricentrs"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planēta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Pundurplanēta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Pavadoņiem"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroīds"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Komēta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Atskaites vietas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Aprēķināt"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Nolaisties uz virsmas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Nenosakāma kļūda atverot skriptu"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroīdiem"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Atskaites vietas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Citas struktūras"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planētām"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objekti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Pagriezt laiku pretējā virzienā"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x &Lēnāk\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr "lēnāk"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Nopauzēt laiku"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr "ātrāk"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Ā&trāk\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Pārslēgt uz tagadni"
@@ -4210,7 +4491,6 @@ msgstr "Platums: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radii"
 
@@ -4231,7 +4511,7 @@ msgstr "Izšķirtspēja: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Kārtot grāmatzīmes"
 
@@ -4262,18 +4542,6 @@ msgstr "Celestia iestatījumi"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objekti"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Pundurplanētas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4364,49 +4632,43 @@ msgstr "Daļējas trajektorijas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Tīkli"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Ekvatoriālais"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptika"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktiskās"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Sadalīt skatu horizontāli"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Shēmas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Rādīt robežas"
 
@@ -4440,7 +4702,6 @@ msgstr "Rādīt vietvārdus"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Pilsētas"
 
@@ -4454,21 +4715,18 @@ msgstr "Piezemēšanās vietas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulkāni"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatorijas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Krāteri"
 
@@ -4503,7 +4761,6 @@ msgstr "Jūras"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Citas struktūras"
 
@@ -4608,7 +4865,7 @@ msgstr "Rādīt"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Iestatījumi"
 
@@ -4851,21 +5108,21 @@ msgid "&About Celestia"
 msgstr "&Par Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "Labi"
 
@@ -4874,530 +5131,620 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Autortiesības (C) 2001-2008, Celestia komanda"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia ir bezmaksas programma un tai nav absolūti nekādu garantiju."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autori"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Kriss Lorels (Chris Laurel)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Izvēlēties objektu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Objekta nosaukums"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licence"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Celestia kontrolēšana"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL draivera informācija"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Iestādīt simlācijas laiku"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formāts: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Pārslēgt uz tagadni"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Pievienot grāmatzīmi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Izveidot iekš >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Jauna mape..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Saules sistēmas pārlūks"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Pievienot jaunu grāmazīmju mapi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Iet uz"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Mapes nosaukums"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Saules sistēmas objekti"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Celestia kontrolēšana"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Zvaigžņu pārlūks"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Tuvākais"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Spožākās"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Ar planētām"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Atjaunot"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Zvaigžņu meklēšanas kritēriji"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maksimālais zvaigžņu skaits sarakstā"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Ceļojumu gids"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Iet uz"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Izvēlieties galamērķi:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Iet uz objektu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objekts"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Garums"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Platums"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Attālums"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Izmērs:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Izvēlēties displeja režīmu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Izšķirtspēja"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Skata opcijas"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Aptumsumu meklētājs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Rādīt"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Aprēķināt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Rādīt"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Iestādīt datumu un doties uz planētu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Ekliptika"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Aizvērt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Orbītas un nosaukumi"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "No:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Latīņu nosaukumus"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Informatīvais teksts"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "īss"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Meklēšanas paramteri"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "pilnīgs"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Izvēlēties objektu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Piezemēšanās vietas"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Objekta nosaukums"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Kalnus"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL draivera informācija"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Jūras"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Iet uz objektu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Ielejas"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Iet uz"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Zemienes"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objekts"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Nosaukt struktūras"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Garums"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Platums"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Attālums"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licence"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Rādīt struktūras"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Nosaukt struktūras"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Minimālais izmērs nosaucamajām struktūrām"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Pievienot jaunu grāmazīmju mapi"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Izmērs:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Mapes nosaukums"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Pārsaukt..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Pārsaukt grāmatzīmi vai mapi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Jauns nosaukums"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Aptumsumu meklētājs"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Iestādīt simlācijas laiku"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Aprēķināt"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formāts: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Iestādīt datumu un doties uz planētu"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Pārslēgt uz tagadni"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Aizvērt"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Saules sistēmas pārlūks"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "No:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Iet uz"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Saules sistēmas objekti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Zvaigžņu pārlūks"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Meklēšanas paramteri"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Atjaunot"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Saules aptumsumi"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Zvaigžņu meklēšanas kritēriji"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Mēness aptumsumi"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maksimālais zvaigžņu skaits sarakstā"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Ceļojumu gids"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Izvēlieties galamērķi:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Skata opcijas"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Rādīt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Rādīt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Orbītas un nosaukumi"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Informatīvais teksts"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "0426"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jūn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jūl"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Pavadonis"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Datums"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Sākt"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Ražotājs: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Logu režīms"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Renderētājs: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Neredzamajiem"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "&Synhronizēt ar orbītu"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Informācija"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Rādīt ķermeņu asis"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Rādīt &rāmju asis"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Rādīt Saules virzienu"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Rādīt ātruma vektoru"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Rādīt planetogrāfisko tīklu"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Show Terminator"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Pavadoņi"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Apriņķojošie objekti"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Ielādē: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "lv"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Ielādē URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versija: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL Versija: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Maksimālais tekstūru skaits vienlaicīgi: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Maksimālais tekstūras izmērs: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Maksimālais tekstūras izmērs: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Punktu mērogošanas attālums: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Atbalstītie paplašinājumi:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Logu režīms"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Neredzamajiem"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "&Synhronizēt ar orbītu"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Informācija"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Rādīt ķermeņu asis"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Rādīt &rāmju asis"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Rādīt Saules virzienu"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Rādīt ātruma vektoru"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Rādīt planetogrāfisko tīklu"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Show Terminator"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Pavadoņi"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Apriņķojošie objekti"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Ielādē: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "lv"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Ielādē URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Kļūda atverot scenāriju"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Kļūda ielādējot scenāriju"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Izpilda scenāriju"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Laika zona"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "UTC nobīde"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Kļūda atverot skripta failu."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Nenosakāma kļūda atverot skriptu"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Kļūda atverot skriptu '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Skripta korutīnas inicializācija neizdevās"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Kļūda atverot skriptu '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Nenosakāma kļūda atverot skriptu"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Kļūda atverot "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Ielādē NV fragmentprogrammu: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Kļūda ielādējot NV fragmentprogrammu:"
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Kļūda fragmentprogrammā"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Inicializē NV fragmentprogrammas . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Visas NV fragmentprogrammas ielādējās veiksmīgi.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Inicializē ARB fragmentprogrammas . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": neatpazīts vai neatbalstīts attēla faila tips.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Ielādē NV verteksu programmu: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Kļūda ielādējot NV verteksu programmu: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Kļūda verteksu programmā "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Ielādē ARB verteksu programmu: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Kļūda ielādējot ARB verteksu programmu: "
+
+#~ msgid ", line "
+#~ msgstr ", līnijā "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Inicializēt NV verteksu programmas . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Visas NV verteksu programmas veiksmīgi ielādētas.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Inicializēt ARB verteksu programmas . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Visas ARB verteksu programmas veiksmīgi ielādētas.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Nenosakāma kļūda atverot skriptu"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Iekopēt URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Iekopēja URL"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Azimutālais režīms ieslēgts"
+
+#~ msgid "Nearest"
+#~ msgstr "Tuvākais"
+
+#~ msgid "Brightest"
+#~ msgstr "Spožākās"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Ar planētām"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Ekliptika"
+
+#~ msgid "Latin Names"
+#~ msgstr "Latīņu nosaukumus"
+
+#~ msgid "Terse"
+#~ msgstr "īss"
+
+#~ msgid "Verbose"
+#~ msgstr "pilnīgs"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Piezemēšanās vietas"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Kalnus"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Jūras"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Ielejas"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Zemienes"
+
+#~ msgid "Label Features"
+#~ msgstr "Nosaukt struktūras"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Saules aptumsumi"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Mēness aptumsumi"
+
+#~ msgid "Vendor: "
+#~ msgstr "Ražotājs: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL Versija: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Atbalstītie paplašinājumi:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Kļūda atverot scenāriju"
+
+#~ msgid "Error loading script"
+#~ msgstr "Kļūda ielādējot scenāriju"
+
+#~ msgid "Running script"
+#~ msgstr "Izpilda scenāriju"
 
 #~ msgid "Invisible"
 #~ msgstr "Neredzams"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:50+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Mercurius"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Aarde"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Maan"
 
@@ -47,140 +47,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturnus"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tethys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Lapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phoebe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uranus"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptunus"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereid"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluto"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Nouméa"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Sterrenstelsels"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "NOORD-AMERIKA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "ZUID-AMERIKA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIË"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIË"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARTICA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NOORD-ATLANTISCHE OCEAAN"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ZUID-ATLANTISCHE OCEAAN"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NOORD-STILLE OCEAAN"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ZUID-STILLE OCEAAN"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "INDISCHE OCEAAN"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "ARCTISCHE OCEAAN"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Algiers"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Asjchabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Athene"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Bakoe"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Peking"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beiroet"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlijn"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bisjkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Brussel"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Boekarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Boedapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Caïro"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Kaapstad"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Kopenhagen"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damascus"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Doesjanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagåtña"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Den Haag"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jeruzalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartoem"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Koeweit"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lissabon"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lomé"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londen"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Malé"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoudzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manamah"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manilla"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Matâ'utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexico-stad"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moskou"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Masqat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Ndjamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Parijs"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom-Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port of Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praag"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Rome"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San José"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tomé"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seoul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapore"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenapura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tasjkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teheran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vaticaanstad"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Wenen"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Warschau"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Jerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Melkweg"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Kleine Magellaanse Wolken"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Grote Magellaanse Wolken"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Massamiddelpunt van zonnestelsel"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Zomertijd"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Fout tijdens openen van afbeeldingsbestand"
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Fout tijdens het lezen van het configuratiebestand."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr "diep ruimte objecten"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Bezig met laden van NV fragment programma: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Fout tijdens laden NV fragment programma: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Fout in fragment programma "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Initialiseren van NV fragment programma's...\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Alle NV fragment programma's succesvol geladen.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Initialiseren van ARB fragment programma's\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Sterrenstelsel (Hubble type: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Bolvormig (kernradius: %4.2f', King concentratie: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Bezig met laden van afbeelding uit bestand"
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": onbekend of niet ondersteund type voor afbeeldingsbestand.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Fout tijdens openen van afbeeldingsbestand"
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "is geen PNG bestand.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Fout bij lezen van PNG afbeeldingsbestand"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Model laden: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Fout tijdens laden van model '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nevels"
 
@@ -1308,92 +1541,92 @@ msgstr "Nevels"
 msgid "Open cluster"
 msgstr "Open sterrenhoop"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Fout in .ssc bestand (regel "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "waarschuwing dubbele definitie van "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "slecht alternatief oppervlak"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "Slechte lokatie"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Slechte koppen voor kruis-index\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Slechte versie voor kruis-index\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Laden van kruis-index faalde bij ingang "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Slecht spectraal type in sterrendatabase, ster #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " sterren in binaire database\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Totaal aantal sterren:"
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Fout in .stc bestand (regel"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ongeldige ster: slecht spectraal type.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ongeldige ster: spectraal type niet aanwezig.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr "bestaat niet.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ongeldige ster: ontbrekende rechte klimming\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Ongeldige ster: ontbrekende declinatie.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Ongeldige ster: ontbrekende afstand.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ongeldige ster: ontbrekende schijnbare helderheid.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "Ongeldige ster: absolute (niet waargenomen) schijnbare helderheid moet "
 "opgegeven worden voor ster nabij oorsprong\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Aanmaken getegelde textuur. Breedte="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Aanmaken normale textuur: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Bezig met laden van NV vertex programma: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Fout tijdens laden van NV vertex programma:"
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Fout in vertex programma"
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Bezig met laden van ARB vertex programma:"
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Fout tijdens laden van ARB vertex programma:"
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", regel"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Initialiseren van NV vertex programma's...\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Alle NV vertex programma's succesvol geladen.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Initialiseren van ARB vertex programma's...\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Alle ARB vertex programma's succesvol geladen.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Fout tijdens openen"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Fout bij lezen van PNG afbeeldingsbestand"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Fout tijdens lezen van favorieten bestand."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Fout tijdens openen van script bestand."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Fout tijdens openen van scriptbestand '%s'."
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Onbekende fout tijdens openen van script bestand."
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Script co-routine initialisatie faalde"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Ongeldig bestandstype"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Schijnbare helderheid limiet: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Markeringen actief"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Markeringen non-actief"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Ga naar oppervlakte"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Azimut modus aan"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Azimut modus uit"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Ster stijl: vage punten"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Ster stijl: punten"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Ster stijl: geschaalde schijven"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Komeetstaarten weergeven"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Komeetstaarten niet weergeven"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "3D Weergave methode: NVIDIA GeForce FX"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-Azimut modus aan"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-Azimut modus uit"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Auto-schijnbare helderheid geactiveerd"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Auto-schijnbare helderheid gedeactiveerd"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Tijd en script zijn gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Tijd is gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Hervatten"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Totaal aantal sterren:"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Totaal aantal sterren:"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Licht reistijd: %.4f jaar"
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Lichtsnelheid reistijd: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Lichtsnelheid reistijd: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Lichtsnelheid reizen vertraging inclusief"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Lichtsnelheid reizen vertraging uitgezet"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Lichtsnelheid reizen vertraging negeerd"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Gebruik normale oppervlakte texturen."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Gebruik limiet van kennis oppervlakte texturen."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Achtervolg"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tijd: Vooruit"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tijd: Achteruit"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Tijdratio"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Synchronizeer omloopbaan"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Vastzetten"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Opjagen"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Schijnbare helderheid limiet: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automatische schijnbare helderheid limiet bij 45 graden: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Omgevingslicht niveau:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "lichtopbrengst"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Bloom aan"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Bloom uit"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Blootstelling"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL fout:"
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Weergave te klein om gedeelt te worden"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Toegevoegde weergave"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "lj"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "au"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr "dagen"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr "uren"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr "minuten"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "seconden"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " lj/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Snelheid: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Observeerbare diameter: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Schijnbare helderheid: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolute helderheid: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Afstand: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Massamiddelpunt van zonnestelsel\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs. (schijnb.) helderheid:  %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Helderheid: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Neutronenster"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Zwart gat"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Oppervlaktetemperatuur: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Straal: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Straal: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Planitaire metgezellen aanwezig\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Afstand van centrum: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Straal: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fasehoek: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatuur: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Lokale Tijd"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Lokale Tijd"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tijd gestopt"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "sneller"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "langzamer"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr "Gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS:"
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Reizen "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Reizen "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "volgen"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Achtervolg "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchronizeer omloopbaan"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Opjagen "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Zon"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Doel naam: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "Opnemen"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Bewerk modus"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Laden van zonnestelsel catalogus: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Laden van zonnestelsel catalogus: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Fout tijdens het lezen van het configuratiebestand."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Initializatie van SPICE bibliotheek faalde."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Kan sterrendatabase niet lezen."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Fout bij openen deepsky catalogusbestand."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Kan sterrendatabase niet lezen."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Fout tijdens openen van zonnestelselcatalogus.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Fout tijdens openen van niet-officiële sterrenbeelden bestand."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Fout tijdens openen van bestanden met sterrenbeeldgrenzingen."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Kon 3D weergave methode niet initialiseren"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Fout tijdens laden van lettertype, tekst zal niet zichtbaar zijn.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Fout tijdens lezen van cross-index"
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Laden van cross-index"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Fout tijdens lezen van bestand met namen van sterren\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Fout tijdens openen"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Fout tijdens lezen van bestand met namen van sterren\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Fout tijdens lezen van bestand met sterren\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Fout tijdens lezen van sterrencatalogus"
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Fout tijdens openen van scriptbestand '%s'."
+msgid "%s Version: %s\n"
+msgstr "Versie: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Onbekende fout tijdens openen van script bestand."
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Uitgever: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "3D weergave: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Max gelijktijdig geladen texturen: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Max textuurgrootte: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Punt grootte bereik: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Punt grootte bereik: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Max kubuskaart grootte: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Fout tijdens het aanmaken van ogg bestand %s voor de opname.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Interne Ogg bibliotheekfout."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - %d frames geschreven\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Hemelse Browser"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Hemelse Browser"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Zonnestelsel"
 
@@ -2433,21 +2633,20 @@ msgstr "Zonnestelsel"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Sterren"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "diep ruimte objecten"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Eclips Vinder"
@@ -2456,463 +2655,514 @@ msgstr "Eclips Vinder"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Tijd"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Rondleiding"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Schermvullend"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "&Film opslaan...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Fout tijdens openen van niet-officiële sterrenbeelden bestand."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Bladwijzers &toevoegen..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Opslaan als:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "is geen PNG bestand.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolutie:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Frame snelheid:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Gekopieerde URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Laden van URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Open script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Maak een nieuwe bladwijzermap in dit menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Onbekende fout tijdens openen van script bestand."
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Ondersteunde extensies:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Ondersteunde extensies:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Over Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Taal</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Uitgever: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL versie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Max gelijktijdig geladen texturen: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Max textuurgrootte: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Punt grootte bereik: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Punt grootte bereik: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Max kubuskaart grootte: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Equatoriaal"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "OpenGL info"
+msgid "Renderer Info"
+msgstr "3D weergave: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Bestand"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Kopieer plaatje"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "&Afbeelding opslaan...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "&Film opslaan...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopieer URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Kopieer URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Gekopieerde URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Open script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia instellingen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Af&sluiten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigatie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Selecteer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centreer selectie\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selectie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ga naar object..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tijd"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Stel tijd in..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Scherm"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Gemarkeerde objecten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Wolkenschaduwen weergeven"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "S&terrenstijl"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Textuurresolutie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Toetsencombinaties"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "B&ladwijzers"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Weergave"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "MeerdereVensters"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Splits weergave verticaal"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Deel weergave &horizontaal\tCrtl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Splits weergave horizontaal"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Deel weergave &verticaal\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Doorloop weergave"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Enkelvoudige weergave"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Enkelvoudige weergave\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Verwijder weergave"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Frames zichtbaar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Actief frame zichtbaar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synchronizeer tijd"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Help"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia instellingen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Over Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "OpenGL info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Bladwijzer &toevoegen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "Bladwijzers &beheren..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Laden "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Duur"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "B&ladwijzers"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Hoofdbalk"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Fout tijdens het lezen van het configuratiebestand."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Bladwijzers"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Zet simulatietijd"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Zet simulatietijd"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Tijd"
@@ -2921,79 +3171,77 @@ msgstr "Tijd"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Nieuwe map..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Equatoriaalraster weergeven"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galactisch"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Equatoriaalraster"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontaal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Zonneweg"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Markeringen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Centreer selectie\tC"
@@ -3002,57 +3250,54 @@ msgstr "&Centreer selectie\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Sterrenbeelden"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, geen vertex programma's</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Sterrenbeeldgrenzen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Omloopbanen"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planeten"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Dwergplaneten"
 
@@ -3062,19 +3307,17 @@ msgstr "Dwergplaneten"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Manen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Kleine manen"
 
@@ -3084,12 +3327,12 @@ msgstr "Kleine manen"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Planetoiden"
 
@@ -3099,12 +3342,12 @@ msgstr "Planetoiden"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Kometen"
 
@@ -3114,14 +3357,15 @@ msgstr "Kometen"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Ruimtevaartuigen"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x &Sneller\tL"
@@ -3130,9 +3374,8 @@ msgstr "10x &Sneller\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Labels"
 
@@ -3140,20 +3383,18 @@ msgstr "Labels"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Sterrenstelsels"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Bolvormige sterrenhopen"
 
@@ -3161,7 +3402,7 @@ msgstr "Bolvormige sterrenhopen"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3171,615 +3412,632 @@ msgstr "Open sterrenhoop"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nevels"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Lokaties"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Open sterrenhoop"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Wolken"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Lichten aan nachtzijde"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Komeetstaarten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Dampkringen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Ringschaduwen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Eclipsschaduwen"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Wolkenschaduwen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Laag"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Middel"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Hoog"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Auto schijnbare helderheid\tCrtl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Meer sterren zichtbaar\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Minder sterren zichtbaar\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Punten"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&Vage punten"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Ge&schaalde schijven"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Lichtsnelheid reizen vertraging uitgezet"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Alt-Azimut modus aan"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Automatische schijnbare helderheid limiet bij 45 graden: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Schijnbare helderheid limiet: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Naam"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Schijnb. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Type"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Sterren weergeven"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Sterren"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filter Sterren"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Met planeten"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Sterren weergeven"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Massamiddelpunt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Slecht spectraal type in sterrendatabase, ster #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Ververs"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Markeer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximum aantal sterren dat in de lijst weergegeven wordt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Markeer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markeringen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Geen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Driehoek"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Vierkant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Cirkel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Pijl links"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Pijl rechts"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Pijl omhoog"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Pijl omlaag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Selecteer &object..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Grootte:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Selecteer &object..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Labelfeatures"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objecten"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Markeer"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "ouderlijk lichaam'"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Start in volledig scherm"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Duur"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Zonsverduisteringen"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Maansverduisteringen"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Verwijder &alles"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Punt grootte bereik: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Maansverduisteringen"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Selecteer &object..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Zonsverduisteringen"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Stel huidige tijd in"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Bezig met laden van afbeelding uit bestand"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Afstand (ly)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Grootte: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informatietekst"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "S&terrenstijl"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Lokaal formaat"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Tijdzonenaam"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC Offset"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Start"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3798,21 +4056,21 @@ msgid "&Select"
 msgstr "&Selecteer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centreren"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Ga Naar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Achtervolg"
 
@@ -3826,49 +4084,54 @@ msgid "Visible"
 msgstr "Actief frame zichtbaar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Verwijder Markering"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Selecteer weergavemodus"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Gevuld vierkant"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Schijf"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Markeer"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Referentiemarkeringen"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Toon lichaamsassen"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Toon frame-assen"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Toon Zon richting"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Toon snelheidsvector"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Toon snelheidsvector"
@@ -3876,190 +4139,41 @@ msgstr "Toon snelheidsvector"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Toon Zon richting"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Planetografisch raster weergeven"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Dag/Nacht-grens weergeven"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "Alternatieve &oppervlakten"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normaal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Ruimtevaartuig"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objecten"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Stel tijd in..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Tijdzone: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Universele Tijd"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Lokale tijd"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Tijdzonenaam"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Datum"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Stel tijd in..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Stel tijd in..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Stel tijd in..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Tijd"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr "uren"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr "minuten"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "seconden"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Juliaanse datum:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Juliaanse datum:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Stel tijd in..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Massamiddelpunt"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Slecht spectraal type in sterrendatabase, ster #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planeet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Dwergplaneet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Kleine manen"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Planetode"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Komeet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Referentiemarkeringen"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Bereken"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Ga naar oppervlakte"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Onbekende fout tijdens openen van script bestand."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Planetoiden"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Referentiemarkeringen"
+msgid "Dwarf planets"
+msgstr "Dwergplaneten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4067,67 +4181,234 @@ msgstr "&Referentiemarkeringen"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Kleine manen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Ruimtevaartuig"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objecten"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Stel tijd in..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Tijdzone: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Universele Tijd"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Lokale tijd"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Tijdzonenaam"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Datum"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Stel tijd in..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Stel tijd in..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Stel tijd in..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Tijd"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr "uren"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr "minuten"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "seconden"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Juliaanse datum:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Juliaanse datum:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Stel tijd in..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Massamiddelpunt"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Slecht spectraal type in sterrendatabase, ster #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planeet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Dwergplaneet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Kleine manen"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Planetode"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Komeet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Referentiemarkeringen"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Bereken"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Ga naar oppervlakte"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Onbekende fout tijdens openen van script bestand."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Planetoiden"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Referentiemarkeringen"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Andere features"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planeten"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objecten"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Teruglopende tijd"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x L&angzamer\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr "langzamer"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Pauzeer tijd"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr "sneller"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x &Sneller\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Zet naar huidige tijd"
@@ -4199,7 +4480,6 @@ msgstr "Breedte: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radius"
 
@@ -4220,7 +4500,7 @@ msgstr "Resolutie:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Bladwijzers beheren"
 
@@ -4251,18 +4531,6 @@ msgstr "Celestia instellingen"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objecten"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Dwergplaneten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4353,49 +4621,43 @@ msgstr "Gedeeltelijke omloopbanen"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Rasters"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Equatoriaal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Zonneweg"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galactisch"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontaal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagrammen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Grenzen"
 
@@ -4429,7 +4691,6 @@ msgstr "Lokatienamen weergeven"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Steden"
 
@@ -4443,21 +4704,18 @@ msgstr "Landingsplaatsen"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulkanen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Sterrewachten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Kraters"
 
@@ -4492,7 +4750,6 @@ msgstr "Maria (Zeeën)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Andere features"
 
@@ -4597,7 +4854,7 @@ msgstr "Scherm"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -4838,21 +5095,21 @@ msgid "&About Celestia"
 msgstr "Over &Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 #, fuzzy
 msgid "OK"
 msgstr "OK"
@@ -4862,530 +5119,620 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2009, Celestia Ontwikkelteam"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia is vrije software en wordt geleverd zonder enige garantie."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Auteurs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Selecteer object"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Objectnaam"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licentie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Toetsencombinaties binnen Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL Driver info"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Zet simulatietijd"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formaat:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Zet naar huidige tijd"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Bladwijzer toevoegen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Maken in >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nieuwe map..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Zonnestelsel verkenner"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Nieuwe bladwijzermap toevoegen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Ga naar"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Mapnaam"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Zonnestelsel objecten"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Toetsencombinaties binnen Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Sterrenbrowser"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Dichtstbijzijnde"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Helderste (Schijnb.)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Met planeten"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Ververs"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Sterren zoekcriteria"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maximum aantal sterren dat in de lijst weergegeven wordt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Rondleiding"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Ga naar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Selecteer uw bestemming:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Ga naar object"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Object"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Afstand "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Grootte:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Selecteer weergavemodus"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Resolutie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Weergaveopties"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Eclips Vinder"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Toon"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Bereken"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Scherm"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Zet datum en ga naar planeet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Zonneweg"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Sluiten"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Omloopbanen / Labels"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Van: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Latijnse namen"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Informatietekst"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Beknopt"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Zoek parameters"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Volledig"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Selecteer object"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Landingsplaatsen"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Objectnaam"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Bergen)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL Driver info"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Zeeën)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Ga naar object"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Valeien)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Ga naar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Landmassa's)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Object"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Labelfeatures"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Afstand "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licentie"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Weergavefeatures"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Labelfeatures"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Minimaal gelabelde feature grootte"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Nieuwe bladwijzermap toevoegen"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Grootte:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Mapnaam"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Hernoemen..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Hernoem bladwijzer of map"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nieuwe naam"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Eclips Vinder"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Zet simulatietijd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Bereken"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formaat:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Zet datum en ga naar planeet"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Zet naar huidige tijd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Sluiten"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Zonnestelsel verkenner"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Van: "
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Ga naar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Zonnestelsel objecten"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Sterrenbrowser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Zoek parameters"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Ververs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Zonsverduisteringen"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Sterren zoekcriteria"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Maansverduisteringen"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maximum aantal sterren dat in de lijst weergegeven wordt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Rondleiding"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Selecteer uw bestemming:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Weergaveopties"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Toon"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Scherm"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Omloopbanen / Labels"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Informatietekst"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "413"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mrt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mei"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satelliet"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Datum"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Uitgever: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Venster modus"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "3D weergave: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Onzichtbaren"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "S&ynchronizeer Omloopbaan"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Toon lichaamsassen"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Toon frame-assen"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Toon Zon richting"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Toon snelheidsvector"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Planetografisch raster weergeven"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Dag/Nacht-grens weergeven"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satellieten"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Lichamen in omloopbaan"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Laden: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "nl"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Laden van URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versie: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL versie: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Max gelijktijdig geladen texturen: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Max textuurgrootte: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Max kubuskaart grootte: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Punt grootte bereik: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Ondersteunde extensies:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Venster modus"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Onzichtbaren"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "S&ynchronizeer Omloopbaan"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Toon lichaamsassen"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Toon frame-assen"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Toon Zon richting"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Toon snelheidsvector"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Planetografisch raster weergeven"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Dag/Nacht-grens weergeven"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satellieten"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Lichamen in omloopbaan"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Laden: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "nl"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Laden van URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Fout tijdens openen van scriptbestand."
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Fout tijdens laden van scriptbestand."
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Uitvoeren van scriptbestand"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Tijdzonenaam"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "UTC Offset"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Fout tijdens openen van script bestand."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Onbekende fout tijdens openen van script bestand."
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Fout tijdens openen van scriptbestand '%s'."
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Script co-routine initialisatie faalde"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Fout tijdens openen van scriptbestand '%s'."
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Onbekende fout tijdens openen van script bestand."
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Fout tijdens openen"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Bezig met laden van NV fragment programma: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Fout tijdens laden NV fragment programma: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Fout in fragment programma "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Initialiseren van NV fragment programma's...\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Alle NV fragment programma's succesvol geladen.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Initialiseren van ARB fragment programma's\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": onbekend of niet ondersteund type voor afbeeldingsbestand.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Bezig met laden van NV vertex programma: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Fout tijdens laden van NV vertex programma:"
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Fout in vertex programma"
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Bezig met laden van ARB vertex programma:"
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Fout tijdens laden van ARB vertex programma:"
+
+#~ msgid ", line "
+#~ msgstr ", regel"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Initialiseren van NV vertex programma's...\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Alle NV vertex programma's succesvol geladen.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Initialiseren van ARB vertex programma's...\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Alle ARB vertex programma's succesvol geladen.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Onbekende fout tijdens openen van script bestand."
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Kopieer URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Gekopieerde URL"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Alt-Azimut modus aan"
+
+#~ msgid "Nearest"
+#~ msgstr "Dichtstbijzijnde"
+
+#~ msgid "Brightest"
+#~ msgstr "Helderste (Schijnb.)"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Met planeten"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Zonneweg"
+
+#~ msgid "Latin Names"
+#~ msgstr "Latijnse namen"
+
+#~ msgid "Terse"
+#~ msgstr "Beknopt"
+
+#~ msgid "Verbose"
+#~ msgstr "Volledig"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Landingsplaatsen"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Bergen)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Zeeën)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Valeien)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Landmassa's)"
+
+#~ msgid "Label Features"
+#~ msgstr "Labelfeatures"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Zonsverduisteringen"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Maansverduisteringen"
+
+#~ msgid "Vendor: "
+#~ msgstr "Uitgever: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL versie: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Ondersteunde extensies:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Fout tijdens openen van scriptbestand."
+
+#~ msgid "Error loading script"
+#~ msgstr "Fout tijdens laden van scriptbestand."
+
+#~ msgid "Running script"
+#~ msgstr "Uitvoeren van scriptbestand"
 
 #~ msgid "Invisible"
 #~ msgstr "Onzichtbaar"

--- a/po/no.po
+++ b/po/no.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:50+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Merkur"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Jorden"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Måne"
 
@@ -47,140 +47,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymede"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturn"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tethys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phobos"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uranus"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptun"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereid"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluto"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galakser"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "NORDAMERIKA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "SØRAMERIKA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARKTIS"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NORDATLANTEREN"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "SØRATLANTEREN"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NORDLIGE STILLEHAVET"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "SØRLIGE STILLEHAVET"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "INDISKE HAV"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "NORDISHAVET"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Alger"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Asjchabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Aten"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Peking"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Beograd"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Brussel"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucuresti"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Kairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Cape Town"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "København"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damaskus"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dusjanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Den Haag"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havanna"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsingfors"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "London"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Manlig"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexico City"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moskva"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Muskat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nukualofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praha"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "P'yŏngyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sana"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seoul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapore"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tasjkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teheran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vatikanstaten"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Wien"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Warszawa"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Melkevei"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Solsystemets massesentrum"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Sommertid"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "Standardtid"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Feil ved åpning av bildefil "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Feil ved lesing av konfigurasjonsfil."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "Standardtid"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " deep space objekter"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Laster NV-fragmentprogram: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Feil ved lasting av NV-fragmentprogram: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Feil i fragmentprogram "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Initierer NV-fragmentprogram . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Alle NV-fragmentprogram vellykket lastet.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Initierer ARB-fragmentprogram . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galakse (Hubble-type: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Kulehop (kjerneradius: %4.2f', King konsentrasjon: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Laster bilde fra fil "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": ukjent eller ikke støttet bildefiltype.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Feil ved åpning av bildefil "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "er ikke en PNG-fil.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Feil ved lesing av PNG-bildefil "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Laster modell: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Feil ved innlasting av modell '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Stjernetåke"
 
@@ -1308,92 +1541,92 @@ msgstr "Stjernetåke"
 msgid "Open cluster"
 msgstr "Åpen stjernehop"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Feil i .ssc-fil (linje "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "advarsel for dobbelt definisjon av "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "feilaktig alternativ overflate"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "feil sted"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Feilaktig overskriftsformat i kryssindeks\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Feilaktig versjon for kryssindeks\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Lasting av krysssindeks feilet ved post "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " stjerner i binærdatabase\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Totale antall stjerner: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Feil i .stc-fil (linje "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ugyldig stjerne: feilaktig spektraltype.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ugyldig stjerne: mangler spektraltype.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " eksisterer ikke.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ugyldig stjerne: mangler rektascensjon\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Ugyldig stjerne: mangler deklinasjon.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Ugyldig stjerne: mangler avstand.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ugyldig stjerne: mangler magnitude.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,770 +1634,744 @@ msgstr ""
 "Ugyldig stjerne: absolutt (ikke tilsynelatende) magnitude må spesifiseres "
 "for stjerne nær utspring\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Oppretter flislagt tekstur. Bredde="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Oppretter vanlig tekstur: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Laster NV-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Feil ved lasting av NV-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Feil i vertexprogram "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Laster ARB-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Feil ved innlasting av ARB-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", linje"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Initierer NV-vertexprogrammer . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Alle NV-vertexprogrammer vellykket lastet.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Initierer ARB-vertexprogrammer . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Alle ARB-vertexprogrammer vellykket lastet.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Feil ved åpning av "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Feil ved lesing av PNG-bildefil "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Feil ved lesing av favorittfil."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Feil ved åpning av skriptfil."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Feil ved åpning av skript '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Ukjent feil ved åpning av skript"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Initiering av skriptets medrutine feilet"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Ugyldig filtype"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudegrense: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Markører aktiverte"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Markører deaktiverte"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Gå til overflate"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-azimut modus aktivert"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-azimut modus deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Stjernestil: Uklare punkter"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Stjernestil: Punkter"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Stjernestil: Skalerte skiver"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Komethaler aktiverte"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Komethaler deaktiverte"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Opptegning: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-azimut modus aktivert"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-azimut modus deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Auto-magnitude aktivert"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Auto-magnitude deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Tid og skript er midlertidig stoppet"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Tiden er midlertidig stoppet"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Gjenoppta"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Totale antall stjerner: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Totale antall stjerner: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Lysreisetid:  %.4f år "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Lysreisetid:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Lysreisetid:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Lysreiseforsinkelse inkludert"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Lysreiseforsinkelse slått av"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Lysreiseforsinkelse ignorert"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Bruker normale overflateteksturer."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Bruker 'limit of knowledge' overflateteksturer."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Følg"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tid: Fram"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tid: Tilbake"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Tidsfrekvens"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Teksturer"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Teksturer"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Teksturer"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Synkron omløpsbane"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Lås"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Gå etter"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudegrense: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Auto-magnitudegrense på 45 grader:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Omgivende lysnivå: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Lysforsterkning"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Overstråling aktivert"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Overstråling deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Eksponering"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL-feil: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Visning for liten til å deles opp"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Tillagt visning"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "lå"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "au"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " dager"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " timer"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minutter"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "Still tid..."
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Rotasjonsperiode: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " lå/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Hastighet: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Tilsynelatende diameter: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Tilsynelatende magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolutt magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Avstand: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Stjernesystemets massesentrum\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (tils.) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Lysstyrke: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Nøytronstjerne"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Svart hull"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Oveflatetemp.: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Planetære satellitter tilstede\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Avstand fra senter: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Tidsfrekvens"
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Sanntid"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Sanntid"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tid stoppet"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "raskere"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "langsommere"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (pause)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Reiser "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Reiser "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Spor"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Følg"
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synkron omløpsbane "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Gå etter"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sol"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Målnavn: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "  Pause"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Opptak"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause     F12 Stopp"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Redigeringsmodus"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Laster solsystemkatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Laster solsystemkatalog: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Feil ved lesing av konfigurasjonsfil."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Initiering av SPICE-biblioteket feilet"
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Kan ikke lese stjernedatabase."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Feil ved åpning av deep-sky-katalog "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Kan ikke lese stjernedatabase."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Feil ved åpning av solsystemskatalog.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Feil ved åpning av asterismefil."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Feil ved åpning av stjernebildegrense-filer."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Feilet i å initialisere opptegninger"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Feil ved lasting av skrift; tekst blir ikke synlig.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Feil ved lesing av kryssindeks"
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Lastet inn kryssindeks"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Feil ved lesing av stjernenavn-fil\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Feil ved åpning av "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Feil ved lesing av stjernenavn-fil\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Feil ved lesing av stjerne-fil\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Feil ved åpning av stjernekatalog "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Feil ved åpning av skript '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versjon: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Ukjent feil ved åpning av skript"
-
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
-
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:108
 #, fuzzy, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Vendor: %s\n"
+msgstr "Tilbyder: "
+
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Opptegner: "
+
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Maks samtidige teksturer: "
+
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Maks teksturstørrelse: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Punktstørrelses-område: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Punktstørrelses-område: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Maks kubekartstørrelse: "
+
+#: ../src/celestia/helper.cpp:132
+#, c-format
+msgid "Number of interpolators: %s\n"
 msgstr ""
-"Celestia var ikke istand til å initialisere OpenGL utvidelser. Grafikk-"
-"kvalitet blir redusert. Bare enkel opptegning blir tilgjengelig"
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
+msgstr ""
 
 #. if (glGetError())
 #. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
@@ -2360,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Feil ved opprettelse av videofil (ogg) %s.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Intern feil i Ogg-bibliotek."
@@ -2386,48 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - skrev %d bilderammer\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, fuzzy, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-"Celestia var ikke istand til å initialisere OpenGL utvidelser. Grafikk-"
-"kvalitet blir redusert. Bare enkel opptegning blir tilgjengelig"
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Objektfinner"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Objektfinner"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Solsystemet"
 
@@ -2437,21 +2633,20 @@ msgstr "Solsystemet"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Stjerner"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " deep space objekter"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Formørkelses-finner"
@@ -2460,7 +2655,7 @@ msgstr "Formørkelses-finner"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 #, fuzzy
 msgid "Time"
 msgstr "&Tid"
@@ -2468,455 +2663,506 @@ msgstr "&Tid"
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Turguide"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Full skjerm"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "&Ta film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Feil ved åpning av asterismefil."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Legg til bokmerker..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Ta bilde"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "er ikke en PNG-fil.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Oppløsning: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Bildefrekvens:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Kopiert URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Laster url"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "Å&pne skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Opprett en ny bokmerkemappe i denne meny"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Ukjent feil ved åpning av skript"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Støttede utvidelser:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Støttede utvidelser:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Om Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Language</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Tilbyder: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL-versjon: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Maks samtidige teksturer: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maks teksturstørrelse: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Punktstørrelses-område: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Punktstørrelses-område: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Maks kubekartstørrelse: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Ekvatorial"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "OpenGL-Info"
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Opptegner: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fil"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Ta bilde"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Ta &bilde...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "&Ta film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopier URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "&Sentrer valgt objekt\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Kopier URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Kopiert URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Å&pne skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia innstillinger"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Avslutt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Kantutjevning\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigering"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Velg"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Sentrer valgt objekt\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Valg: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Gå til objekt..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tid"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Still tid..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Vis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr " deep space objekter"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Vis sky-skygger"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Stj&ernestil"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Teksturens oppløsning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Styring"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Bokmerker"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vis"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "&Vis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Del visning vertikalt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Del &horisontalt\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Del visning horisontalt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Del &vertikalt\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Syklusvisning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Enkel visning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Enkel visning\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Slett visning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Slett"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Synlige rammer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktive ramme synlig"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synkroniser tid"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Hjelp"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia innstillinger"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Om Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "OpenGL-Info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Legg til bokmerke"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organiser bokmerker..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Laster"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skript"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Varighet"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Bokmerker"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Vis bokmerke-verktøylinje"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Feil ved lesing av favorittfil."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Bokmerker"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Still inn simuleringstid"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Still inn simuleringstid"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "&Tid"
@@ -2925,79 +3171,77 @@ msgstr "&Tid"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Ny mappe..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Vis ekvatorialt rutenett"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galaktisk"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Ekvatorialt rutnett"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horisontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr ", linje"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Markører"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "Copyright © 2001-2009, Celestias utviklingsgruppe"
@@ -3006,57 +3250,54 @@ msgstr "Copyright © 2001-2009, Celestias utviklingsgruppe"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Stjernebilder"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA-kombinatorer, ingen vertexprogram</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Stjernebilder-grenser"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Omløpsbaner"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planeter"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Dvergplaneter"
 
@@ -3066,19 +3307,17 @@ msgstr "Dvergplaneter"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Måner"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Mindre måner"
 
@@ -3088,12 +3327,12 @@ msgstr "Mindre måner"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroider"
 
@@ -3103,12 +3342,12 @@ msgstr "Asteroider"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Kometer"
 
@@ -3118,14 +3357,15 @@ msgstr "Kometer"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Romfartøy"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x &raskere\tL"
@@ -3134,9 +3374,8 @@ msgstr "10x &raskere\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Påskrifter"
 
@@ -3144,20 +3383,18 @@ msgstr "Påskrifter"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galakser"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Kulehoper"
 
@@ -3165,7 +3402,7 @@ msgstr "Kulehoper"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3175,617 +3412,634 @@ msgstr "Åpne stjernehoper"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Stjernetåker"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Steder"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Åpne stjernehoper"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Skyer"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Nattside-lys"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Komethaler"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosfærer"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Ring-skygger"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Formørkelsesskygger"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Sky-skygger"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Lav"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Middels"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Høy"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Auto-magnitude\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Flere  stjerner synlige\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Færre stjerner synlige\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Punkter"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&Uklare punkter"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Skalerte s&kiver"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Lysreiseforsinkelse slått av"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Alt-azimut modus aktivert"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Auto-magnitudegrense på 45 grader:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudegrense: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Navn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Tils. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Vis stjerner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Stjerner"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrer stjerner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 #, fuzzy
 msgid "With Planets"
 msgstr "Med planeter"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Vis stjerner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Massesentrum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 #, fuzzy
 msgid "Refresh"
 msgstr "&Gjenoppfrisk"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marker"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maksimale antall stjerner vist i liste"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marker"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markører"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triangel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Kvadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Pluss"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Sirkel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Venstrepil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Høyrepil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Opp-pil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Ned-pil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Velg &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Størrelse:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Velg &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Sett påskrift på detaljer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "' ikke funnet.\n"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marker"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "overordnet objekt '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Start med full skjerm"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Varighet"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Solformørkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Måneformørkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Fjern merking av &alle"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Søkeparametere"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Solformørkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Velg &objekt..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Solformørkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Still tid til nå"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Laster bilde fra fil "
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ekvatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotasjonsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Avstand (lå)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Størrelse: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informasjonsstekst"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ekvatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ekvatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotasjonsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Stj&ernestil"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Lokalt format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Tidssonenavn"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Avvikelse fra UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Start"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3804,21 +4058,21 @@ msgid "&Select"
 msgstr "&Velg"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Sentrer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Gå til"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Følg"
 
@@ -3832,50 +4086,55 @@ msgid "Visible"
 msgstr "Aktive ramme synlig"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Fjern markering"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Velg visningsmodus"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Fyllt kvadrat"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disk"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marker"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "&Referanse-vektorer"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Vis legeme-akser"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Vis ramme-akser"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Vis solretning"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Vis hastighetsvektor"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Vis hastighetsvektor"
@@ -3883,191 +4142,41 @@ msgstr "Vis hastighetsvektor"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Vis solretning"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Vis planetografisk rutenett"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Vis terminator"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternative overflater"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Romfartøy"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Andre detaljer"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Still tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Tidssone: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Universaltid"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Lokal tid"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Tidssonenavn"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Dato"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Still tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Still tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Still tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Tid"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " timer"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minutter"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "Still tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Juliansk dato: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Juliansk dato: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Still tid..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Massesentrum"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Dvergplanet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Mindre måner"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroid"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Komet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Referanse-vektorer"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Beregn"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Gå til overflate"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Ukjent feil ved åpning av skript"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroider"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Referanse-vektorer"
+msgid "Dwarf planets"
+msgstr "Dvergplaneter"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4075,67 +4184,235 @@ msgstr "&Referanse-vektorer"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Mindre måner"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Romfartøy"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Andre detaljer"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Still tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Tidssone: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Universaltid"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Lokal tid"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Tidssonenavn"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Dato"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Still tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Still tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Still tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Tid"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " timer"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minutter"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "Still tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Juliansk dato: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Juliansk dato: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Still tid..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Massesentrum"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Dvergplanet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Mindre måner"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroid"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Komet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Referanse-vektorer"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Beregn"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Gå til overflate"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Ukjent feil ved åpning av skript"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroider"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Referanse-vektorer"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Andre detaljer"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planeter"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Klasse: "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Snu tiden"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x &langsommere\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr "langsommere"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Stopp tiden midlertidig"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr "raskere"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x &raskere\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Still inn til gjeldende tid"
@@ -4207,7 +4484,6 @@ msgstr "Breddegrad: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radier"
 
@@ -4228,7 +4504,7 @@ msgstr "Oppløsning: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organiser bokmerker"
 
@@ -4260,18 +4536,6 @@ msgstr "Celestia innstillinger"
 #, fuzzy
 msgid "Objects"
 msgstr " deep space objekter"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Dvergplaneter"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4362,49 +4626,43 @@ msgstr "Delvise baner"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Rutenett"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Ekvatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptikken"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktisk"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horisontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagrammer"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Grenser"
 
@@ -4438,7 +4696,6 @@ msgstr "Vis stedspåskrifter"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Byer"
 
@@ -4452,21 +4709,18 @@ msgstr "Landingsplasser"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulkaner"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatorier"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Krater"
 
@@ -4501,7 +4755,6 @@ msgstr "Maria (Hav)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Andre detaljer"
 
@@ -4606,7 +4859,7 @@ msgstr "Vis"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Innstillinger"
 
@@ -4848,21 +5101,21 @@ msgid "&About Celestia"
 msgstr "Om &Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4871,531 +5124,637 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright © 2001-2009, Celestias utviklingsgruppe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 #, fuzzy
 msgid "https://celestia.space/"
 msgstr "http://celestiaproject.net/"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia er gratis programvare og absolutt ingen garanti gjelder."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Utviklere"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Velg objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Objektnavn"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Lisens"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Celestia styring"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL driverinfo"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Still inn simuleringstid"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Format: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Still inn til gjeldende tid"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Legg til bokmerke"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Opprett i >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Ny mappe..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Solsystemviser"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Legg til ny bokmerkemappe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Gå til"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Mappenavn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Solsystemobjekter"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Celestia styring"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Stjerneviser"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Nærmeste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Lyssterkest"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "Med planeter"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Gjenoppfrisk"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Stjernesøk-kriterie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maksimale antall stjerner vist i liste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Turguide"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Gå til"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Velg ditt mål:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Gå til objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "L.gr."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Br.gr."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Avstand"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Størrelse:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Velg visningsmodus"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Oppløsning"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Visningsalternativ"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Formørkelses-finner"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Vis"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Beregn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Vis"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Still inn dato og gå til planet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#, fuzzy
-msgid "Ecliptic Line"
-msgstr ", linje"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Lukk"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Omløpsbaner / Påskrifter"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Fra:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Latinske navn"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Informasjonsstekst"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Knapp"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Søkeparametere"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Utførlig"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Velg objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Landingsplasser"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Objektnavn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Fjell)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL driverinfo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Hav)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Gå til objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Daler)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Gå til"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Landmasser)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Sett påskrift på detaljer"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "L.gr."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Br.gr."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Avstand"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Lisens"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Vis detaljer"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Sett påskrift på detaljer"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Minste størrelse på detaljer med påskrift"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Legg til ny bokmerkemappe"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Størrelse:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Mappenavn"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Endre navn..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Endre navn på bokmerke eller mappe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nytt navn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Formørkelses-finner"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Still inn simuleringstid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Beregn"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Still inn dato og gå til planet"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Still inn til gjeldende tid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Lukk"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Solsystemviser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Fra:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Gå til"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Solsystemobjekter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Stjerneviser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Søkeparametere"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Gjenoppfrisk"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Solformørkelser"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Stjernesøk-kriterie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Måneformørkelser"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maksimale antall stjerner vist i liste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Turguide"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Velg ditt mål:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Visningsalternativ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Vis"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Vis"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Omløpsbaner / Påskrifter"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Informasjonsstekst"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "414"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Des"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satellitt"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Dato"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Tilbyder: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Vindusmodus"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Opptegner: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Usynlige"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "S&ynkr. omløpsbane"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Vis legeme-akser"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Vis ramme-akser"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Vis solretning"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Vis hastighetsvektor"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Vis planetografisk rutenett"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Vis terminator"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satellitter"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Legemer i bane"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Laster: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "no"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Laster url"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versjon: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL-versjon: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Maks samtidige teksturer: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Maks teksturstørrelse: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Maks kubekartstørrelse: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Punktstørrelses-område: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Støttede utvidelser:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Vindusmodus"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Usynlige"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "S&ynkr. omløpsbane"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Vis legeme-akser"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Vis ramme-akser"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Vis solretning"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Vis hastighetsvektor"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Vis planetografisk rutenett"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Vis terminator"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satellitter"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Legemer i bane"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Laster: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "no"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Laster url"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Feil ved åpning av skript"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Feil ved lasting av skript"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Kjør skript"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Tidssonenavn"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Avvikelse fra UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Feil ved åpning av skriptfil."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Ukjent feil ved åpning av skript"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Feil ved åpning av skript '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Initiering av skriptets medrutine feilet"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Feil ved åpning av skript '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Ukjent feil ved åpning av skript"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Feil ved åpning av "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Laster NV-fragmentprogram: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Feil ved lasting av NV-fragmentprogram: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Feil i fragmentprogram "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Initierer NV-fragmentprogram . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Alle NV-fragmentprogram vellykket lastet.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Initierer ARB-fragmentprogram . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": ukjent eller ikke støttet bildefiltype.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Laster NV-vertexprogram: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Feil ved lasting av NV-vertexprogram: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Feil i vertexprogram "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Laster ARB-vertexprogram: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Feil ved innlasting av ARB-vertexprogram: "
+
+#~ msgid ", line "
+#~ msgstr ", linje"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Initierer NV-vertexprogrammer . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Alle NV-vertexprogrammer vellykket lastet.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Initierer ARB-vertexprogrammer . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Alle ARB-vertexprogrammer vellykket lastet.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Ukjent feil ved åpning av skript"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia var ikke istand til å initialisere OpenGL utvidelser. Grafikk-"
+#~ "kvalitet blir redusert. Bare enkel opptegning blir tilgjengelig"
+
+#, fuzzy, qt-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia var ikke istand til å initialisere OpenGL utvidelser. Grafikk-"
+#~ "kvalitet blir redusert. Bare enkel opptegning blir tilgjengelig"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Kopier URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Kopiert URL"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Alt-azimut modus aktivert"
+
+#~ msgid "Nearest"
+#~ msgstr "Nærmeste"
+
+#~ msgid "Brightest"
+#~ msgstr "Lyssterkest"
+
+#~ msgid "With planets"
+#~ msgstr "Med planeter"
+
+#, fuzzy
+#~ msgid "Ecliptic Line"
+#~ msgstr ", linje"
+
+#~ msgid "Latin Names"
+#~ msgstr "Latinske navn"
+
+#~ msgid "Terse"
+#~ msgstr "Knapp"
+
+#~ msgid "Verbose"
+#~ msgstr "Utførlig"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Landingsplasser"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Fjell)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Hav)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Daler)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Landmasser)"
+
+#~ msgid "Label Features"
+#~ msgstr "Sett påskrift på detaljer"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Solformørkelser"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Måneformørkelser"
+
+#~ msgid "Vendor: "
+#~ msgstr "Tilbyder: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL-versjon: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Støttede utvidelser:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Feil ved åpning av skript"
+
+#~ msgid "Error loading script"
+#~ msgstr "Feil ved lasting av skript"
+
+#~ msgid "Running script"
+#~ msgstr "Kjør skript"
 
 #~ msgid "Invisible"
 #~ msgstr "Usynlig"

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2019-02-14 21:31+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Polish (https://www.transifex.com/celestia/teams/93131/pl/)\n"
@@ -32,12 +32,12 @@ msgstr "Merkury"
 msgid "Venus"
 msgstr "Wenus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Ziemia"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Księżyc"
 
@@ -53,140 +53,140 @@ msgstr "Fobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jowisz"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amaltea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganimedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Kallisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturn"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometeusz"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimeteusz"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tetyda"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Tytan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Japet"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Febe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uran"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Tytania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptun"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteusz"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tryton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluton-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluton"
 
@@ -195,1028 +195,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amaltea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Kallisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Sty"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaktyki"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "AMERYKA PÓŁNOCNA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "AMERYKA POŁUDNIOWA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURAZJA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRYKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARKTYKA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "PÓŁNOCNY OCEAN ATLANTYCKI"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "POŁUDNIOWY OCEAN ATLANTYCKI"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "PÓŁNOCNY OCEAN SPOKOJNY"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "POŁUDNIOWY OCEAN SPOKOJNY"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCEAN INDYJSKI"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCEAN ARKTYCZNY"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Zabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abudża"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Akra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Algier"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andora"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarywa"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Aszchabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Ateny"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangi"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Bandżul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Pekin"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Bejrut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Biszkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfointein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratysława"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruksela"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bukareszt"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapeszt"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bużumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Kair"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Kapsztad"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Kajenna"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Kiszyniów"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Kolombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Konakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Kopenhaga"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Kotonu"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damaszek"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Dżibuti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Ad-Dauha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Duszanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Wielki Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Gwatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Haga"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Hawana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Dżakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerozolima"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Chartum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kijów"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinszasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwejt"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "Al-Ujun"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lizbona"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Lublana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londyn"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luksemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madryt"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Malé"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoudzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Meksyk"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Mińsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadiszu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monako"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moskwa"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Maskat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Ndżamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Nowe Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nikozja"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nawakszut"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Wagadugu"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paryż"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praga"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pjongjang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavík"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Ryga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Rijad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Rzym"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San José"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sana"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajewo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapur"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Dźajawardanapura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Sztokholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Tajpej"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Taszkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teheran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Awiw-Jafa"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Thorshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Trypolis"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ułan Bator"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Watykan"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Wiedeń"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Wientian"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Wilno"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Warszawa"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Waszyngton D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Jamusukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Jaunde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Okręg Yaren"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Erywań"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagrzeb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Droga Mleczna"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Układ Słoneczny Barycentrum"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Błąd podczas otwierania pliku astronomów."
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Błąd odczytu pliku konfiguracyjnego."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1226,87 +1488,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr ""
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Ładowanie programu fragmentowego NV: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Błąd podczas ładowania programu fragmentowego  NV: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Błąd w programie fragmentowym"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Inicjalizowanie programów fragmentowych NV. . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Wszystkie programy fragmentowe NV zostały pomyślnie załadowane.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Inicjalizowanie programów fragmentowych ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaktyka (typ Hubble’a: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Gromada kulista (promień jądra: %4.2f', koncentracja Kinga: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, c-format
 msgid "Loading image from file %s\n"
 msgstr ""
 
-#: ../src/celengine/image.cpp:337
-#, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ""
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, c-format
 msgid "Error opening image file %s\n"
 msgstr ""
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr ""
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, c-format
 msgid "Loading model: %s\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, c-format
 msgid "Error loading model '%s'\n"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Mgławica"
 
@@ -1314,92 +1547,92 @@ msgstr "Mgławica"
 msgid "Open cluster"
 msgstr "Gromada otwarta "
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "zła zastępcza powierzchnia"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "zła lokalizacja"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Zły nagłówek indeksu skrośnego\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Zła wersja indeksu skrośnego\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, c-format
 msgid "%d stars in binary database\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, c-format
 msgid "Total star count: %d\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Nieprawidłowa gwiazda: zły typ spektralny.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Nieprawidłowa gwiazda: brak typu spektralnego.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Nieprawidłowa gwiazda: brak poprawnej rektascencji\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Nieprawidłowa gwiazda: brak deklinacji\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Nieprawidłowa gwiazda: brak odległości\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Nieprawidłowa gwiazda: brak wielkości\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1407,758 +1640,723 @@ msgstr ""
 "Nieprawidłowa gwiazda: bezwzględna (nie pozorna) wielkość musi być określona "
 "dla gwiazdy w pobliżu pochodzenia\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr ""
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Ładowanie programu wierzchołkowego NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Błąd podczas ładowania programu wierzchołkowego NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Błąd w programie wierzchołkowym"
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Ładowanie programu wierzchołkowego ARB: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Błąd podczas ładowania programu wierzchołkowego ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", wiersz"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Inicjalizowanie programów wierzchołkowych NV . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Wszystkie programy wierzchołkowe NV załadowane pomyślnie.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Inicjalizowanie programów wierzchołkowych ARB . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Wszystkie programy wierzchołkowe ARB załadowane pomyślnie.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Błąd otwarcia skryptu"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Błąd odczytu pliku gwiazd\n"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Błąd otwierania pliku skryptu."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Błąd otwierania skryptu '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Nieznany błąd podczas otwierania skryptu"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Zainicjowanie skryptu współprogramu nie powiodło się"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Nieprawidłowy typ pliku"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limit wielkości: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Markery włączone"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Markery wyłączone"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Idź do powierzchni"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Tryb alt-azymutalny włączony"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Tryb alt-azymutalny wyłączony"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Styl gwiazd: rozmyte punkty"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Styl gwiazd: punkty"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Styl gwiazd: skalowane tarcze"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Ogony komet włączone"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Ogony komet wyłączone"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Ścieżka renderowania: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 msgid "Anti-aliasing enabled"
 msgstr "Wygładzanie włączone"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 msgid "Anti-aliasing disabled"
 msgstr "Wygładzanie wyłączone"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Wielkość automatyczna włączona"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Wielkość automatyczna wyłączona"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Czas i skrypt zostały wstrzymane"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Czas jest wstrzymany"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Wznów"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 msgid "Star color: Blackbody D65"
 msgstr "Kolor gwiazd: ciało czarne D65"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 msgid "Star color: Enhanced"
 msgstr "Kolor gwiazd: wzmocniony"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Czas podróży światła:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Czas podróży światła:  %d g  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Włączone opóźnienie czasu podróży światła"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Wyłączone opóźnienie czasu podróży światła"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Zignorowane opóźnienie czasu podróży światła"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Korzystaj z normalnych tekstur powierzchni."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Korzystaj z tekstur powierzchni przy ograniczonej wiedzy."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Śledź"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Czas: do przodu"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Czas: wstecz"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, c-format
 msgid "Time rate: %.6g"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 msgid "Low res textures"
 msgstr "Tekstury niskiej rozdzielczości"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 msgid "Medium res textures"
 msgstr "Tekstury średniej rozdzielczości"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 msgid "High res textures"
 msgstr "Tekstury wysokiej rozdzielczości"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Synchronizacja orbity"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Zablokuj"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Goń"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automatyczny limit wielkości przy 45 stopniach:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Poziom oświetlenia otoczenia:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Lekkie wzmocnienie"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Bloom włączony"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Bloom wyłączony"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Ekspozycja"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Błąd GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Widok zbyt mały, aby został podzielony"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Dodano widok"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "lś"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "j.a."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 msgid "minutes"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 msgid "seconds"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, c-format
 msgid "Rotation period: %s %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2821
-msgid "m/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2823
-msgid "km/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2827
-msgid "AU/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2829
-msgid "ly/s"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2456
 #, c-format
-msgid "Speed: %s %s\n"
+msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2458
 #, c-format
-msgid "Apparent diameter: %s\n"
+msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2908
-#, c-format
-msgid "Apparent magnitude: %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2912
-#, c-format
-msgid "Absolute magnitude: %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2992
-#, c-format
-msgid "%.6f%c %.6f%c %f km"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
-#, c-format
-msgid "Distance: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3022
-msgid "Star system barycenter\n"
-msgstr "Barycentrum systemu gwiezdnego\n"
-
-#: ../src/celestia/celestiacore.cpp:3026
-#, c-format
-msgid "Abs (app) mag: %.2f (%.2f)\n"
-msgstr "Mag. abs (poz): %.2f (%.2f)\n"
-
-#: ../src/celestia/celestiacore.cpp:3032
-#, c-format
-msgid "Luminosity: %sx Sun\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3038
-msgid "Neutron star"
-msgstr "Gwiazda neuronowa"
-
-#: ../src/celestia/celestiacore.cpp:3041
-msgid "Black hole"
-msgstr "Czarna dziura"
-
-#: ../src/celestia/celestiacore.cpp:3046
-#, c-format
-msgid "Class: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3053
-#, c-format
-msgid "Surface temp: %s K\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3058
-#, c-format
-msgid "Radius: %s Rsun  (%s km)\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3064
-#, c-format
-msgid "Radius: %s km\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3080
-msgid "Planetary companions present\n"
-msgstr "Obecne towarzysze planetarne\n"
-
-#: ../src/celestia/celestiacore.cpp:3096
-#, c-format
-msgid "Distance from center: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
-#, c-format
-msgid "Radius: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3168
-#, c-format
-msgid "Phase angle: %.1f%s\n"
-msgstr "Kąt fazowy: %.1f%s\n"
-
-#: ../src/celestia/celestiacore.cpp:3180
+#: ../src/celestia/celestiacore.cpp:2460
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2471
+msgid "m/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2476
+msgid "km/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2486
+msgid "AU/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2491
+msgid "ly/s"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2494
+#, c-format
+msgid "Speed: %s %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2558
+#, c-format
+msgid "Apparent diameter: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2571
+#, c-format
+msgid "Apparent magnitude: %.1f\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2575
+#, c-format
+msgid "Absolute magnitude: %.1f\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2655
+#, c-format
+msgid "%.6f%c %.6f%c %f km"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
+#, c-format
+msgid "Distance: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Star system barycenter\n"
+msgstr "Barycentrum systemu gwiezdnego\n"
+
+#: ../src/celestia/celestiacore.cpp:2689
+#, c-format
+msgid "Abs (app) mag: %.2f (%.2f)\n"
+msgstr "Mag. abs (poz): %.2f (%.2f)\n"
+
+#: ../src/celestia/celestiacore.cpp:2695
+#, c-format
+msgid "Luminosity: %sx Sun\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2701
+msgid "Neutron star"
+msgstr "Gwiazda neuronowa"
+
+#: ../src/celestia/celestiacore.cpp:2704
+msgid "Black hole"
+msgstr "Czarna dziura"
+
+#: ../src/celestia/celestiacore.cpp:2709
+#, c-format
+msgid "Class: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2716
+#, c-format
+msgid "Surface temp: %s K\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2721
+#, c-format
+msgid "Radius: %s Rsun  (%s km)\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2727
+#, c-format
+msgid "Radius: %s km\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2743
+msgid "Planetary companions present\n"
+msgstr "Obecne towarzysze planetarne\n"
+
+#: ../src/celestia/celestiacore.cpp:2759
+#, c-format
+msgid "Distance from center: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
+#, c-format
+msgid "Radius: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2831
+#, c-format
+msgid "Phase angle: %.1f%s\n"
+msgstr "Kąt fazowy: %.1f%s\n"
+
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, c-format
 msgid "Temperature: %.0f K\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Czas rzeczywisty"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Czas rzeczywisty"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Czas zatrzymany"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, c-format
 msgid "%.6g x faster"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, c-format
 msgid "%.6g x slower"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Wstrzymano)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, c-format
 msgid "Travelling (%s)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, c-format
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Słońce"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nazwa celu: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pauza    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Tryb edycji"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Błąd odczytu pliku konfiguracyjnego."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Nie udało się wczytać biblioteki SPICE."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Nie można odczytać bazy danych gwiazd."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Błąd otwierania pliku skryptu."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Nie można odczytać bazy danych gwiazd."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Błąd podczas otwierania pliku astronomów."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Błąd otwierania plików granic gwiazdozbiorów."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Nie udało się zainicjować renderera"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Błąd ładowania czcionki; tekst nie będzie widoczny.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, c-format
 msgid "Error reading cross index %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, c-format
 msgid "Loaded cross index %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Błąd wczytania pliku nazwy gwiazd\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, c-format
 msgid "Error opening %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Błąd wczytania pliku nazwy gwiazd\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Błąd odczytu pliku gwiazd\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, c-format
 msgid "Error opening star catalog %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
+#, fuzzy, c-format
+msgid "%s Version: %s\n"
+msgstr "Wersja:"
+
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Dostawca: "
+
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Renderer: "
+
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Maksymalna jednoczesna ilość tekstur: "
+
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Maksymalny rozmiar tekstury: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Zakres rozmiaru punktu: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Zakres rozmiaru punktu: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Maks. rozmiar mapy kostki: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid "Error opening LuaHook '%s'"
+msgid "Number of interpolators: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4976
-msgid "Unknown error loading hook script"
-msgstr ""
-
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
-"OSTRZEŻENIE:\n"
-"\n"
-"Skrypt prosi o pozwolenie na odczyt i zapis plików oraz wykonywanie "
-"programów zewnętrznych. Pozwalanie na to może być groźne.\n"
-"Czy ufasz skryptowi i pozwoliszmu na to?\n"
-"\n"
-"y = tak, Esc = anuluj skrypt, inne klawisze = nie"
-
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-"OSTRZEŻENIE:\n"
-"\n"
-"Skrypt prosi o pozwolenie na odczyt i zapis plików oraz wykonywanie "
-"zewnętrznych programów. Pozwalanie na to może być niebezpieczne.\n"
-"Czy masz zaufanie do skryptu i pozwolisz mu na to?"
-
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:135
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2340,14 +2538,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Błąd w tworzeniu pliku ogg %s do nagrywania.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 msgid "Internal Ogg library error.\n"
 msgstr ""
 
@@ -2365,51 +2563,39 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - napisano %d klatek\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
+#, fuzzy
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 "Celestia nie może się uruchomić, gdyż brakuje katalogu z danymi, "
 "przypuszczalnie na skutek niewłaściwej instalacji."
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
-"Celestia nie może wystartować, gdyż brakuje katalogu z zasobami, "
-"przypuszczalnie na skutek niewłaściwej instalacji."
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-"Celestia nie mogła zainicjować rozszerzeń OpenGL (błąd %1). Jakość grafiki "
-"będzie zmniejszona."
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Przeglądarka kosmosu"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 msgid "Info Browser"
 msgstr "Przeglądarka informacji"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Układ słoneczny"
 
@@ -2419,20 +2605,19 @@ msgstr "Układ słoneczny"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Gwiazdy"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 msgid "Deep Sky Objects"
 msgstr "Obiekty głębokiego nieba"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Wyszukiwarka wydarzeń"
 
@@ -2440,103 +2625,105 @@ msgstr "Wyszukiwarka wydarzeń"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Czas"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 msgid "Guides"
 msgstr "Przewodniki"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 msgid "Full screen"
 msgstr "Pełny ekran"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 msgid "Shift+F11"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 msgid "Error opening bookmarks file"
 msgstr "Błąd podczas otwierania pliku zakładek"
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 msgid "Error Saving Bookmarks"
 msgstr "Błąd zapisu zakładek"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 msgid "Save Image"
 msgstr "Zapisz obraz"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 msgid "Images (*.png *.jpg)"
 msgstr "Obrazy (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Przechwyć wideo"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 msgid "Video (*.avi)"
 msgstr "Wideo (*.avi)"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 msgid "Video (*.ogv)"
 msgstr "Wideo (*.ogv)"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 msgid "Resolution:"
 msgstr "Rozdzielczość:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Tempo klatek:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr "Skopiowano zrzut ekranu do schowka"
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Skopiowany URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 msgid "Pasting URL"
 msgstr "Wklejanie URLa"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 msgid "Open Script"
 msgstr "Otwórz skrypt"
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Skrypty Celestii (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 msgid "New bookmark"
 msgstr "Nowa zakładka"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
-#, qt-format
+#: ../src/celestia/qt/qtappwin.cpp:1004
+#, fuzzy, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 "<html><p><b>Celestia 1.7.0 (Qt5, wersja beta, git commit %1)</b></p><p>Prawa "
 "autorskie (C) 2001-2018 - Celestia Development Team. Celestia jest wolnym "
@@ -2548,303 +2735,356 @@ msgstr ""
 "CelestiaProject/Celestia<a href=\"https://github.com/CelestiaProject/Celestia"
 "\"><br></a>"
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>Wersja OpenGL:</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1105
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1039
+msgid "Unknown compiler"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1043
+msgid "supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+msgid "not supported"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "O Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>Wersja OpenGL:</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Dostawca: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "Renderer: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "<b>Wersja GLSL:</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Maksymalna jednoczesna ilość tekstur: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Maksymalny rozmiar tekstury: </b>"
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-msgid "<b>Extensions:</b><br>\n"
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Zakres rozmiaru punktu: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Zakres rozmiaru punktu: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Maks. rozmiar mapy kostki: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Rozszerzenia:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "Informacje o OpenGL"
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Renderer: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Plik"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 msgid "&Grab image"
 msgstr "&Przechwyć obraz"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 msgid "F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 msgid "Capture &video"
 msgstr "Przechwyć &wideo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 msgid "Shift+F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 msgid "&Copy image"
 msgstr "&Kopiuj obraz"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 msgid "Ctrl+Shift+C"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-msgid "Copy &URL"
-msgstr "Kopiuj &URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-msgid "&Paste URL"
-msgstr "&Wklej URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Otwórz skrypt..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 msgid "&Preferences..."
 msgstr "&Ustawienia..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Wyjście"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 msgid "Ctrl+Q"
 msgstr ""
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Nawigacja"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 msgid "Select Sun"
 msgstr "Zaznacz Słońce"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 msgid "Center Selection"
 msgstr "Wyśrodkuj zaznaczenie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 msgid "Goto Selection"
 msgstr "Idź do zaznaczenia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Przejdź &do obiektu..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Czas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 msgid "Set &time"
 msgstr "Ustaw &czas"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 msgid "&Display"
 msgstr "&Wyświetlanie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 msgid "Dee&p Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 msgid "&Shadows"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "W&ygląd gwiazd"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 msgid "Texture &Resolution"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 msgid "&FPS control"
 msgstr ""
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Zakładki"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Widok"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 msgid "&MultiView"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Split view vertically"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 msgid "Ctrl+R"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 msgid "Split view horizontally"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 msgid "Ctrl+U"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 msgid "Cycle views"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 msgid "Single view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 msgid "Ctrl+D"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 msgid "Delete view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 msgid "Frames visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 msgid "Active frame visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 msgid "Synchronize time"
 msgstr ""
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Pomo&c"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 msgid "Celestia Manual"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "O Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "Informacje o OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 msgid "Add Bookmark..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 msgid "Organize Bookmarks..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "&Skrypty"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 msgid "Description"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 msgid "Bookmarks Menu"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 msgid "Bookmarks Toolbar"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 msgid "Error reading bookmarks file"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Zakładki"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 msgid "Current simulation time"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 msgid "Simulation time at activation"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 msgid "System time at activation"
 msgstr ""
 
@@ -2852,72 +3092,70 @@ msgstr ""
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 msgid "New Folder"
 msgstr ""
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr "Rów."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 msgid "Equatorial coordinate grid"
 msgstr "Siatka równikowa"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr "Gal."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 msgid "Galactic coordinate grid"
 msgstr "Siatka galaktyczna"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr "Ekl."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 msgid "Ecliptic coordinate grid"
 msgstr "Siatka ekliptyczna"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr "Hor."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 msgid "Horizontal coordinate grid"
 msgstr "Siatka horyzontalna"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr "Ekl"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 msgid "Ecliptic line"
 msgstr "Linia ekliptyki"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 msgid "M"
 msgstr ""
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Markery"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 msgid "C"
 msgstr ""
 
@@ -2925,54 +3163,51 @@ msgstr ""
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Gwiazdozbiory"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 msgid "B"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 msgid "Constellation boundaries"
 msgstr "Granice gwiazdozbiorów"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 msgid "O"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Orbity"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planety"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planety karłowate"
 
@@ -2982,19 +3217,17 @@ msgstr "Planety karłowate"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Księżyce"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Drobne księżyce"
 
@@ -3004,12 +3237,12 @@ msgstr "Drobne księżyce"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroidy"
 
@@ -3019,12 +3252,12 @@ msgstr "Asteroidy"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Komety"
 
@@ -3034,14 +3267,15 @@ msgstr "Komety"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Pojazdy kosmiczne"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 msgid "L"
 msgstr ""
 
@@ -3049,9 +3283,8 @@ msgstr ""
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Nazwy"
 
@@ -3059,20 +3292,18 @@ msgstr "Nazwy"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaktyki"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Gromady kuliste"
 
@@ -3080,7 +3311,7 @@ msgstr "Gromady kuliste"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 msgid "Open clusters"
 msgstr "Gromady otwarte"
@@ -3089,576 +3320,594 @@ msgstr "Gromady otwarte"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Mgławice"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Miejsca"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Gromady otwarte"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Chmury"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Światła nocnej strony"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Ogony komet"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosfery"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Cienie pierścieni"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Cienie zaćmień"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Cienie chmur"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Niska"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Średnia"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Wysoka"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 msgid "Auto Magnitude"
 msgstr "Jasność automatyczna"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr "Najmniejsza widoczna jasność, w oparciu o pole widzenia"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 msgid "More Stars Visible"
 msgstr "Pokazuj więcej gwiazd"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 msgid "Fewer Stars Visible"
 msgstr "Pokazuj mniej gwiazd"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 msgid "Points"
 msgstr "Punkty"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 msgid "Fuzzy Points"
 msgstr "Rozmyte punkty"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 msgid "Scaled Discs"
 msgstr "Skalowane dyski"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 msgid "Light Time Delay"
 msgstr "Opóźnienie czasu świetlnego"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-msgid "Enable Vsync"
-msgstr ""
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Automatyczny limit jasności przy 45 stopniach: %L1"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Limit jasności: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nazwa"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Odległość (lś)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Poz. wielk."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs. wielk."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 msgid "Closest Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 msgid "Brightest Stars"
 msgstr ""
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 msgid "Filter"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Z planetami"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 msgid "Multiple Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 msgid "Barycenters"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 msgid "Spectral Type"
 msgstr ""
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 msgid "Mark Selected"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 msgid "Mark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Odznacz &wszystko"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 msgid "Clear Markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Brak tekstu"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Romb"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Trójkąt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Kwadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Koło"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Strzałka w lewo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Strzałka w prawo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Strzałka w górę"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Strzałka w dół"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Select marker symbol"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 msgid "Select marker size"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 msgid "Click to select marker color"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Label"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, qt-format
 msgid "%1 objects found"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 msgid "Unmark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 msgid "Eclipsed body"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 msgid "Start time"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Trwanie"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 msgid "Solar eclipses"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 msgid "Lunar eclipses"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 msgid "All eclipses"
 msgstr ""
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 msgid "Search range"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 msgid "Find eclipses"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, qt-format
 msgid "%1 is not a valid object"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 msgid "Finding eclipses..."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 msgid "Set time to mid-eclipse"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, qt-format
 msgid "Near %1"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, qt-format
 msgid "From surface of %1"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, qt-format
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, qt-format
+msgid "<b>Start:</b> %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, qt-format
+msgid "<b>End:</b> %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 msgid "Classic colors"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 msgid "Local format"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 msgid "Time zone name"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 msgid "UTC offset"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Start"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
@@ -3678,21 +3927,21 @@ msgid "&Select"
 msgstr "&Wybierz"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centruj"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Przejdź do"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Śledź"
 
@@ -3705,210 +3954,87 @@ msgid "Visible"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Odznacz"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Wybierz tryb ekranu"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Wypełniony kwadrat"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Dysk"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Zaznacz"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "Punkty &odniesienia"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 msgid "Show &Body Axes"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 msgid "Show &Frame Axes"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 msgid "Show &Sun Direction"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 msgid "Show &Velocity Vector"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 msgid "Show S&pin Vector"
 msgstr ""
 
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, qt-format
 msgid "Show &Direction to %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 msgid "Show Planetographic &Grid"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 msgid "Show &Terminator"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternatywne powierzchnie"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Standardowo"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Pojazd kosmiczny"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
-msgid "Other objects"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-msgid "Set Time"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Strefa czasowa: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Czas uniwersalny"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Czas lokalny"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-msgid "Select Time Zone"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-msgid "Date: "
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-msgid "Set Year"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-msgid "Set Month"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-msgid "Set Day"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-msgid "Time: "
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-msgid "Set Hours"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-msgid "Set Minutes"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-msgid "Set Seconds"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Data Juliańska: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-msgid "Set Julian Date"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-msgid "Set time"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Barycentrum"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-msgid "Star"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planeta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-msgid "Dwarf planet"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-msgid "Minor moon"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroida"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Kometa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-msgid "Reference point"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-msgid "Component"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-msgid "Surface feature"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-msgid "Unknown"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-msgid "Asteroids & comets"
-msgstr ""
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-msgid "Reference points"
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
+msgid "Dwarf planets"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
@@ -3917,58 +4043,202 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Pojazd kosmiczny"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+msgid "Other objects"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+msgid "Set Time"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Strefa czasowa: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Czas uniwersalny"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Czas lokalny"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+msgid "Select Time Zone"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+msgid "Date: "
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+msgid "Set Year"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+msgid "Set Month"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+msgid "Set Day"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+msgid "Time: "
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+msgid "Set Hours"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+msgid "Set Minutes"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+msgid "Set Seconds"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Data Juliańska: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+msgid "Set Julian Date"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+msgid "Set time"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Barycentrum"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+msgid "Star"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planeta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+msgid "Dwarf planet"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+msgid "Minor moon"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroida"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Kometa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+msgid "Reference point"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+msgid "Component"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+msgid "Surface feature"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+msgid "Unknown"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+msgid "Asteroids & comets"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+msgid "Reference points"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 msgid "Surface features"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+msgid "Planets and moons"
+msgstr ""
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 msgid "Group objects by class"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 msgid "Reverse time"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "10x slower"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 msgid "2x slower"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 msgid "Pause time"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 msgid "2x faster"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 msgid "10x faster"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 msgid "Set to current time"
 msgstr ""
 
@@ -4031,7 +4301,6 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "prom."
 
@@ -4050,7 +4319,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizuj zakładki"
 
@@ -4079,17 +4348,6 @@ msgstr ""
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Obiekty"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-msgid "Dwarf planets"
-msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4168,49 +4426,43 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Siatka"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Równikowy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptczna"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktyczna"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Pozioma"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Schematy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Granice"
 
@@ -4241,7 +4493,6 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Miasta"
 
@@ -4254,21 +4505,18 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Wulkany"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Obserwatoria"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Kratery"
 
@@ -4299,7 +4547,6 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Inne miejsca"
 
@@ -4391,7 +4638,7 @@ msgstr ""
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -4628,21 +4875,21 @@ msgid "&About Celestia"
 msgstr "&O Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4651,529 +4898,626 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
-msgid "Copyright (C) 2001-2019, Celestia Development Team"
+msgid "1.7.0"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:74
-msgid "https://celestia.space/"
+msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:75
+msgid "https://celestia.space/"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr ""
 "Celestia jest wolnym oprogramowaniem i udostępnione jest bez żadnej "
 "gwarancji."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autorzy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Wybierz obiekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Nazwa obiektu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licencja"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Kontrole Celestii"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informacje sterownika OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Ustaw czas symulacji"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Format: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Ustaw do aktualnego czasu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Dodaj zakładkę"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Utwórz w >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nowy folder..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Przeglądarka układu słonecznego"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Dodaj nowy folder zakładek"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Przejdź do"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nazwa folderu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Obiekty układu słonecznego"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Kontrole Celestii"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Przeglądarka gwiazd"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Najbliższe"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Najjaśniejsze"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Odśwież"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Filtr wyszukiwania gwiazd"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maks. ilość gwiazd wyświetlana w liście"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Przewodnik"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Przejdź do"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Wybierz twój cel:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Przejdź do objektu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Obiekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Długość"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Szerokość"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Odległość"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Rozmiar:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Wybierz tryb ekranu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Rozdzielczość"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Wyszukiwarka zaćmienia"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Oblicz"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Ustaw datę i przejdź do planety"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Zamknij"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Filtry wyszukiwania"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Wybierz obiekt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Nazwa obiektu"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Informacje sterownika OpenGL"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Przejdź do objektu"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Przejdź do"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Obiekt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Długość"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Szerokość"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Odległość"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licencja"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "Pokaż miejsca"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+msgid "Show Label"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "Minimalna wielkość wpisanych miejsc"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Rozmiar:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "Zmień nazwę..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "Zmień nazwę zakładki lub folderu"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "Nowa nazwa"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Ustaw czas symulacji"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Format: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Ustaw do aktualnego czasu"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Przeglądarka układu słonecznego"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Przejdź do"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Obiekty układu słonecznego"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Przeglądarka gwiazd"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Odśwież"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Filtr wyszukiwania gwiazd"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maks. ilość gwiazd wyświetlana w liście"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Przewodnik"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Wybierz twój cel:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
 msgid "View Options"
 msgstr "Opcje widoku"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 #, fuzzy
 msgid "Show:"
 msgstr "Pokaż"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:173
 #, fuzzy
 msgid "Display:"
 msgstr "Wyświetlanie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Ekliptyka"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:175
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbity / Nazwy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Łacińskie nazwy"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Information Text"
 msgstr "Informacje tekstowe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Krótkie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Szczegółowe"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Miejsca lądowania"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (góry)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (morza)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (doliny)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (masy ziemi)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Nazwy miejsc"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "Pokaż miejsca"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-msgid "Show Label"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "Minimalna wielkość wpisanych miejsc"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Dodaj nowy folder zakładek"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nazwa folderu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "Zmień nazwę..."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "Zmień nazwę zakładki lub folderu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "Nowa nazwa"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Wyszukiwarka zaćmienia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Oblicz"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Ustaw datę i przejdź do planety"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Zamknij"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Od:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Filtry wyszukiwania"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Zaćmienia Słońca"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Zaćmienia Księżyca"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "415"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Kwi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Lut"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Sty"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Cze"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Maj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Sie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Gru"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Lip"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Lis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Paź"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Wrz"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satelita"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Data"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Dostawca: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Tryb okna"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Renderer: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Niewidzialne"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "S&ynchronizacja orbity"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Informacja"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Pokaż osie ciała"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Pokaż osie ramek"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Pokaż kierunek słońca"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Pokaż wektor prędkości"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Pokaż siatkę planetarną"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Pokaż terminatora"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satelity"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Orbitujące ciała"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Ładowanie: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "pl"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Ładowanie URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Wersja:"
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Wersja GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Maksymalna jednoczesna ilość tekstur: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Maksymalny rozmiar tekstury: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Maks. rozmiar mapy kostki: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Zakres rozmiaru punktu: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Obsługiwane rozszerzenia:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Tryb okna"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Niewidzialne"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "S&ynchronizacja orbity"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Informacja"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Pokaż osie ciała"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Pokaż osie ramek"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Pokaż kierunek słońca"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Pokaż wektor prędkości"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Pokaż siatkę planetarną"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Pokaż terminatora"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satelity"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Orbitujące ciała"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Ładowanie: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "pl"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Ładowanie URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Błąd otwarcia skryptu"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Błąd ładowania skryptu"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Uruchamianie skryptu"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Nazwa strefy czasowej"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Przesunięcie do UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Błąd otwierania pliku skryptu."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Nieznany błąd podczas otwierania skryptu"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+"OSTRZEŻENIE:\n"
+"\n"
+"Skrypt prosi o pozwolenie na odczyt i zapis plików oraz wykonywanie "
+"programów zewnętrznych. Pozwalanie na to może być groźne.\n"
+"Czy ufasz skryptowi i pozwoliszmu na to?\n"
+"\n"
+"y = tak, Esc = anuluj skrypt, inne klawisze = nie"
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+"OSTRZEŻENIE:\n"
+"\n"
+"Skrypt prosi o pozwolenie na odczyt i zapis plików oraz wykonywanie "
+"zewnętrznych programów. Pozwalanie na to może być niebezpieczne.\n"
+"Czy masz zaufanie do skryptu i pozwolisz mu na to?"
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Błąd otwierania skryptu '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Zainicjowanie skryptu współprogramu nie powiodło się"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:223
+msgid "Unknown error loading hook script"
+msgstr ""
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Błąd otwarcia skryptu"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Ładowanie programu fragmentowego NV: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Błąd podczas ładowania programu fragmentowego  NV: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Błąd w programie fragmentowym"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Inicjalizowanie programów fragmentowych NV. . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Wszystkie programy fragmentowe NV zostały pomyślnie załadowane.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Inicjalizowanie programów fragmentowych ARB . . .\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Ładowanie programu wierzchołkowego NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Błąd podczas ładowania programu wierzchołkowego NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Błąd w programie wierzchołkowym"
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Ładowanie programu wierzchołkowego ARB: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Błąd podczas ładowania programu wierzchołkowego ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", wiersz"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Inicjalizowanie programów wierzchołkowych NV . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Wszystkie programy wierzchołkowe NV załadowane pomyślnie.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Inicjalizowanie programów wierzchołkowych ARB . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Wszystkie programy wierzchołkowe ARB załadowane pomyślnie.\n"
+
+#~ msgid ""
+#~ "Celestia is unable to run because the CelestiaResources folder was not "
+#~ "found, probably due to improper installation."
+#~ msgstr ""
+#~ "Celestia nie może wystartować, gdyż brakuje katalogu z zasobami, "
+#~ "przypuszczalnie na skutek niewłaściwej instalacji."
+
+#, qt-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Celestia nie mogła zainicjować rozszerzeń OpenGL (błąd %1). Jakość "
+#~ "grafiki będzie zmniejszona."
+
+#~ msgid "Copy &URL"
+#~ msgstr "Kopiuj &URL"
+
+#~ msgid "&Paste URL"
+#~ msgstr "&Wklej URL"
+
+#~ msgid "Nearest"
+#~ msgstr "Najbliższe"
+
+#~ msgid "Brightest"
+#~ msgstr "Najjaśniejsze"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Ekliptyka"
+
+#~ msgid "Latin Names"
+#~ msgstr "Łacińskie nazwy"
+
+#~ msgid "Terse"
+#~ msgstr "Krótkie"
+
+#~ msgid "Verbose"
+#~ msgstr "Szczegółowe"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Miejsca lądowania"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (góry)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (morza)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (doliny)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (masy ziemi)"
+
+#~ msgid "Label Features"
+#~ msgstr "Nazwy miejsc"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Zaćmienia Słońca"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Zaćmienia Księżyca"
+
+#~ msgid "GLSL version: "
+#~ msgstr "Wersja GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Obsługiwane rozszerzenia:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Błąd otwarcia skryptu"
+
+#~ msgid "Error loading script"
+#~ msgstr "Błąd ładowania skryptu"
+
+#~ msgid "Running script"
+#~ msgstr "Uruchamianie skryptu"
 
 #~ msgid "License file 'License.txt' is missing!"
 #~ msgstr "Brakuje pliku licencji 'License.txt'!"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Mercúrio"
 msgid "Venus"
 msgstr "Vénus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Terra"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Lua"
 
@@ -47,140 +47,140 @@ msgstr "Fobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Júpiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amaltéia"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganimedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Calisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturno"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometeu"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimeteu"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Jano"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encelado"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tétis"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Reia"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titã"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hipérion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Jápeto"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Febe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Úrano"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titânia"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptuno"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Lárissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteu"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tritão"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Plutão-Caronte"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plutão"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Caronte"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Nouméa"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amaltéia"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Calisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galáxias"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "AMÉRICA DO NORTE"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "AMÉRICA DO SUL"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURÁSIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "ÁFRICA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRÁLIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTÁRCTICA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO NORTE"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO SUL"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO NORTE"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO SUL"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCEANO ÍNDICO"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ÁRTICO"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Acra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Adís Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Argel"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amã"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ancara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ashgabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Assunção"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Atenas"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdá"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Banguecoque"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Pequim"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirute"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlim"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Berna"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasília"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruxelas"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucareste"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapeste"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Cairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Camberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Cidade do Cabo"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Caiena"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conacry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damasco"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar-es-Salam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dacca"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "The Hague"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanói"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinque"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jacarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalém"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Cabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Cartum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Liubliana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lomé"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londres"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longuiarbien"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madri"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Malé"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamuzu"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Manágua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Cidade do México"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Mônaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monróvia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevidéu"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moscou"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Mascate"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Nova Deli"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicósia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Otawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panamá"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port of Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praga"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretória"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "St Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipão"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San José"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago do Chile"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "São Tomé e Príncipe"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Saraievo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Cingapura"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipé"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa-Sul"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teerã"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tóquio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Túnis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulan Bator"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valeta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "O Vale"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Cidade do Vaticano"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Vitória"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Viena"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Viantiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsóvia"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Via Láctea"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "PNM"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "GNM"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Baricentro do Sistema Solar"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Hora de Verão"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Erro ao abrir o ficheiro de imagem "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Erro ao ler o ficheiro de configuração."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " objectos de céu profundo"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "A carregar o programa de fragmentos NV: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Erro ao carregar o programa de fragmentos NV: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Erro no programa de fragmentos"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "A inicializar o programa de fragmentos NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Todos os programas de fragmentos NV foram carregados com sucesso.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "A inicialzar os programas de fragmentos ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galáxia (classe de Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Globular (raio do núcleo: %4.2f', concentração King: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "A carregar imagem do ficheiro "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Erro ao abrir o ficheiro de imagem "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " não é um ficheiro PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Carregando o modelo: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Erro ao carregar o modelo '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebulosa"
 
@@ -1308,92 +1541,92 @@ msgstr "Nebulosa"
 msgid "Open cluster"
 msgstr "Aglomerados Abertos"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Erro no ficheiro .ssc (linha"
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "aviso de definição duplicada de "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "superfície alternativa inválida"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "localização inválida"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Cabeçalho inválido para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Versão inválida para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "O carregamento do índice remissivo falhou no registo "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr "estrelas na base de dados de binárias\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Total de estrelas: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Erro no ficheiro .stc (linha"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrela inválida: classe espectral inválida.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrela inválida: classe espectral ausente.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " não existe.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrela inválida: ascensão recta ausente\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrela inválida: declinação ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrela inválida: distância ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrela inválida: magnitude ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "Estrela inválida: terá que especificar a magnitude absoluta (não a aparente) "
 "para a estrela perto da origem \n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Criando uma textura em mosaico. Largura="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Criando textura normal: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "A carregar o programa de vértices NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Erro ao carregar o programa de vértices NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Erro no programa de vértices "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "A carregar o programa de vértices ARB: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Erro ao carregar o programa de vértices ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", linha "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "A inicializar o programa de vértices NV . . . \n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Todos os programas de vértices NV foram carregados com sucesso.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "A inicializar os programas de vértices ARB . . . \n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Todos os programas de vértices ARB foram carregados com sucesso.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Erro ao abrir "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Erro ao abrir o ficheiro de script."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erro ao abrir o script '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Erro desconhecido ao abrir o script"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Falha na inicialização da co-rotina do script"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Tipo de ficheiro inválido"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marcas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marcas desactivadas"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Ir para a superfície"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo altazimutal activado"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo altazimutal desactivado"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Forma das estrelas: Pontos Indistintos"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Forma das estrelas: Pontos"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Forma das estrelas: Discos à escala"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Caudas de cometa activadas"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Caudas de cometa desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Caminho de Renderização: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Marcas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Marcas desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Magnitude automática activada"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Magnitude automática desactivada"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "O tempo e o script estão em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "O tempo está em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Retomar"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "N&avegador Estelar..."
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "N&avegador Estelar..."
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tempo de viagem da luz: %.4f anos "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Atraso da viagem da luz incluído"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Atraso da viagem da luz desligado"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Atraso da viagem da luz ignorado"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Usando texturas de superfície normais."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Usando texturas no limite do conhecimento de superfície "
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tempo: para a frente"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tempo: para trás"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Velocidade do tempo"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Órbita Geoest."
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Fixar"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Limite de magnitude automática a 45 graus: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiente: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Ganho de luz"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Florescência activada"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Florescência desactivada"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Exposição"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Erro de GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vista demasiado pequena para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Panorama acrescentado"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "a.l."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "ua"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "segundos"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Velocidade: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diâmetro aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitude aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitude absoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distância: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Baricentro do sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs (apa): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Buraco negro"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Temp à superfície:"
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Companheiros planetários presentes\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distância do centro: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Ângulo de fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Seguir a rota "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Geoest. "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sol"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nome do alvo: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr " A gravar"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Parar"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Erro ao ler o ficheiro de configuração."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Inicialização da livraria SPICE falhou."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Erro ao abrir o catálogo de céu profundo. "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Erro ao abrir o catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Erro ao abrir o ficheiro das fronteiras das constelações."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Falha na inicialização do motor de renderização"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Erro ao carregar a fonte; o texto não será visível.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Erro ao ler o índice remissivo "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Índice remissivo carregado "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Erro ao ler o ficheiro com o nome das estrelas\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Erro ao abrir "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Erro ao ler o ficheiro com o nome das estrelas\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Erro ao ler o ficheiro das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Erro ao abrir o catálogo de estrelas "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Erro ao abrir o script '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versão: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Erro desconhecido ao abrir o script"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Vendedor: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Motor de Renderização: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Nº máx. de texturas em simultâneo: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Erro ao criar o ficheiro ogg %s para captura.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Erro na livraria interna de Ogg."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navegador Celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "&Informação"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -2433,21 +2633,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " objectos de céu profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
@@ -2456,463 +2655,514 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Hora"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Guia de Excursão"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Ecrã inteiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Gravar como:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " não é um ficheiro PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolução: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Imagens por segundo:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL copiado"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "A carregar o URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Criar uma nova pasta de marcadores neste menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>OpenGL 1.1. sem extensão</b>"
+msgid "Unknown compiler"
+msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
+#: ../src/celestia/qt/qtappwin.cpp:1043
 #, fuzzy
-msgid "<b>Renderer: </b>"
-msgstr "<b>OpenGL 1.1. sem extensão</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
-msgstr "Versão GLSL: "
-
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
-msgstr "Tamanho máx. de texturas: "
-
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-#, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "supported"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1045
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Informação do OpenGL"
+msgid "not supported"
+msgstr "Extensões suportadas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Acerca do Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>OpenGL 1.1. sem extensão</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Vendedor: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>OpenGL 1.1. sem extensão</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "Versão GLSL: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Nº máx. de texturas em simultâneo: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Equatorial"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Extensões suportadas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Motor de Renderização: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Capturar Imagem"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Capturar &Imagem...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Copiar URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL copiado"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferências do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "S&air"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegação"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrar na Selecção\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selecção: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir para Objecto..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Hora"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Definir a Hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Visualização"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Sombras dos Anéis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Resolução das Texturas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Panorama"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Multipanorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividir o Panorama Verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir &Horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividir o Panorama Horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividir &Verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Alternar o Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Panorama individual"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Panorama &Individual\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Apagar Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Bordas Visíveis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Borda Activa Visível"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizar Hora"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Ajuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Acerca do Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Informação do OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Adicionar marcador"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizar Marcadores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "A carregar "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Duração"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Barra de Ferramentas Principal"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Hora"
@@ -2921,79 +3171,77 @@ msgstr "Hora"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Nova Pasta..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Mostrar Grade Equatorial"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galáctico"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Eclíptica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Eclíptica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marcas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Centrar na Selecção\tC"
@@ -3002,57 +3250,54 @@ msgstr "&Centrar na Selecção\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Constelações"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>Combiner NVIDIA, nenhum programa de vértices</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Fronteiras das Constelações"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Órbitas"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planetas Anões"
 
@@ -3062,19 +3307,17 @@ msgstr "Planetas Anões"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Luas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Luas Menores"
 
@@ -3084,12 +3327,12 @@ msgstr "Luas Menores"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteróides"
 
@@ -3099,12 +3342,12 @@ msgstr "Asteróides"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Cometas"
 
@@ -3114,14 +3357,15 @@ msgstr "Cometas"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Naves Espaciais"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Mais &Rápido\tL"
@@ -3130,9 +3374,8 @@ msgstr "10x Mais &Rápido\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Legendas"
 
@@ -3140,20 +3383,18 @@ msgstr "Legendas"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galáxias"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Globulares"
 
@@ -3161,7 +3402,7 @@ msgstr "Globulares"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3171,615 +3412,632 @@ msgstr "Enxames Abertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulosas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Localizações"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Enxames Abertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nuvens"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Luzes do Lado Nocturno"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Caudas dos Cometas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosferas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Sombras dos Anéis"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Sombras dos Eclipses"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Sombras das Nuvens"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "&Baixa"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "&Média"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Alto"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Magnitude Automática\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Mais Estrelas Visíveis\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Menos Estrelas Visíveis\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Pontos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Pontos &Indistintos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&Discos à Escala"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Atraso da viagem da luz desligado"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Modo altazimutal activado"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Limite de magnitude automática a 45 graus: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distância (a.l.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag apa."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Mais Brilhante"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Com Planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Quadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Mais"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Seta Esquerda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Seta Direita"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Seta para Cima"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Seta para Baixo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamanho:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Legendar as Feições"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "corpo pai '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Início"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Duração"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Eclipses Lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Desmarcar &Todos"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Procurar"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Eclipses Lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Objecto: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Definir a Hora para Agora"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "De:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Duração: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Distância: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Tamanho: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Formato Local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Fuso Horário"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Desvio em relação ao GMT"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Início"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3798,21 +4056,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Ir para"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -3826,49 +4084,54 @@ msgid "Visible"
 msgstr "Borda Activa Visível"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Escolher o Modo de Visualização"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Encher Quadrado"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Pontos de Referência"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Mostrar Eixos"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Mostrar os Eixos das Bordas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Mostrar a Direcção do Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Mostrar o Vector de Velocidade"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Mostrar o Vector de Velocidade"
@@ -3876,190 +4139,41 @@ msgstr "Mostrar o Vector de Velocidade"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Mostrar a Direcção do Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Mostrar a Grelha Planetográfica"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Mostrar o Terminador"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Superfícies alternativas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Naves espaciais"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objectos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Fuso Horário: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Tempo Universal"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Tempo Local"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Fuso Horário: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Data"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Definir"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Definir"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Definir"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Hora"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " horas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minutos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "segundos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Data Juliana: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Data Juliana: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Baricentro"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planeta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Planeta Anão"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Luas Menores"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteróide"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Cometa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Pontos de Referência"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Calcular"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Ir para a superfície"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Erro desconhecido ao abrir o script"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteróides"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Pontos de Referência"
+msgid "Dwarf planets"
+msgstr "Planetas Anões"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4067,67 +4181,234 @@ msgstr "&Pontos de Referência"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Luas Menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Naves espaciais"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objectos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Fuso Horário: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Tempo Universal"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Tempo Local"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Fuso Horário: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Data"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Definir"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Definir"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Definir"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Hora"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " horas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minutos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "segundos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Data Juliana: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Data Juliana: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Baricentro"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planeta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Planeta Anão"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Luas Menores"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteróide"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Cometa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Pontos de Referência"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Calcular"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Ir para a superfície"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteróides"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Pontos de Referência"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Outras feições"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planetas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Inverter o Tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x Mais &Lento\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Parar o Tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Mais &Rápido\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Actualizar para a Hora Actual"
@@ -4199,7 +4480,6 @@ msgstr "Latitude: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "raio"
 
@@ -4220,7 +4500,7 @@ msgstr "Resolução: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizar Marcadores"
 
@@ -4251,18 +4531,6 @@ msgstr "Preferências do Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objectos"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Planetas Anões"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4353,49 +4621,43 @@ msgstr "Trajectórias Parciais"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Grelhas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Equatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galáctico"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Mostrar Fronteiras"
 
@@ -4429,7 +4691,6 @@ msgstr "localização inválida"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Cidades"
 
@@ -4443,21 +4704,18 @@ msgstr "Sítios de Aterragem"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulcões"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatórios"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Crateras"
 
@@ -4492,7 +4750,6 @@ msgstr "Maria (Mares)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Outras feições"
 
@@ -4597,7 +4854,7 @@ msgstr "Visualização"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Configuração"
 
@@ -4840,21 +5097,21 @@ msgid "&About Celestia"
 msgstr "&Acerca do Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4863,530 +5120,620 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2008, Grupo de Desenvolvimento do Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "O Celestia é software livre e não vem com qualquer garantia."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Seleccionar Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Nome do Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licença"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Controlos do Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informação do Driver OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Definir Hora da Simulação"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formato: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Actualizar para a Hora Actual"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Adicionar Marcardor"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Criar em >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nova Pasta..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navegador do Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Adicionar Nova Pasta de Marcadores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Ir Para"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nome da Pasta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Objectos do Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Controlos do Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navegador Estelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Mais Próxima"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Mais Brilhante"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Com Planetas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Refrescar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Critério de Busca de Estrelas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Nº Máximo de Estrelas Apresentado na Lista"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Guia de Excursão"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Ir Para"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Escolha o seu destino:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Ir para Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Distância"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Tamanho:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Escolher o Modo de Visualização"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Resolução"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Opções de Visualização"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Mostrar"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Calcular"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Visualização"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Definir Data e Ir para Planeta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Eclíptica"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Fechar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Órbitas / Legendas"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "De:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Nomes em Latim"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Texto Informativo"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Conciso"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parâmetros de busca"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Completo"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Seleccionar Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Sítios de Aterragem"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Nome do Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Montanhas)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Informação do Driver OpenGL"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Mares)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Ir para Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Vales)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Ir Para"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Massas de Terra)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Legendar as Feições"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Distância"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licença"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Mostrar as Feições"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Legendar as Feições"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Tamanho Mínimo da Feição Legendada"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Adicionar Nova Pasta de Marcadores"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Tamanho:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nome da Pasta"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Renomear Marcador ou Pasta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Novo Nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Buscador de eclipses"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Calcular"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formato: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Definir Data e Ir para Planeta"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Actualizar para a Hora Actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Fechar"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navegador do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "De:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Ir Para"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Objectos do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navegador Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parâmetros de busca"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Refrescar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Eclipses Solares"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Critério de Busca de Estrelas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Eclipses Lunares"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Guia de Excursão"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Escolha o seu destino:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Opções de Visualização"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Mostrar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Visualização"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Órbitas / Legendas"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Texto Informativo"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "0816"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Fev"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dez"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Out"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Set"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satélite"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Data"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Início"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Vendedor: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Modo em janela"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Motor de Renderização: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invisíveis"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Ó&rbita Geoest."
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Informação"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Mostrar Eixos"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Mostrar os Eixos das Bordas"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Mostrar a Direcção do Sol"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Mostrar o Vector de Velocidade"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Mostrar a Grelha Planetográfica"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Mostrar o Terminador"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satélites"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Corpos em órbita"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "A carregar: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "pt"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "A carregar o URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versão: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Versão GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Nº máx. de texturas em simultâneo: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Tamanho máx. de texturas: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Tamanho máx. de texturas: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Intervalo do tamanho dos pontos"
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Extensões suportadas: "
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Modo em janela"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invisíveis"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Ó&rbita Geoest."
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Informação"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Mostrar Eixos"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Mostrar os Eixos das Bordas"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Mostrar a Direcção do Sol"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Mostrar o Vector de Velocidade"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Mostrar a Grelha Planetográfica"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Mostrar o Terminador"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satélites"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Corpos em órbita"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "A carregar: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "pt"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "A carregar o URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Erro ao abrir o script"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Erro ao carregar o script"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "A executar o script"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Fuso Horário"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Desvio em relação ao GMT"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Erro ao abrir o ficheiro de script."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Erro ao abrir o script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Falha na inicialização da co-rotina do script"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Erro ao abrir o script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Erro ao abrir "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "A carregar o programa de fragmentos NV: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Erro ao carregar o programa de fragmentos NV: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Erro no programa de fragmentos"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "A inicializar o programa de fragmentos NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Todos os programas de fragmentos NV foram carregados com sucesso.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "A inicialzar os programas de fragmentos ARB . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "A carregar o programa de vértices NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Erro ao carregar o programa de vértices NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Erro no programa de vértices "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "A carregar o programa de vértices ARB: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Erro ao carregar o programa de vértices ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", linha "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "A inicializar o programa de vértices NV . . . \n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Todos os programas de vértices NV foram carregados com sucesso.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "A inicializar os programas de vértices ARB . . . \n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Todos os programas de vértices ARB foram carregados com sucesso.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Erro desconhecido ao abrir o script"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Copiar URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL copiado"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Modo altazimutal activado"
+
+#~ msgid "Nearest"
+#~ msgstr "Mais Próxima"
+
+#~ msgid "Brightest"
+#~ msgstr "Mais Brilhante"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Com Planetas"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Eclíptica"
+
+#~ msgid "Latin Names"
+#~ msgstr "Nomes em Latim"
+
+#~ msgid "Terse"
+#~ msgstr "Conciso"
+
+#~ msgid "Verbose"
+#~ msgstr "Completo"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Sítios de Aterragem"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Montanhas)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Mares)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Vales)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Massas de Terra)"
+
+#~ msgid "Label Features"
+#~ msgstr "Legendar as Feições"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Eclipses Solares"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Eclipses Lunares"
+
+#~ msgid "Vendor: "
+#~ msgstr "Vendedor: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Versão GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Extensões suportadas: "
+
+#~ msgid "Error opening script"
+#~ msgstr "Erro ao abrir o script"
+
+#~ msgid "Error loading script"
+#~ msgstr "Erro ao carregar o script"
+
+#~ msgid "Running script"
+#~ msgstr "A executar o script"
 
 #~ msgid "Invisible"
 #~ msgstr "Invisíveis"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Mercúrio"
 msgid "Venus"
 msgstr "Vénus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Terra"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Lua"
 
@@ -47,140 +47,140 @@ msgstr "Fobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Júpiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amaltéia"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganimedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Calisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturno"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometeu"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimeteu"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Jano"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Encelado"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tétis"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Reia"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titã"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hipérion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Jápeto"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Febe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Úrano"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titânia"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptuno"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Lárissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteu"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Tritão"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Plutão-Caronte"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Plutão"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Caronte"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Nouméa"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amaltéia"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Calisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galáxias"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "AMÉRICA DO NORTE"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "AMÉRICA DO SUL"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURÁSIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "ÁFRICA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRÁLIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTÁRCTICA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO NORTE"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO SUL"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO NORTE"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO SUL"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "OCEANO ÍNDICO"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ÁRTICO"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Acra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Adís Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Argel"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amã"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ancara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ashgabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Assunção"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Atenas"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdá"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Banguecoque"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Pequim"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirute"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlim"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Berna"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasília"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bruxelas"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bucareste"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapeste"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Cairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Camberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Cidade do Cabo"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Caiena"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conacry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damasco"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar-es-Salam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dacca"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "The Hague"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanói"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinque"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jacarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalém"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Cabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Cartum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Liubliana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lomé"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londres"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longuiarbien"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madri"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Malé"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamuzu"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Manágua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Cidade do México"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Mônaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monróvia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevidéu"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moscou"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Mascate"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Nova Deli"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicósia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Otawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panamá"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port of Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praga"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretória"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Roma"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "St Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipão"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San José"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago do Chile"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "São Tomé e Príncipe"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Saraievo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Cingapura"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipé"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa-Sul"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teerã"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tóquio"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Túnis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulan Bator"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valeta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "O Vale"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Cidade do Vaticano"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Vitória"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Viena"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Viantiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varsóvia"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Via Láctea"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "PNM"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "GNM"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Baricentro do Sistema Solar"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Hora de Verão"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Erro ao abrir o ficheiro de imagem "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Erro ao ler o ficheiro de configuração."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " objectos de céu profundo"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "A carregar o programa de fragmentos NV: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Erro ao carregar o programa de fragmentos NV: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Erro no programa de fragmentos"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "A inicializar o programa de fragmentos NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Todos os programas de fragmentos NV foram carregados com sucesso.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "A inicialzar os programas de fragmentos ARB . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galáxia (classe de Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Globular (raio do núcleo: %4.2f', concentração King: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "A carregar imagem do ficheiro "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Erro ao abrir o ficheiro de imagem "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " não é um ficheiro PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Carregando o modelo: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Erro ao carregar o modelo '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebulosa"
 
@@ -1308,92 +1541,92 @@ msgstr "Nebulosa"
 msgid "Open cluster"
 msgstr "Aglomerados Abertos"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Erro no ficheiro .ssc (linha"
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "aviso de definição duplicada de "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "superfície alternativa inválida"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "localização inválida"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Cabeçalho inválido para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Versão inválida para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "O carregamento do índice remissivo falhou no registo "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr "estrelas na base de dados de binárias\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Total de estrelas: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Erro no ficheiro .stc (linha"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrela inválida: classe espectral inválida.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrela inválida: classe espectral ausente.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " não existe.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrela inválida: ascensão recta ausente\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrela inválida: declinação ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrela inválida: distância ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrela inválida: magnitude ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "Estrela inválida: terá que especificar a magnitude absoluta (não a aparente) "
 "para a estrela perto da origem \n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Criando uma textura em mosaico. Largura="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Criando textura normal: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "A carregar o programa de vértices NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Erro ao carregar o programa de vértices NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Erro no programa de vértices "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "A carregar o programa de vértices ARB: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Erro ao carregar o programa de vértices ARB: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", linha "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "A inicializar o programa de vértices NV . . . \n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Todos os programas de vértices NV foram carregados com sucesso.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "A inicializar os programas de vértices ARB . . . \n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Todos os programas de vértices ARB foram carregados com sucesso.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Erro ao abrir "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Erro ao abrir o ficheiro de script."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erro ao abrir o script '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Erro desconhecido ao abrir o script"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Falha na inicialização da co-rotina do script"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Tipo de ficheiro inválido"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marcas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marcas desactivadas"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Ir para a superfície"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo altazimutal activado"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo altazimutal desactivado"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Forma das estrelas: Pontos Indistintos"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Forma das estrelas: Pontos"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Forma das estrelas: Discos à escala"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Caudas de cometa activadas"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Caudas de cometa desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Caminho de Renderização: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Modo altazimutal ativado"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Modo altazimutal desativado"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Magnitude automática activada"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Magnitude automática desactivada"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "O tempo e o script estão em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "O tempo está em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Retomar"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Total de estrelas: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Total de estrelas: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tempo de viagem da luz: %.4f anos "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Atraso da viagem da luz incluído"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Atraso da viagem da luz desligado"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Atraso da viagem da luz ignorado"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Usando texturas de superfície normais."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Usando texturas no limite do conhecimento de superfície "
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tempo: para a frente"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tempo: para trás"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Velocidade do tempo"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Alto"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Órbita Geoest."
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Fixar"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Limite de magnitude automática a 45 graus: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiente: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Ganho de luz"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Florescência activada"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Florescência desactivada"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Exposição"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Erro de GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vista demasiado pequena para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Panorama acrescentado"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "a.l."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "ua"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "segundos"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Velocidade: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diâmetro aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitude aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitude absoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distância: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Baricentro do sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs (apa): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Buraco negro"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Temp à superfície:"
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Companheiros planetários presentes\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distância do centro: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Ângulo de fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Seguir a rota "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Geoest. "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sol"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Nome do alvo: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr " A gravar"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Parar"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Erro ao ler o ficheiro de configuração."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Inicialização da livraria SPICE falhou."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Erro ao abrir o catálogo de céu profundo. "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Erro ao abrir o catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Erro ao abrir o ficheiro das fronteiras das constelações."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Falha na inicialização do motor de renderização"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Erro ao carregar a fonte; o texto não será visível.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Erro ao ler o índice remissivo "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Índice remissivo carregado "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Erro ao ler o ficheiro com o nome das estrelas\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Erro ao abrir "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Erro ao ler o ficheiro com o nome das estrelas\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Erro ao ler o ficheiro das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Erro ao abrir o catálogo de estrelas "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Erro ao abrir o script '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versão: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Erro desconhecido ao abrir o script"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Vendedor: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Motor de Renderização: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Nº máx. de texturas em simultâneo: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Erro ao criar o ficheiro ogg %s para captura.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Erro na livraria interna de Ogg."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navegador Celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navegador Celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -2433,21 +2633,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " objectos de céu profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
@@ -2456,463 +2655,514 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Hora"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Guia de Excursão"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Ecrã inteiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Erro ao abrir o ficheiro de imagem "
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Gravar como:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " não é um arquivo PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolução: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Imagens por segundo:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL copiado"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Carregando o URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Adicionar Nova Pasta de Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Extensões suportadas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Extensões suportadas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Acerca do Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>Linguagem de Sombreamento OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Vendedor: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "Versão GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Nº máx. de texturas em simultâneo: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Tamanho máx. de texturas: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Intervalo do tamanho dos pontos"
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Tamanho máx. de texturas: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Equatorial"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Informação do &Open GL"
+msgid "Renderer Info"
+msgstr "Motor de Renderização: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Capturar Imagem"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Capturar &Imagem...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Copiar URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL copiado"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferências do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "S&air"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegação"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Selecionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrar na Selecção\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selecção: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir para Objecto..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Hora"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Definir a Hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Visualização"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Mostrar Sombras das Nuvens"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Resolução das Texturas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Panorama"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Multipanorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividir o Panorama Verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir &Horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividir o Panorama Horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividir &Verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Alternar o Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Panorama individual"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Panorama &Individual\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Apagar Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Bordas Visíveis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Borda Activa Visível"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizar Hora"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Ajuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Preferências do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Acerca do Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Informação do &Open GL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Adicionar Marcardor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizar Marcadores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Carregando"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Duração"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Hora"
@@ -2921,79 +3171,77 @@ msgstr "Hora"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Nova Pasta..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Mostrar Grade Equatorial"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galáctico"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Eclíptica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Eclíptica"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marcas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Centrar na Seleção\tC"
@@ -3002,57 +3250,54 @@ msgstr "&Centrar na Seleção\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Constelações"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>Combiner NVIDIA, nenhum programa de vértices</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Fronteiras das Constelações"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Órbitas"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planetas Anões"
 
@@ -3062,19 +3307,17 @@ msgstr "Planetas Anões"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Luas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Luas Menores"
 
@@ -3084,12 +3327,12 @@ msgstr "Luas Menores"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteróides"
 
@@ -3099,12 +3342,12 @@ msgstr "Asteróides"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Cometas"
 
@@ -3114,14 +3357,15 @@ msgstr "Cometas"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Naves Espaciais"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Mais &Rápido\tL"
@@ -3130,9 +3374,8 @@ msgstr "10x Mais &Rápido\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Legendas"
 
@@ -3140,20 +3383,18 @@ msgstr "Legendas"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galáxias"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Globulares"
 
@@ -3161,7 +3402,7 @@ msgstr "Globulares"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3171,615 +3412,632 @@ msgstr "Enxames Abertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulosas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Localizações"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Enxames Abertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nuvens"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Luzes do Lado Nocturno"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Caudas dos Cometas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosferas"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Sombras dos Anéis"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Sombras dos Eclipses"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Sombras das Nuvens"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Baixo"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Médio"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Alto"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Magnitude automática activada"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Mais Estrelas Visíveis\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Menos Estrelas Visíveis\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Pontos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Pontos &Indistintos"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&Discos à Escala"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Atraso da viagem da luz desligado"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Marcas activadas"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Limite de magnitude automática a 45 graus: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distância (a.l.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag apa."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Mostrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Estrelas"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Com Planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Mostrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Quadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Mais"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Seta Esquerda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Seta Direita"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Seta para Cima"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Seta para Baixo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamanho:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Legendar as Feições"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "corpo pai '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Iníciar em tele cheia"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Duração"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Eclipses Lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Desmarcar &Todos"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Intervalo do tamanho dos pontos:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Eclipses Lunares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Objecto"
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Eclipses Solares"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Definir a Hora para Agora"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Carregando imagem do arquivo"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informação do OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Distância (anos-luz)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Tamanho: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Formato Local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Fuso Horário"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Desvio em relação ao GMT"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Início"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3798,21 +4056,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Ir para"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -3826,49 +4084,54 @@ msgid "Visible"
 msgstr "Bordas Visíveis"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Escolher o Modo de Visualização"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Encher Quadrado"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disco"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Pontos de Referência"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Mostrar Eixos"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Mostrar os Eixos das Bordas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Mostrar a Direcção do Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Mostrar o Vector de Velocidade"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Mostrar o Vector de Velocidade"
@@ -3876,191 +4139,41 @@ msgstr "Mostrar o Vector de Velocidade"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Mostrar a Direcção do Sol"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Mostrar a Grelha Planetográfica"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Mostrar o Terminador"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Superfícies alternativas"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Naves espaciais"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objetos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Fuso Horário: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Tempo Universal"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Tempo Local"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Fuso Horário: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Data"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Hora"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " horas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minutos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "segundos"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Data Juliana: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Data Juliana: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Definir a Hora..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Baricentro "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Estrela de neutrões"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planeta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Planeta Anão"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Luas Menores"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteróide"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Cometa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Pontos de Referência"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Calcular"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Tamanho Mínimo da Feição Legendada"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Erro desconhecido ao abrir o script"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteróides"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Pontos de Referência"
+msgid "Dwarf planets"
+msgstr "Planetas Anões"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4068,67 +4181,235 @@ msgstr "&Pontos de Referência"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Luas Menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Naves espaciais"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objetos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Fuso Horário: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Tempo Universal"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Tempo Local"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Fuso Horário: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Data"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Hora"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " horas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minutos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "segundos"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Data Juliana: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Data Juliana: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Definir a Hora..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Baricentro "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Estrela de neutrões"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planeta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Planeta Anão"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Luas Menores"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteróide"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Cometa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Pontos de Referência"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Calcular"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Tamanho Mínimo da Feição Legendada"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteróides"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Pontos de Referência"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Outras feições"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planetas"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Inverter o Tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x Mais &Lento\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Parar o Tempo"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Mais &Rápido\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Actualizar para a Hora Actual"
@@ -4200,7 +4481,6 @@ msgstr "Latitude: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "raio"
 
@@ -4221,7 +4501,7 @@ msgstr "Resolução: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizar Marcadores"
 
@@ -4252,18 +4532,6 @@ msgstr "Preferências do Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objectos"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Planetas Anões"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4354,49 +4622,43 @@ msgstr "Trajectórias Parciais"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Grelhas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Equatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galáctico"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Mostrar Fronteiras"
 
@@ -4430,7 +4692,6 @@ msgstr "Mostrar Nomes das Localizações"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Cidades"
 
@@ -4444,21 +4705,18 @@ msgstr "Sítios de Aterragem"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulcões"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatórios"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Crateras"
 
@@ -4493,7 +4751,6 @@ msgstr "Maria (Mares)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Outras feições"
 
@@ -4598,7 +4855,7 @@ msgstr "Formato: "
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Configuração"
 
@@ -4839,21 +5096,21 @@ msgid "&About Celestia"
 msgstr "&Acerca do Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4862,530 +5119,620 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2008, Grupo de Desenvolvimento do Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "O Celestia é software livre e não vem com qualquer garantia."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Seleccionar Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Nome do Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licença"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Controlos do Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informação do Driver OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Definir Hora da Simulação"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formato: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Actualizar para a Hora Actual"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Adicionar Marcardor"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Criar em >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nova Pasta..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navegador do Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Adicionar Nova Pasta de Marcadores"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Ir Para"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Nome da Pasta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Objectos do Sistema Solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Controlos do Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navegador Estelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Mais Próxima"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Mais Brilhante"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Com Planetas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Refrescar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Critério de Busca de Estrelas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Nº Máximo de Estrelas Apresentado na Lista"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Guia de Excursão"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Ir Para"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Escolha o seu destino:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Ir para Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objecto"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Distância"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Tamanho:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Escolher o Modo de Visualização"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Resolução"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Opções de Visualização"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Mostrar"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Calcular"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Visualização"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Definir Data e Ir para Planeta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Eclíptica"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Fechar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Órbitas / Legendas"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "De:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Nomes em Latim"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Texto Informativo"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Conciso"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parâmetros de busca"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Completo"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Seleccionar Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Sítios de Aterragem"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Nome do Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Montanhas)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Informação do Driver OpenGL"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Mares)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Ir para Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Vales)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Ir Para"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Massas de Terra)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objecto"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Legendar as Feições"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Distância"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licença"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Mostrar as Feições"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Legendar as Feições"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Tamanho Mínimo da Feição Legendada"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Adicionar Nova Pasta de Marcadores"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Tamanho:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Nome da Pasta"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Renomear Marcador ou Pasta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Novo Nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Buscador de eclipses"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Calcular"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formato: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Definir Data e Ir para Planeta"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Actualizar para a Hora Actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Fechar"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navegador do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "De:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Ir Para"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Objectos do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navegador Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parâmetros de busca"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Refrescar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Eclipses Solares"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Critério de Busca de Estrelas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Eclipses Lunares"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Guia de Excursão"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Escolha o seu destino:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Opções de Visualização"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Mostrar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Visualização"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Órbitas / Legendas"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Texto Informativo"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "0816"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Fev"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dez"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Out"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Set"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satélite"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Data"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Início"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Vendedor: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Modo em janela"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Motor de Renderização: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invisíveis"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Ó&rbita Geoest."
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Informação"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Mostrar Eixos"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Mostrar os Eixos das Bordas"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Mostrar a Direcção do Sol"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Mostrar o Vector de Velocidade"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Mostrar a Grelha Planetográfica"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Mostrar o Terminador"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satélites"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Corpos em órbita"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "A carregar: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "pt"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "A carregar o URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versão: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Versão GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Nº máx. de texturas em simultâneo: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Tamanho máx. de texturas: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Tamanho máx. de texturas: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Intervalo do tamanho dos pontos"
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Extensões suportadas: "
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Modo em janela"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invisíveis"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Ó&rbita Geoest."
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Informação"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Mostrar Eixos"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Mostrar os Eixos das Bordas"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Mostrar a Direcção do Sol"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Mostrar o Vector de Velocidade"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Mostrar a Grelha Planetográfica"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Mostrar o Terminador"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satélites"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Corpos em órbita"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "A carregar: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "pt"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "A carregar o URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Erro ao abrir o script"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Erro ao carregar o script"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "A executar o script"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Fuso Horário"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Desvio em relação ao GMT"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Erro ao abrir o ficheiro de script."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Erro ao abrir o script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Falha na inicialização da co-rotina do script"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Erro ao abrir o script '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Erro desconhecido ao abrir o script"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Erro ao abrir "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "A carregar o programa de fragmentos NV: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Erro ao carregar o programa de fragmentos NV: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Erro no programa de fragmentos"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "A inicializar o programa de fragmentos NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Todos os programas de fragmentos NV foram carregados com sucesso.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "A inicialzar os programas de fragmentos ARB . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "A carregar o programa de vértices NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Erro ao carregar o programa de vértices NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Erro no programa de vértices "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "A carregar o programa de vértices ARB: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Erro ao carregar o programa de vértices ARB: "
+
+#~ msgid ", line "
+#~ msgstr ", linha "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "A inicializar o programa de vértices NV . . . \n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Todos os programas de vértices NV foram carregados com sucesso.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "A inicializar os programas de vértices ARB . . . \n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Todos os programas de vértices ARB foram carregados com sucesso.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Erro desconhecido ao abrir o script"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Copiar URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL copiado"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Marcas activadas"
+
+#~ msgid "Nearest"
+#~ msgstr "Mais Próxima"
+
+#~ msgid "Brightest"
+#~ msgstr "Mais Brilhante"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Com Planetas"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Eclíptica"
+
+#~ msgid "Latin Names"
+#~ msgstr "Nomes em Latim"
+
+#~ msgid "Terse"
+#~ msgstr "Conciso"
+
+#~ msgid "Verbose"
+#~ msgstr "Completo"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Sítios de Aterragem"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Montanhas)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Mares)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Vales)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Massas de Terra)"
+
+#~ msgid "Label Features"
+#~ msgstr "Legendar as Feições"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Eclipses Solares"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Eclipses Lunares"
+
+#~ msgid "Vendor: "
+#~ msgstr "Vendedor: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Versão GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Extensões suportadas: "
+
+#~ msgid "Error opening script"
+#~ msgstr "Erro ao abrir o script"
+
+#~ msgid "Error loading script"
+#~ msgstr "Erro ao carregar o script"
+
+#~ msgid "Running script"
+#~ msgstr "A executar o script"
 
 #~ msgid "Invisible"
 #~ msgstr "Invisíveis"

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -27,12 +27,12 @@ msgstr "Mercur"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Pământ"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Lună"
 
@@ -48,140 +48,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymede"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturn"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tethys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phoebe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uranus"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptun"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereid"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluto"
 
@@ -190,1033 +190,1292 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
-msgid "NORTH AMERICA"
-msgstr "AMERICA DE NORD"
+msgid "Styx"
+msgstr ""
 
 #: ../data/data.cpp:43
-msgid "SOUTH AMERICA"
-msgstr "AMERICA DE SUD"
+msgid "Nix"
+msgstr ""
 
 #: ../data/data.cpp:44
-msgid "EURASIA"
-msgstr "EURASIA"
+msgid "Kerberos"
+msgstr ""
 
 #: ../data/data.cpp:45
-msgid "AFRICA"
-msgstr "AFRICA"
+msgid "Hydra"
+msgstr ""
 
 #: ../data/data.cpp:46
-msgid "AUSTRALIA"
-msgstr "AUSTRALIA"
+msgid "Haumea"
+msgstr ""
 
 #: ../data/data.cpp:47
-msgid "ANTARCTICA"
-msgstr "ANTARCTICA"
+msgid "Namaka"
+msgstr ""
 
 #: ../data/data.cpp:48
-msgid "NORTH ATLANTIC OCEAN"
-msgstr "OCEANUL ATLANTIC DE NORD"
+msgid "Hi'iaka"
+msgstr ""
 
 #: ../data/data.cpp:49
-msgid "SOUTH ATLANTIC OCEAN"
-msgstr "OCEANUL ATLANTIC DE SUD"
+msgid "Makemake"
+msgstr ""
 
 #: ../data/data.cpp:50
-msgid "NORTH PACIFIC OCEAN"
-msgstr "OCEANUL PACIFIC DE NORD"
+msgid "S-2015 136472 I"
+msgstr ""
 
 #: ../data/data.cpp:51
-msgid "SOUTH PACIFIC OCEAN"
-msgstr "OCEANUL PACIFIC DE SUD"
+msgid "Eris"
+msgstr ""
 
 #: ../data/data.cpp:52
-msgid "INDIAN OCEAN"
-msgstr "OCEANUL INDIAN"
+msgid "Dysnomia"
+msgstr ""
 
 #: ../data/data.cpp:53
-msgid "ARCTIC OCEAN"
-msgstr "OCEANUL ARCTIC"
+msgid "Metis"
+msgstr ""
 
 #: ../data/data.cpp:54
-msgid "Abu Dhabi"
+msgid "Adrastea"
 msgstr ""
 
 #: ../data/data.cpp:55
-msgid "Abuja"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: ../data/data.cpp:56
-msgid "Accra"
+msgid "Thebe"
 msgstr ""
 
 #: ../data/data.cpp:57
-msgid "Adamstown"
+msgid "Themisto"
 msgstr ""
 
 #: ../data/data.cpp:58
-msgid "Addis Ababa"
+msgid "Leda"
 msgstr ""
 
 #: ../data/data.cpp:59
-msgid "Algiers"
+msgid "Himalia"
 msgstr ""
 
 #: ../data/data.cpp:60
-msgid "Alofi"
+msgid "Lysithea"
 msgstr ""
 
 #: ../data/data.cpp:61
-msgid "Amman"
+msgid "Elara"
 msgstr ""
 
 #: ../data/data.cpp:62
-msgid "Amsterdam"
+msgid "Iocaste"
 msgstr ""
 
 #: ../data/data.cpp:63
-msgid "Andorra la Vella"
+msgid "Praxidike"
 msgstr ""
 
 #: ../data/data.cpp:64
-msgid "Ankara"
+msgid "Harpalyke"
 msgstr ""
 
 #: ../data/data.cpp:65
-msgid "Antananarivo"
+msgid "Ananke"
 msgstr ""
 
 #: ../data/data.cpp:66
-msgid "Apia"
+msgid "Isonoe"
 msgstr ""
 
 #: ../data/data.cpp:67
-msgid "Ashgabat"
+msgid "Erinome"
 msgstr ""
 
 #: ../data/data.cpp:68
-msgid "Asmara"
+msgid "Taygete"
 msgstr ""
 
 #: ../data/data.cpp:69
-msgid "Astana"
+msgid "Chaldene"
 msgstr ""
 
 #: ../data/data.cpp:70
-msgid "Asuncion"
+msgid "Carme"
 msgstr ""
 
 #: ../data/data.cpp:71
-msgid "Athens"
+msgid "Pasiphae"
 msgstr ""
 
 #: ../data/data.cpp:72
-msgid "Avarua"
+msgid "Kalyke"
 msgstr ""
 
 #: ../data/data.cpp:73
-msgid "Baghdad"
+msgid "Megaclite"
 msgstr ""
 
 #: ../data/data.cpp:74
-msgid "Baku"
+msgid "Sinope"
 msgstr ""
 
 #: ../data/data.cpp:75
-msgid "Bamako"
-msgstr ""
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
 
 #: ../data/data.cpp:76
-msgid "Bandar Seri Begawan"
-msgstr ""
+#, fuzzy
+msgid "Pan"
+msgstr "Ian"
 
 #: ../data/data.cpp:77
-msgid "Bangkok"
+msgid "Atlas"
 msgstr ""
 
 #: ../data/data.cpp:78
-msgid "Bangui"
-msgstr ""
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
 
 #: ../data/data.cpp:79
-msgid "Banjul"
+msgid "Calypso"
 msgstr ""
 
 #: ../data/data.cpp:80
-msgid "Basse-Terre"
+msgid "Helene"
 msgstr ""
 
 #: ../data/data.cpp:81
-msgid "Basseterre"
+msgid "Cordelia"
 msgstr ""
 
 #: ../data/data.cpp:82
-msgid "Beijing"
+msgid "Ophelia"
 msgstr ""
 
 #: ../data/data.cpp:83
-msgid "Beirut"
+msgid "Bianca"
 msgstr ""
 
 #: ../data/data.cpp:84
-msgid "Belgrade"
+msgid "Cressida"
 msgstr ""
 
 #: ../data/data.cpp:85
-msgid "Belmopan"
+msgid "Desdemona"
 msgstr ""
 
 #: ../data/data.cpp:86
-msgid "Berlin"
+msgid "Juliet"
 msgstr ""
 
 #: ../data/data.cpp:87
-msgid "Bern"
+msgid "Portia"
 msgstr ""
 
 #: ../data/data.cpp:88
-msgid "Bishkek"
+msgid "Rosalind"
 msgstr ""
 
 #: ../data/data.cpp:89
-msgid "Bissau"
+msgid "Belinda"
 msgstr ""
 
 #: ../data/data.cpp:90
-msgid "Bloemfontein"
+msgid "Puck"
 msgstr ""
 
 #: ../data/data.cpp:91
-msgid "Bogota"
+msgid "Caliban"
 msgstr ""
 
 #: ../data/data.cpp:92
-msgid "Brasilia"
+msgid "Stephano"
 msgstr ""
 
 #: ../data/data.cpp:93
-msgid "Bratislava"
+msgid "Sycorax"
 msgstr ""
 
 #: ../data/data.cpp:94
-msgid "Brazzaville"
+msgid "Prospero"
 msgstr ""
 
 #: ../data/data.cpp:95
-msgid "Bridgetown"
+msgid "Setebos"
 msgstr ""
 
 #: ../data/data.cpp:96
-msgid "Brussels"
+msgid "Naiad"
 msgstr ""
 
 #: ../data/data.cpp:97
-msgid "Bucharest"
+msgid "Thalassa"
 msgstr ""
 
 #: ../data/data.cpp:98
-msgid "Budapest"
+msgid "Despina"
 msgstr ""
 
 #: ../data/data.cpp:99
-msgid "Buenos Aires"
-msgstr ""
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxi"
 
 #: ../data/data.cpp:100
-msgid "Bujumbura"
-msgstr ""
+msgid "NORTH AMERICA"
+msgstr "AMERICA DE NORD"
 
 #: ../data/data.cpp:101
-msgid "Cairo"
-msgstr ""
+msgid "SOUTH AMERICA"
+msgstr "AMERICA DE SUD"
 
 #: ../data/data.cpp:102
-msgid "Canberra"
-msgstr ""
+msgid "EURASIA"
+msgstr "EURASIA"
 
 #: ../data/data.cpp:103
-msgid "Cape Town"
-msgstr ""
+msgid "AFRICA"
+msgstr "AFRICA"
 
 #: ../data/data.cpp:104
-msgid "Caracas"
-msgstr ""
+msgid "AUSTRALIA"
+msgstr "AUSTRALIA"
 
 #: ../data/data.cpp:105
-msgid "Castries"
-msgstr ""
+msgid "ANTARCTICA"
+msgstr "ANTARCTICA"
 
 #: ../data/data.cpp:106
-msgid "Cayenne"
-msgstr ""
+msgid "NORTH ATLANTIC OCEAN"
+msgstr "OCEANUL ATLANTIC DE NORD"
 
 #: ../data/data.cpp:107
-msgid "Charlotte Amalie"
-msgstr ""
+msgid "SOUTH ATLANTIC OCEAN"
+msgstr "OCEANUL ATLANTIC DE SUD"
 
 #: ../data/data.cpp:108
-msgid "Chisinau"
-msgstr ""
+msgid "NORTH PACIFIC OCEAN"
+msgstr "OCEANUL PACIFIC DE NORD"
 
 #: ../data/data.cpp:109
-msgid "Colombo"
-msgstr ""
+msgid "SOUTH PACIFIC OCEAN"
+msgstr "OCEANUL PACIFIC DE SUD"
 
 #: ../data/data.cpp:110
-msgid "Conakry"
-msgstr ""
+msgid "INDIAN OCEAN"
+msgstr "OCEANUL INDIAN"
 
 #: ../data/data.cpp:111
-msgid "Copenhagen"
-msgstr ""
+msgid "ARCTIC OCEAN"
+msgstr "OCEANUL ARCTIC"
 
 #: ../data/data.cpp:112
-msgid "Cotonou"
+msgid "Abu Dhabi"
 msgstr ""
 
 #: ../data/data.cpp:113
-msgid "Dakar"
+msgid "Abuja"
 msgstr ""
 
 #: ../data/data.cpp:114
-msgid "Damascus"
+msgid "Accra"
 msgstr ""
 
 #: ../data/data.cpp:115
-msgid "Dar es Salaam"
+msgid "Adamstown"
 msgstr ""
 
 #: ../data/data.cpp:116
-msgid "Dhaka"
+msgid "Addis Ababa"
 msgstr ""
 
 #: ../data/data.cpp:117
-msgid "Dili"
+msgid "Algiers"
 msgstr ""
 
 #: ../data/data.cpp:118
-msgid "Djibouti"
+msgid "Alofi"
 msgstr ""
 
 #: ../data/data.cpp:119
-msgid "Doha"
+msgid "Amman"
 msgstr ""
 
 #: ../data/data.cpp:120
-msgid "Douglas"
+msgid "Amsterdam"
 msgstr ""
 
 #: ../data/data.cpp:121
-msgid "Dublin"
+msgid "Andorra la Vella"
 msgstr ""
 
 #: ../data/data.cpp:122
-msgid "Dushanbe"
+msgid "Ankara"
 msgstr ""
 
 #: ../data/data.cpp:123
-msgid "Fongafale"
+msgid "Antananarivo"
 msgstr ""
 
 #: ../data/data.cpp:124
-msgid "Fort-de-France"
+msgid "Apia"
 msgstr ""
 
 #: ../data/data.cpp:125
-msgid "Freetown"
+msgid "Ashgabat"
 msgstr ""
 
 #: ../data/data.cpp:126
-msgid "Gaborone"
+msgid "Asmara"
 msgstr ""
 
 #: ../data/data.cpp:127
-msgid "George Town"
+msgid "Astana"
 msgstr ""
 
 #: ../data/data.cpp:128
-msgid "Georgetown"
+msgid "Asuncion"
 msgstr ""
 
 #: ../data/data.cpp:129
-msgid "Gibraltar"
+msgid "Athens"
 msgstr ""
 
 #: ../data/data.cpp:130
-msgid "Grand Turk"
+msgid "Avarua"
 msgstr ""
 
 #: ../data/data.cpp:131
-msgid "Guatemala"
+msgid "Baghdad"
 msgstr ""
 
 #: ../data/data.cpp:132
-msgid "Hagatna"
+msgid "Baku"
 msgstr ""
 
 #: ../data/data.cpp:133
-msgid "The Hague"
+msgid "Bamako"
 msgstr ""
 
 #: ../data/data.cpp:134
-msgid "Hamilton"
+msgid "Bandar Seri Begawan"
 msgstr ""
 
 #: ../data/data.cpp:135
-msgid "Hanoi"
+msgid "Bangkok"
 msgstr ""
 
 #: ../data/data.cpp:136
-msgid "Harare"
+msgid "Bangui"
 msgstr ""
 
 #: ../data/data.cpp:137
-msgid "Havana"
+msgid "Banjul"
 msgstr ""
 
 #: ../data/data.cpp:138
-msgid "Helsinki"
+msgid "Basse-Terre"
 msgstr ""
 
 #: ../data/data.cpp:139
-msgid "Honiara"
+msgid "Basseterre"
 msgstr ""
 
 #: ../data/data.cpp:140
-msgid "Islamabad"
+msgid "Beijing"
 msgstr ""
 
 #: ../data/data.cpp:141
-msgid "Jakarta"
+msgid "Beirut"
 msgstr ""
 
 #: ../data/data.cpp:142
-msgid "Jamestown"
+msgid "Belgrade"
 msgstr ""
 
 #: ../data/data.cpp:143
-msgid "Jerusalem"
+msgid "Belmopan"
 msgstr ""
 
 #: ../data/data.cpp:144
-msgid "Kabul"
+msgid "Berlin"
 msgstr ""
 
 #: ../data/data.cpp:145
-msgid "Kampala"
+msgid "Bern"
 msgstr ""
 
 #: ../data/data.cpp:146
-msgid "Kathmandu"
+msgid "Bishkek"
 msgstr ""
 
 #: ../data/data.cpp:147
-msgid "Khartoum"
+msgid "Bissau"
 msgstr ""
 
 #: ../data/data.cpp:148
-msgid "Kiev"
+msgid "Bloemfontein"
 msgstr ""
 
 #: ../data/data.cpp:149
-msgid "Kigali"
+msgid "Bogota"
 msgstr ""
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
-msgid "Kingston"
+#: ../data/data.cpp:150
+msgid "Brasilia"
+msgstr ""
+
+#: ../data/data.cpp:151
+msgid "Bratislava"
 msgstr ""
 
 #: ../data/data.cpp:152
-msgid "Kingstown"
+msgid "Brazzaville"
 msgstr ""
 
 #: ../data/data.cpp:153
-msgid "Kinshasa"
+msgid "Bridgetown"
 msgstr ""
 
 #: ../data/data.cpp:154
-msgid "Koror"
+msgid "Brussels"
 msgstr ""
 
 #: ../data/data.cpp:155
-msgid "Kuala Lumpur"
+msgid "Bucharest"
 msgstr ""
 
 #: ../data/data.cpp:156
-msgid "Kuwait"
+msgid "Budapest"
 msgstr ""
 
 #: ../data/data.cpp:157
-msgid "La'youn"
+msgid "Buenos Aires"
 msgstr ""
 
 #: ../data/data.cpp:158
-msgid "La Paz"
+msgid "Bujumbura"
 msgstr ""
 
 #: ../data/data.cpp:159
-msgid "Libreville"
+msgid "Cairo"
 msgstr ""
 
 #: ../data/data.cpp:160
-msgid "Lilongwe"
+msgid "Canberra"
 msgstr ""
 
 #: ../data/data.cpp:161
-msgid "Lima"
+msgid "Cape Town"
 msgstr ""
 
 #: ../data/data.cpp:162
-msgid "Lisbon"
+msgid "Caracas"
 msgstr ""
 
 #: ../data/data.cpp:163
-msgid "Ljubljana"
+msgid "Castries"
 msgstr ""
 
 #: ../data/data.cpp:164
-msgid "Lobamba"
+msgid "Cayenne"
 msgstr ""
 
 #: ../data/data.cpp:165
-msgid "Lome"
+msgid "Charlotte Amalie"
 msgstr ""
 
 #: ../data/data.cpp:166
-msgid "London"
+msgid "Chisinau"
 msgstr ""
 
 #: ../data/data.cpp:167
-msgid "Longyearbyen"
+msgid "Colombo"
 msgstr ""
 
 #: ../data/data.cpp:168
-msgid "Luanda"
+msgid "Conakry"
 msgstr ""
 
 #: ../data/data.cpp:169
-msgid "Lusaka"
+msgid "Copenhagen"
 msgstr ""
 
 #: ../data/data.cpp:170
-msgid "Luxembourg"
+msgid "Cotonou"
 msgstr ""
 
 #: ../data/data.cpp:171
-msgid "Madrid"
+msgid "Dakar"
 msgstr ""
 
 #: ../data/data.cpp:172
-msgid "Majuro"
+msgid "Damascus"
 msgstr ""
 
 #: ../data/data.cpp:173
-msgid "Malabo"
+msgid "Dar es Salaam"
 msgstr ""
 
 #: ../data/data.cpp:174
-msgid "Male"
+msgid "Dhaka"
 msgstr ""
 
 #: ../data/data.cpp:175
-msgid "Mamoutzou"
+msgid "Dili"
 msgstr ""
 
 #: ../data/data.cpp:176
-msgid "Managua"
+msgid "Djibouti"
 msgstr ""
 
 #: ../data/data.cpp:177
-msgid "Manama"
+msgid "Doha"
 msgstr ""
 
 #: ../data/data.cpp:178
-msgid "Manila"
+msgid "Douglas"
 msgstr ""
 
 #: ../data/data.cpp:179
-msgid "Maputo"
+msgid "Dublin"
 msgstr ""
 
 #: ../data/data.cpp:180
-msgid "Maseru"
+msgid "Dushanbe"
 msgstr ""
 
 #: ../data/data.cpp:181
-msgid "Mata-Utu"
+msgid "Fongafale"
 msgstr ""
 
 #: ../data/data.cpp:182
-msgid "Mbabane"
+msgid "Fort-de-France"
 msgstr ""
 
 #: ../data/data.cpp:183
+msgid "Freetown"
+msgstr ""
+
+#: ../data/data.cpp:184
+msgid "Gaborone"
+msgstr ""
+
+#: ../data/data.cpp:185
+msgid "George Town"
+msgstr ""
+
+#: ../data/data.cpp:186
+msgid "Georgetown"
+msgstr ""
+
+#: ../data/data.cpp:187
+msgid "Gibraltar"
+msgstr ""
+
+#: ../data/data.cpp:188
+msgid "Grand Turk"
+msgstr ""
+
+#: ../data/data.cpp:189
+msgid "Guatemala"
+msgstr ""
+
+#: ../data/data.cpp:190
+msgid "Hagatna"
+msgstr ""
+
+#: ../data/data.cpp:191
+msgid "The Hague"
+msgstr ""
+
+#: ../data/data.cpp:192
+msgid "Hamilton"
+msgstr ""
+
+#: ../data/data.cpp:193
+msgid "Hanoi"
+msgstr ""
+
+#: ../data/data.cpp:194
+msgid "Harare"
+msgstr ""
+
+#: ../data/data.cpp:195
+msgid "Havana"
+msgstr ""
+
+#: ../data/data.cpp:196
+msgid "Helsinki"
+msgstr ""
+
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
+msgid "Honiara"
+msgstr ""
+
+#: ../data/data.cpp:198
+msgid "Islamabad"
+msgstr ""
+
+#: ../data/data.cpp:199
+msgid "Jakarta"
+msgstr ""
+
+#: ../data/data.cpp:200
+msgid "Jamestown"
+msgstr ""
+
+#: ../data/data.cpp:201
+msgid "Jerusalem"
+msgstr ""
+
+#: ../data/data.cpp:202
+msgid "Kabul"
+msgstr ""
+
+#: ../data/data.cpp:203
+msgid "Kampala"
+msgstr ""
+
+#: ../data/data.cpp:204
+msgid "Kathmandu"
+msgstr ""
+
+#: ../data/data.cpp:205
+msgid "Khartoum"
+msgstr ""
+
+#: ../data/data.cpp:206
+msgid "Kiev"
+msgstr ""
+
+#: ../data/data.cpp:207
+msgid "Kigali"
+msgstr ""
+
+#: ../data/data.cpp:208 ../data/data.cpp:209
+msgid "Kingston"
+msgstr ""
+
+#: ../data/data.cpp:210
+msgid "Kingstown"
+msgstr ""
+
+#: ../data/data.cpp:211
+msgid "Kinshasa"
+msgstr ""
+
+#: ../data/data.cpp:212
+msgid "Koror"
+msgstr ""
+
+#: ../data/data.cpp:213
+msgid "Kuala Lumpur"
+msgstr ""
+
+#: ../data/data.cpp:214
+msgid "Kuwait"
+msgstr ""
+
+#: ../data/data.cpp:215
+msgid "La'youn"
+msgstr ""
+
+#: ../data/data.cpp:216
+msgid "La Paz"
+msgstr ""
+
+#: ../data/data.cpp:217
+msgid "Libreville"
+msgstr ""
+
+#: ../data/data.cpp:218
+msgid "Lilongwe"
+msgstr ""
+
+#: ../data/data.cpp:219
+msgid "Lima"
+msgstr ""
+
+#: ../data/data.cpp:220
+msgid "Lisbon"
+msgstr ""
+
+#: ../data/data.cpp:221
+msgid "Ljubljana"
+msgstr ""
+
+#: ../data/data.cpp:222
+msgid "Lobamba"
+msgstr ""
+
+#: ../data/data.cpp:223
+msgid "Lome"
+msgstr ""
+
+#: ../data/data.cpp:224
+msgid "London"
+msgstr ""
+
+#: ../data/data.cpp:225
+msgid "Longyearbyen"
+msgstr ""
+
+#: ../data/data.cpp:226
+msgid "Luanda"
+msgstr ""
+
+#: ../data/data.cpp:227
+msgid "Lusaka"
+msgstr ""
+
+#: ../data/data.cpp:228
+msgid "Luxembourg"
+msgstr ""
+
+#: ../data/data.cpp:229
+msgid "Madrid"
+msgstr ""
+
+#: ../data/data.cpp:230
+msgid "Majuro"
+msgstr ""
+
+#: ../data/data.cpp:231
+msgid "Malabo"
+msgstr ""
+
+#: ../data/data.cpp:232
+msgid "Male"
+msgstr ""
+
+#: ../data/data.cpp:233
+msgid "Mamoutzou"
+msgstr ""
+
+#: ../data/data.cpp:234
+msgid "Managua"
+msgstr ""
+
+#: ../data/data.cpp:235
+msgid "Manama"
+msgstr ""
+
+#: ../data/data.cpp:236
+msgid "Manila"
+msgstr ""
+
+#: ../data/data.cpp:237
+msgid "Maputo"
+msgstr ""
+
+#: ../data/data.cpp:238
+msgid "Maseru"
+msgstr ""
+
+#: ../data/data.cpp:239
+msgid "Mata-Utu"
+msgstr ""
+
+#: ../data/data.cpp:240
+msgid "Mbabane"
+msgstr ""
+
+#: ../data/data.cpp:241
 #, fuzzy
 msgid "Mexico City"
 msgstr "Randarizează locaţiile oraşelor"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr ""
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr ""
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr ""
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr ""
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr ""
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr ""
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr ""
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr ""
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr ""
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr ""
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr ""
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 #, fuzzy
 msgid "New Delhi"
 msgstr "Adaugă dosar nou pentru marcaje"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr ""
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr ""
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr ""
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr ""
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr ""
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr ""
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr ""
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr ""
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr ""
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr ""
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr ""
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr ""
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr ""
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr ""
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr ""
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr ""
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr ""
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr ""
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr ""
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr ""
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 #, fuzzy
 msgid "Port-au-Prince"
 msgstr " ua/s"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr ""
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr ""
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr ""
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr ""
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr ""
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr ""
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr ""
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr ""
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr ""
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr ""
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr ""
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr ""
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr ""
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr ""
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr ""
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr ""
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr ""
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr ""
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr ""
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr ""
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr ""
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr ""
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr ""
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr ""
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr ""
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr ""
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr ""
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr ""
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr ""
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr ""
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr ""
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr ""
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr ""
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr ""
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr ""
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr ""
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr ""
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr ""
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr ""
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr ""
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr ""
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr ""
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr ""
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr ""
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr ""
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr ""
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr ""
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr ""
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr ""
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr ""
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr ""
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr ""
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr ""
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr ""
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr ""
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr ""
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr ""
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr ""
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr ""
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 #, fuzzy
 msgid "Vatican City"
 msgstr "Randarizează locaţiile oraşelor"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr ""
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr ""
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr ""
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr ""
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr ""
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr ""
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr ""
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 #, fuzzy
 msgid "West Island"
 msgstr "Vest"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr ""
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr ""
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr ""
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr ""
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr ""
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr ""
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr ""
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Calea Lactee"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Micul nor al lui Magellan"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Marele nor al lui Magellan"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Baricentrul sistemului solar"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "ora de vară"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "ora de iarnă"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Eroare la deschiderea fişierului imagine "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Eroare la citirea fişierului de configurare."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1226,88 +1485,58 @@ msgstr "ora de iarnă"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " obiect cerestru îndepărtat"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Încărcarea programului de fragmentare NV:"
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Eroare la încărcarea programului de fragmentare NV:"
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Eroare în programul de fragmentare"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Iniţializarea programelor de fragmentare NV...\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Toate programele de fragmentare NV au fost încărcate.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Iniţializarea programelor de fragmentare ARB...\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxie (tip Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Încărcarea imaginei din fişier "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ""
-": formatul fişierului imagine este necunoscut sau nu este implementat.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Eroare la deschiderea fişierului imagine "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "nu este un fişier PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Eroare la citirea fişierului cu imagine PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Încărcarea modelului: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Eroare la încărcarea modelului '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 #, fuzzy
 msgid "Nebula"
 msgstr "Randarizează numele nebuloaselor"
@@ -1317,92 +1546,92 @@ msgstr "Randarizează numele nebuloaselor"
 msgid "Open cluster"
 msgstr "Randarizează numele roiurilor deschise"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Eroare in fişierul .scc (linia "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Atenţie, definiţie dublă pentru "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "textură alternativă invalidă"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "locaţie invalidă"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Antet invalid pentru indexul încrucişat\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Versiune invalidă pentru indexul incrucişat\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Încărcarea indexului încrucişat a eşual la înregistrarea "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Tip spectral invalid în baza de date stelară, steaua #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr "stele în baza de date binară\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Număr total de stele: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Eroare în fişierul .stc (linia "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Stea invalidă: tip spectral invalid.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Stea invalidă: tipul spectral lipseste.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " nu există.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Stea invalidă: lipseşte ascensiunea dreaptă\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Stea invalidă: lipseşte declinaţia.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Stea invalidă: lipseşte distanţa.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Stea invalidă: lipseşte magnitudinea.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1410,767 +1639,743 @@ msgstr ""
 "Stea invalidă: magnitudinea absolută (nu cea aparentă) trebuie specificată "
 "pentru o stea aproape de origine\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Crearea texturii de pavaj. Laţime="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Crearea texturii: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Încărcarea programului NV vertex: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Eroare la încărcarea programului NV vertex: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Eroare îin programul vertex "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Încărcarea programului ARB vertex: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Eraoare la încărcarea programului ARB vertex"
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", linia "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Iniţializarea programelor NV vertex...\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Toate programele NV vertex au fos încărcate cu succes.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Iniţializarea programelorARB vertex...\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Toate programele ARB vertex au fost încarcate cu succes.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Eroare la deschiderea "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Eroare la citirea fişierului cu imagine PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Eroare la citirea fişierului."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Eroare la deschiderea fişierului script."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Eroare la deschiderea scriptului '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Eroare necunoscută la deschiderea scriptului"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Iniţializarea corutinei scriptului a eşuat"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Tipul fişierului este invalid"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudinea limită: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Marcaje activate"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Marcaje dezactivate"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Mergi la suprafaţa"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Modul alt-azimuth activat"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Modul alt-azimuth dezactivat"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Stilul stelelor: puncte vagi"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Stilul stelelor: puncte"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Stilul stelelor: discuri la scală"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Coada cometelor activată"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Coada cometelor dezactivată"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Calea de ranbarizare: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Modul alt-azimuth activat"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Modul alt-azimuth dezactivat"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Magnitudinea automată activată"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Magnitudinea automată dezactivată"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Anulare"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Timpul şi scriptul sunt pe pauză"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Timpul este pe pauză"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Revenire"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Număr total de stele: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Număr total de stele: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Timpul de călătorie al luminii: %.4f al"
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Timpul de călătorie al luminii: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Timpul de călătorie al luminii: %d o %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Include întârzierea de timp necesar luminii pentru călătorie"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Întârzierea de timp necesar luminii pentru călătorie oprită"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Ignoră întârzierea de timp necesar luminii pentru călătorie"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Utilizează texturi normale pentru suprafaţă."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Utilizează texturi limitate de cunoaşterea actuala pentru suprafaţă."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Urmează"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Timpul: Crescător"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Timpul: Descrescător"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Rata timpului"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturi"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturi"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturi"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Orbitare sincronă"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Blocheaza"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Urmareşte"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudinea limită: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Magnitudinea limită automată pentru 45 de grade: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Nivelul luminii ambientale: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Amplificare luminoasă"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Efectul Bloom activat"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Efectul Bloom dezactivat"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Expunere"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Eroare GL:"
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vedere prea mică pentru a fi împărţită"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Vedere adăugată"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "ua"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " zile"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " ore"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minute"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr "Seteaza timpul"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " ua/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Viteza: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diametru aparent: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitudine aparentă: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitudine absolută: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distanţă: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Baricentrul sistemului stelar\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs. (aparentă): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Luminozitate: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Stea de neutroni"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Gaura neagra"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clasa: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Temperatura la suprafaţă: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Raza: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Raza: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Însoţitor planetar prezent\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distanţa de la centru: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raza: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Timp real"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Timp real"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Timp oprit"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " mai repede"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " mai încet"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pauză)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "IPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Pe drum"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Pe drum"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rută"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Urmează "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Orbită sincronă"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Urmăreşte"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Soare"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Numele ţintei: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "  Pauză"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Înregistrează"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pauză    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Mod de editare"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Încărcarea catalogului sistemului solar: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Încărcarea catalogului sistemului solar: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Eroare la citirea fişierului de configurare."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Iniţializarea librăriei SPICE a eşuat."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Baza de date stelara nu poate fi citită."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Eroare la deschiderea catalogului cu obiecte cerestre îndepărtate."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Baza de date stelara nu poate fi citită."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Eroare la deschiderea catalogului sistemului solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Eroare la deschiderea fişierului asterisms."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Eroare la deschiderea fişierelor cu limitele constelaţiilor."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Eşuare la iniţializarea motorului de randarizare"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Eroare la încarcarea fontului; textul nu va fi vizibil.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Eroare la citirea indexului încrucişat "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Indexul incrucişat a fost încărcat "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Eroare la deschiderea fişierului cu numele stelelor\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Eroare la deschiderea "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Eroare la deschiderea fişierului cu numele stelelor\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Eroare la citirea fişierului pentru stele\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Eroare la deschiderea catalogului stelar "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Eroare la deschiderea scriptului '%s'"
+msgid "%s Version: %s\n"
+msgstr "Versiune: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Eroare necunoscută la deschiderea scriptului"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Furnizor: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Motor de randarizare: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Număr maxim de texturi simultane:"
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Mărimea maximă a texturii: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Plaja dimensiunilor pentru puncte: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Plaja dimensiunilor pentru puncte: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Mărimea maximă a texturii cubice: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2366,14 +2571,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Eroare la crearea fişierului ogg %s pentru captură.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Eroare interna a librăriei Ogg."
@@ -2392,46 +2597,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Navigator celest"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navigator celest"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Sistem solar"
 
@@ -2441,21 +2637,20 @@ msgstr "Sistem solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Stele"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " obiect cerestru îndepărtat"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Caută eclipse"
@@ -2464,463 +2659,514 @@ msgstr "Caută eclipse"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Timp"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Tur de iniţiere..."
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Pe tot ecranul"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Captură &video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Eroare la deschiderea fişierului asterisms."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Adaugă marcaje..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Salvează ca:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "nu este un fişier PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Rezoluţie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Viteza de randarizare:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL-ul copiat"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Încarcare URL-ul"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Deschide script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crează un dosar nou pentru marcaje în meniul curent"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Eroare necunoscută la deschiderea scriptului"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Extensii suportate: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Extensii suportate: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Despre Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>Limbajul de randarizare OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Furnizor: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "Versiune GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Număr maxim de texturi simultane:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Mărimea maximă a texturii: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Plaja dimensiunilor pentru puncte: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Plaja dimensiunilor pentru puncte: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Mărimea maximă a texturii cubice: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Raza: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Informaţii OpenGL"
+msgid "Renderer Info"
+msgstr "Motor de randarizare: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fişier"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Captură imagine"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Captură &imagine...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Captură &video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiază URL-ul"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Copiază URL-ul"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL-ul copiat"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Deschide script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferinţe pentru Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "I&eşire"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigare"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Selectează"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrează selecţia\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selecţia: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Mergi la obiect..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Timp"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Seteaza timpul"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Afişaj"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Obiectele marcate"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Randarizează umbra norilor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Formatul stelelor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Rezoluţia &texturilor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controale"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "Marca&je"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vizualizare"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vederi multiple"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Împarte vederea pe verticală"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Împarte &orizontal\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "împarte vederea pe orizontală"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Împarte &vertical\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Parcurge vederile ciclic"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "O singură vedere"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "O &singură vedere\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Şterge vederea"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Şterge"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Vederi vizibile"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Vederea activă vizibilă"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizează timpul"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Ajutor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Preferinţe pentru Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Despre Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Informaţii OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Adaugă marcaj"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizează marcajele..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Încarcăre "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripturi"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Durată"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Marca&je"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Bara de unelte principală"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Eroare la citirea fişierului."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Marcaje"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Setează timpul simulaţiei"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Setează timpul simulaţiei"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Timp"
@@ -2929,79 +3175,77 @@ msgstr "Timp"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Dosar nou..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Randarizează grila planetară"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galactic"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Ecliptică"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Orizontal"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr ", linia "
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Marcaje"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Centrează selecţia\tC"
@@ -3010,57 +3254,54 @@ msgstr "&Centrează selecţia\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Constelaţi"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>Combinatorii NVIDIA, fără programe vertex</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Limitele constelaţiilor"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Orbite"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planete"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Planete pitici"
 
@@ -3070,19 +3311,17 @@ msgstr "Planete pitici"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Luni"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Loni minore"
 
@@ -3092,12 +3331,12 @@ msgstr "Loni minore"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroizi"
 
@@ -3107,12 +3346,12 @@ msgstr "Asteroizi"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Comete"
 
@@ -3122,14 +3361,15 @@ msgstr "Comete"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Nave spaţiale"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Mai &repede\tL"
@@ -3138,9 +3378,8 @@ msgstr "10x Mai &repede\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Etichete"
 
@@ -3148,20 +3387,18 @@ msgstr "Etichete"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxi"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "globularii"
 
@@ -3169,7 +3406,7 @@ msgstr "globularii"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3179,615 +3416,632 @@ msgstr "Rroiuri deschise"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebuloase"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Locaţii"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Rroiuri deschise"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Nori"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Luminile din timpul noapţi"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Cozile cometelor"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosfere"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Umbrele inelelor"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Umbrele eclipselor"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Umbrele norilor"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Redus"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Mediu"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Complex"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Magnitudine automată\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Mai multe stele vizibile\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Mai puţine stele vizibile\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Puncte"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "Puncte di&fuze"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&Discuri la scală"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Întârzierea de timp necesar luminii pentru călătorie oprită"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Modul alt-azimuth activat"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Magnitudinea limită automată pentru 45 de grade: %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudinea limită: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Nume"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Mag. aparentă"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Mag. abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Tip"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Randarizează stelele"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Stele"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrează stelele"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Cu planete"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Randarizează stelele"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentru"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tip spectral invalid în baza de date stelară, steaua #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Reimprospătează"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marchează"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Număr maxim de stele afişate în listă"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marchează"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcaje activate"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Nimic"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Carou"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triunghi"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Pătrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Cerc"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Săgeată stânga"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Săgeată dreapta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Săgeată sus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Săgeată jos"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Selectează &obiect..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Mărime:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Selectează &obiect..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Nume"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Obiecte"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marchează"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "obiectul părinte '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Porneşte pe tot ecranul"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Durată"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Eclipsă solară"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Eclipsă de Lună"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Demarchează &tot"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Plaja dimensiunilor pentru puncte: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Eclipsă de lună"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Selectează &obiect..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Eclipsă solară"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Sincronizează ceasul cu ceasul real"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Încărcarea imaginei din fişier "
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informaţii OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Distanţa (al)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Dimensiune: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Text informativ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "&Formatul stelelor"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Format local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Numele fusului orar"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Decalaj GMT"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Stea"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3806,21 +4060,21 @@ msgid "&Select"
 msgstr "&Selectează"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Anulează"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "M&ergi la"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Urmareşte"
 
@@ -3834,50 +4088,55 @@ msgid "Visible"
 msgstr "Vederea activă vizibilă"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Demarchează"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Mod de randarizare"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Câmp pătrat"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disc"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Marchează"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "Puncte di&fuze"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Afişează axele corpului"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Afişează axele reper"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Afişează direcţia Soarelui"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Afişează vectorul viteză"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Afişează vectorul viteză"
@@ -3885,191 +4144,41 @@ msgstr "Afişează vectorul viteză"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Afişează direcţia Soarelui"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Randarizează grila planetară"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Randarizează terminatorul"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "Suprafeţe &alternative"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Nave spaţiale"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Obiecte"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Seteaza timpul"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Fusu orar: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Fusul orar universal"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Fusul orar local"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Numele fusului orar"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Dată"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Seteaza timpul"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Seteaza timpul"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Seteaza timpul"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Timp"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " ore"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minute"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr "Seteaza timpul"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Calendarul Iulian: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Calendarul Iulian: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Seteaza timpul"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Baricentru"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Tip spectral invalid în baza de date stelară, steaua #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planetă"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Planetă pitică"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Loni minore"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroid"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Cometă"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "Plaja dimensiunilor pentru puncte: "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Calculează"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Mergi la suprafaţa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Eroare necunoscută la deschiderea scriptului"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroizi"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "Puncte di&fuze"
+msgid "Dwarf planets"
+msgstr "Planete pitici"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4077,67 +4186,235 @@ msgstr "Puncte di&fuze"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Loni minore"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Nave spaţiale"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Obiecte"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Seteaza timpul"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Fusu orar: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Fusul orar universal"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Fusul orar local"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Numele fusului orar"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Dată"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Seteaza timpul"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Seteaza timpul"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Seteaza timpul"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Timp"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " ore"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minute"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr "Seteaza timpul"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Calendarul Iulian: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Calendarul Iulian: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Seteaza timpul"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Baricentru"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Tip spectral invalid în baza de date stelară, steaua #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planetă"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Planetă pitică"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Loni minore"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroid"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Cometă"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "Plaja dimensiunilor pentru puncte: "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Calculează"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Mergi la suprafaţa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Eroare necunoscută la deschiderea scriptului"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroizi"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "Puncte di&fuze"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Altele"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planete"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Obiecte"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Reporneşte timpul"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x M&ai încet\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " mai încet"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Opreşte timpul"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " mai repede"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Mai &repede\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Sincronizează cu ora curentă"
@@ -4209,7 +4486,6 @@ msgstr "Latitudine: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radius"
 
@@ -4230,7 +4506,7 @@ msgstr "Rezoluţie: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizează marcajele"
 
@@ -4261,18 +4537,6 @@ msgstr "Preferinţe pentru Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Obiecte"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Planete pitici"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4363,14 +4627,13 @@ msgstr "Traiectori parţiale"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Caroiaje"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 #, fuzzy
 msgid "Equatorial"
 msgstr "Randarizează grila planetară"
@@ -4378,35 +4641,30 @@ msgstr "Randarizează grila planetară"
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ecliptică"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galactic"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Orizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagrame"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Limite"
 
@@ -4440,7 +4698,6 @@ msgstr "Randarizează numele locaţiilor"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Oraşe"
 
@@ -4454,21 +4711,18 @@ msgstr "Zone de aterizare"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulcani"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatoare"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Cratere"
 
@@ -4503,7 +4757,6 @@ msgstr "Maria (Mări)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Altele"
 
@@ -4608,7 +4861,7 @@ msgstr "Afişaj"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Setări"
 
@@ -4850,21 +5103,21 @@ msgid "&About Celestia"
 msgstr "&Despre Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4873,530 +5126,621 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
-msgid "Copyright (C) 2001-2019, Celestia Development Team"
+msgid "1.7.0"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:74
-msgid "https://celestia.space/"
+msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:75
+msgid "https://celestia.space/"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia este un soft gratuit şi nu are nici un fel de garanţie."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autori"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Selectează obiectul"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Numele obiectului"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Liceenţa"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Controalele folosite de Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informaţii driver OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Setează timpul simulaţiei"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Format: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Sincronizează cu ora curentă"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Adaugă marcaj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Crează in >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Dosar nou..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Navigator al sistemului solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Adaugă dosar nou pentru marcaje"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Mergi la"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Numele dosarului"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Obiectele sistemului solar"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Controalele folosite de Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Navigator stelar"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Cel/cea mai apropiat(ă)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Luminozitate"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Cu planete"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Reactualizează"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Criteriu de cautare a stelelor"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Număr maxim de stele afişate în listă"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Tur de iniţiere..."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Mergi la"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Selectaţi destinaţia:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Mergi la obiect"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Obiect"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Distanţă"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Mărime:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Mod de randarizare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Rezoluţie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Obţiuni de vizualizare"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Caută eclipse"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Încet"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Calculează"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Afişaj"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Setează ceasul şi mergi la planetă"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#, fuzzy
-msgid "Ecliptic Line"
-msgstr ", linia "
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Închide"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Orbite/Etichete"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "De la: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Nume latine"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Text informativ"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Concis"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parametri la căutare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Complet"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Selectează obiectul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Zone de aterizare"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Numele obiectului"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Munţi)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Informaţii driver OpenGL"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Mări)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Mergi la obiect"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Văi)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Mergi la"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Continente)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Obiect"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Nume"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Distanţă"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Liceenţa"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Afişează caracteristicile"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Nume"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Mărime minimă a numelor reperelor"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Adaugă dosar nou pentru marcaje"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Mărime:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Numele dosarului"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Redenumeşte..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Redenumeşte marcaj sau dosar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nume nou"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Caută eclipse"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Setează timpul simulaţiei"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Calculează"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Setează ceasul şi mergi la planetă"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Sincronizează cu ora curentă"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Închide"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Navigator al sistemului solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "De la: "
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Mergi la"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Obiectele sistemului solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Navigator stelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parametri la căutare"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Reactualizează"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Eclipsă solară"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Criteriu de cautare a stelelor"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Eclipsă de Lună"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Număr maxim de stele afişate în listă"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Tur de iniţiere..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Selectaţi destinaţia:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Obţiuni de vizualizare"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Încet"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Afişaj"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Orbite/Etichete"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Text informativ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "418"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Ian"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Iun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Iul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Noi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satelit"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Dată"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Stea"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Furnizor: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Mod fereastră"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Motor de randarizare: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Invizibile"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "&Orbită sincronă"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Afişează axele corpului"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Afişează axele reper"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Afişează direcţia Soarelui"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Afişează vectorul viteză"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Randarizează grila planetară"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Randarizează terminatorul"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Sateliţi"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Obiecte în orbită"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Se încarcă: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "ro"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Încarcare URL-ul"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Versiune: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Versiune GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Număr maxim de texturi simultane:"
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Mărimea maximă a texturii: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Mărimea maximă a texturii cubice: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Plaja dimensiunilor pentru puncte: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Extensii suportate: "
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Mod fereastră"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Invizibile"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "&Orbită sincronă"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Afişează axele corpului"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Afişează axele reper"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Afişează direcţia Soarelui"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Afişează vectorul viteză"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Randarizează grila planetară"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Randarizează terminatorul"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Sateliţi"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Obiecte în orbită"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Se încarcă: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "ro"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Încarcare URL-ul"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Eroare la deschiderea scriptului"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Eroare la încărcarea scriptului"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Rulare script"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Numele fusului orar"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Decalaj GMT"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Eroare la deschiderea fişierului script."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Eroare necunoscută la deschiderea scriptului"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Eroare la deschiderea scriptului '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Iniţializarea corutinei scriptului a eşuat"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Eroare la deschiderea scriptului '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Eroare necunoscută la deschiderea scriptului"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Eroare la deschiderea "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Încărcarea programului de fragmentare NV:"
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Eroare la încărcarea programului de fragmentare NV:"
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Eroare în programul de fragmentare"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Iniţializarea programelor de fragmentare NV...\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Toate programele de fragmentare NV au fost încărcate.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Iniţializarea programelor de fragmentare ARB...\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ""
+#~ ": formatul fişierului imagine este necunoscut sau nu este implementat.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Încărcarea programului NV vertex: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Eroare la încărcarea programului NV vertex: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Eroare îin programul vertex "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Încărcarea programului ARB vertex: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Eraoare la încărcarea programului ARB vertex"
+
+#~ msgid ", line "
+#~ msgstr ", linia "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Iniţializarea programelor NV vertex...\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Toate programele NV vertex au fos încărcate cu succes.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Iniţializarea programelorARB vertex...\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Toate programele ARB vertex au fost încarcate cu succes.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Eroare necunoscută la deschiderea scriptului"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Copiază URL-ul"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL-ul copiat"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Modul alt-azimuth activat"
+
+#~ msgid "Nearest"
+#~ msgstr "Cel/cea mai apropiat(ă)"
+
+#~ msgid "Brightest"
+#~ msgstr "Luminozitate"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Cu planete"
+
+#, fuzzy
+#~ msgid "Ecliptic Line"
+#~ msgstr ", linia "
+
+#~ msgid "Latin Names"
+#~ msgstr "Nume latine"
+
+#~ msgid "Terse"
+#~ msgstr "Concis"
+
+#~ msgid "Verbose"
+#~ msgstr "Complet"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Zone de aterizare"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Munţi)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Mări)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Văi)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Continente)"
+
+#~ msgid "Label Features"
+#~ msgstr "Nume"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Eclipsă solară"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Eclipsă de Lună"
+
+#~ msgid "Vendor: "
+#~ msgstr "Furnizor: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Versiune GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Extensii suportate: "
+
+#~ msgid "Error opening script"
+#~ msgstr "Eroare la deschiderea scriptului"
+
+#~ msgid "Error loading script"
+#~ msgstr "Eroare la încărcarea scriptului"
+
+#~ msgid "Running script"
+#~ msgstr "Rulare script"
 
 #~ msgid "Invisible"
 #~ msgstr "Invizibil"

--- a/po/ru.po
+++ b/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2020-05-19 22:50+0300\n"
 "Last-Translator: Askaniy Anpilogov <aaskaniy@gmail.com>\n"
 "Language-Team: Russian (https://www.transifex.com/celestia/teams/93131/ru/)\n"
@@ -30,12 +30,12 @@ msgstr "Меркурий"
 msgid "Venus"
 msgstr "Венера"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Земля"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Луна"
 
@@ -51,140 +51,140 @@ msgstr "Фобос"
 msgid "Deimos"
 msgstr "Деймос"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Юпитер"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Амальтея"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Ио"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Европа"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ганимед"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Каллисто"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Сатурн"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Прометей"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Пандора"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Эпиметей"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Янус"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Мимас"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Энцелад"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Тефия"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Диона"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Рея"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Титан"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Гиперион"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Япет"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Феба"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Уран"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Миранда"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ариэль"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Умбриэль"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Титания"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Оберон"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Нептун"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Ларисса"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Протей"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Тритон"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Нереида"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Плутон-Харон"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Плутон"
 
@@ -193,1028 +193,1290 @@ msgid "Charon"
 msgstr "Харон"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Нумеа"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Бамако"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Амальтея"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Каллисто"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "янв"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Порт-Вила"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Галактики"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "СЕВЕРНАЯ АМЕРИКА"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "ЮЖНАЯ АМЕРИКА"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "ЕВРАЗИЯ"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "АФРИКА"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "АВСТРАЛИЯ"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "АНТАРКТИДА"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "АТЛАНТИЧЕСКИЙ ОКЕАН"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "АТЛАНТИЧЕСКИЙ ОКЕАН"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ТИХИЙ ОКЕАН"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ТИХИЙ ОКЕАН"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "ИНДИЙСКИЙ ОКЕАН"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "СЕВЕРНЫЙ ЛЕДОВИТЫЙ ОКЕАН"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Абу-Даби"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Аккра"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Адамстаун"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Аддис-Абеба"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Алжир"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Алофи"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Амман"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Амстердам"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Андорра-ла-Велья"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Анкара"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Антананариву"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Апиа"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ашхабад"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Асмэра"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Астана"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Асунсьон"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Афины"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Баку"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Бамако"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Бандар-Сери-Бегаван"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Бангкок"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Банги"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Банжул"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Бас-Тер"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Бастер"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Пекин"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Бейрут"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Белград"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Бельмопан"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Берлин"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Берн"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Бишкек"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Бисау"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Блумфонтейн"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Богота"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Бразилия"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Братислава"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Браззавиль"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Бриджтаун"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Брюссель"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Бухарест"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Будапешт"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Буэнос-Айрес"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Каир"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Канберра"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Кейптаун"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Каракас"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Кастри"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Кайенна"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Шарлотта Амалия"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Кишинёв"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Коломбо"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Конакри"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Копенгаген"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Котону"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Дакар"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Дар-эс-Салам"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Дакка"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Дили"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Джибути"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Доха"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Дуглас"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Дублин"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Душанбе"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Фонгафале"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Фор-де-Франс"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Фритаун"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Габороне"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "Джорджтаун"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Джорджтаун"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Гибралтар"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Гранд-Тёркс"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Гватемала"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Хагатна"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Гаага"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Гамильтон"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Хараре"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Гавана"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Хельсинки"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Хониара"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Исламабад"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Джеймстаун"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Иерусалим"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Кабул"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Кампала"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Киев"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Кигали"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Кингстон"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Кингстаун"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Киншаса"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Корор"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Куала-Лумпур"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Кувейт"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "Эль-Аюн"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "Ла-Пас"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Либревиль"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Лилонгве"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Лима"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Лиссабон"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Лобамба"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Ломе"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Лондон"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Лонгйир"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Луанда"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Люксембург"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Мадрид"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Маджуро"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Малабо"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Мале"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Манагуа"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Манама"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Манила"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Мапуту"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Масеру"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Мбабане"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Мехико"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Минск"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Могадишо"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Монако"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Монровия"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Монтевидео"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Морони"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Москва"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Маскат"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Найроби"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Нассау"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Нджамена"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Нью-Дели"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Ниамей"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Никосия"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Нумеа"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Нук"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Ораньестад"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Осло"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Оттава"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Уагадугу"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Паго-Паго"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Паликир"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Панама"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Папеэте"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Парамарибо"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Париж"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Пномпень"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Плимут"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Порт-Луи"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Порт-Морсби"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Порт-ау-Принс"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Порт-оф-Спейн"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Порто-Ново"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Порт-Вила"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Прага"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Прая"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Претория"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Пхеньян"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Кито"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Рабат"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Янгон"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Рейкьявик"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Рига"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Эр-Рияд"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Род-Таун"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Рим"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Розо"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Сент-Джордж"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Сент-Хельер"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Сент-Джонс"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Сент-Питер-Порт"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Сен-Дени"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Сент-Пьер"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "Сан-Хосе"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "Сан-Хуан"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "Сан-Марино"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "Сан-Сальвадор"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Сана"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Сантьяго"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Санто-Доминго"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Сан-Томе"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Сараево"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Сеул"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "Сетлмент"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Сингапур"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Скопье"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "София"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шри-Джаяварденепура-Котте"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Порт-Стэнли"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Стокгольм"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Сукре"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Сува"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Тайбэй"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Таллин"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Тарава"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Тбилиси"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Тегусигальпа"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Тегеран"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Тель-Авив"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Тхимпху"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Тирана"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Токио"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Торсхавн"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Триполи"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Тунис"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Улан-Батор"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Валлетта"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "Валли"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Ватикан"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Виктория"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Вена"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Вьентьян"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Вильнюс"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Вашингтон, DC"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Веллингтон"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "Вест Исланд"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Виллемстад"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Виндхук"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Ямусукро"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Яунде"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Район Ярен"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Ереван"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Загреб"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Млечный путь"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Центр Солнечной системы"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "STD"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Ошибка при открытии файла изображения %s\n"
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Ошибка чтения файла конфигурации."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1224,88 +1486,59 @@ msgstr "STD"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr "Загружено %i объектов глубокого космоса\n"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Загрузка NV фрагмента программы: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Ошибка загрузки NV фрагмента программы: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Ошибка в фрагменте программы "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Инициализация NV фрагмента программы . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Все NV фрагменты программы успешно загружены.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Инициализация ABR фрагмента программы . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Галактика (тип: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Шаровое скопление (радиус ядра: %4.2f', плотность: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, c-format
 msgid "Loading image from file %s\n"
 msgstr "Загрузка изображения из файла %s\n"
 
-#: ../src/celengine/image.cpp:337
-#, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr "%s: нераспознанный или неподдерживаемый тип файла изображения.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, c-format
 msgid "Error opening image file %s\n"
 msgstr "Ошибка при открытии файла изображения %s\n"
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr "Ошибка: %s не PNG файл.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Ошибка чтения файла PNG изображения %s\n"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, c-format
 msgid "Loading model: %s\n"
 msgstr "Загрузка 3D модели: %s\n"
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 "   У 3D модели вершин: %u, примитивов: %u, материалов: %u (%u уникальных)\n"
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Ошибка при загрузке модели '%s'\n"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Туманность"
 
@@ -1313,859 +1546,819 @@ msgstr "Туманность"
 msgid "Open cluster"
 msgstr "Рассеянное скопление"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Ошибка в файле .ssc (строка %d): "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "родитель '%s' объекта '%s' не найден.\n"
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "предупреждение о дубликате определения %s %s\n"
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "неверная альтернативная поверхность"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "неверное местоположение"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Неверный заголовок для перекрёстного индекса\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Неверная версия для перекрёстного индекса\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr ""
 "Не удалось загрузить перекрёстный индекс при записи %u\n"
 "\n"
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Неверный спектральный тип звезды %u\n"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, c-format
 msgid "%d stars in binary database\n"
 msgstr "Звёзд в двоичной базе данных: %d\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, c-format
 msgid "Total star count: %d\n"
 msgstr "Общее количество звёзд: %d\n"
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Ошибка в файле .stc (строка %i): %s\n"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ошибка у звезды: неверный спектральный тип.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ошибка у звезды: отсутствие спектрального типа.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr "Центр масс %s не существует.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ошибка у звезды: отсутствие прямого восхождения.\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Ошибка у звезды: отсутствие склонения.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Ошибка у звезды: отсутствие расстояния.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ошибка у звезды: отсутствие звёздной величины.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Ошибка у звезды: значение абсолютной величины должно находиться в пределах\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr "Уровень %i, %.5f св.л., узлов: %i, звёзд: %i\n"
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Создание мозаичной текстуры. Ширина=%i, макс.=%i\n"
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Создание обычной текстуры: %ix%i\n"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Загрузка NV шейдера: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Ошибка загрузки NV шейдера: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Ошибка в шейдере "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Загрузка ABR шейдера: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Ошибка загрузки ABR шейдера: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", строка "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Инициализация NV шейдеров . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Все NV шейдеры загружены успешно.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Инициализация ARB шейдеров . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Все ARB шейдеры загружены успешно.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, c-format
 msgid "Error openning %s.\n"
 msgstr "Ошибка открытия %s.\n"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Ошибка чтения заголовка %s.\n"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr "Неверный двоичный файл xyzv %s.\n"
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr "Неподдерживаемый порядок байтов %i, ожидается %i.\n"
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr "Неподдерживаемый номер цифр %i, ожидается %i.\n"
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Ошибка чтения файла избранного."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-"%s\n"
-"Ориентация: [%f, %f, %f], %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Ошибка открытия файла сценария."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Ошибка открытия сценария '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Неизвестная ошибка при открытии сценария"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Ошибка инициализации сценария"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Неверный тип файла"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Предел звёздной величины: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Метки включены"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Метки отключены"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Перейти к поверхности"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Альт-азимутальный режим включён"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Альт-азимутальный режим отключён"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Звёзды как размытые точки"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Звёзды как точки"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Звёзды как диски"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Хвосты комет включены"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Хвосты комет отключены"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Рендеринг: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 msgid "Anti-aliasing enabled"
 msgstr "Режим сглаживания включён"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 msgid "Anti-aliasing disabled"
 msgstr "Режим сглаживания отключён"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Автонастройка звёздной величины включена"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Автонастройка звёздной величины отключена"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Время и сценарий приостановлены"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Время приостановлено"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Продолжаю"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 msgid "Star color: Blackbody D65"
 msgstr "Цвет звёзд: АЧТ стандарта D65"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 msgid "Star color: Enhanced"
 msgstr "Цвет звёзд: искажённый"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Световое запаздывание:  %.4f л"
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Световое запаздывание:  %d мин  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Световое запаздывание:  %d ч  %d мин  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Поправка на задержку света включена"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Поправка на задержку света отключена"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Световое запаздывание не учитывается"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Использование карт нормалей."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Использование ограниченных текстур."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Наблюдение"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Время: вперёд"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Время: назад"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "Множитель времени: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 msgid "Low res textures"
 msgstr "Текстуры низкого разрешения"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 msgid "Medium res textures"
 msgstr "Текстуры среднего разрешения"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 msgid "High res textures"
 msgstr "Текстуры высокого разрешения"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Синхронное вращение"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Блокировка фазы"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Следовать"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Предел звёздной величины:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
-msgstr "Предел автонастройки звёздной величины для поля зрения 45 градусов:  %.2f"
+msgstr ""
+"Предел автонастройки звёздной величины для поля зрения 45 градусов:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Яркость подсветки:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Яркость галактик"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Расцветка включена"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Расцветка отключена"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Вид"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Ошибка GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Вид слишком мал для разделения"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Добавленный вид"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr "Мпк"
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr "кпк"
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "св. л."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "а.е."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr "дн."
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr "ч."
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 msgid "minutes"
 msgstr "мин."
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 msgid "seconds"
 msgstr "сек."
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Период вращения: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2821
-msgid "m/s"
-msgstr "м/с"
+#: ../src/celestia/celestiacore.cpp:2456
+#, fuzzy, c-format
+msgid "Mass: %.6g kg\n"
+msgstr "Масса: %.2f земных\n"
 
-#: ../src/celestia/celestiacore.cpp:2823
-msgid "km/s"
-msgstr "км/с"
+#: ../src/celestia/celestiacore.cpp:2458
+#, fuzzy, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr "Масса: %.2f земных\n"
 
-#: ../src/celestia/celestiacore.cpp:2827
-msgid "AU/s"
-msgstr "а.е./с"
-
-#: ../src/celestia/celestiacore.cpp:2829
-msgid "ly/s"
-msgstr "св. л./с"
-
-#: ../src/celestia/celestiacore.cpp:2831
-#, c-format
-msgid "Speed: %s %s\n"
-msgstr "Скорость: %s %s\n"
-
-#: ../src/celestia/celestiacore.cpp:2895
-#, c-format
-msgid "Apparent diameter: %s\n"
-msgstr "Угловой размер: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:2908
-#, c-format
-msgid "Apparent magnitude: %.1f\n"
-msgstr "Видимая звёздная величина: %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:2912
-#, c-format
-msgid "Absolute magnitude: %.1f\n"
-msgstr "Абсолютная звёздная величина: %.1f\n"
-
-#: ../src/celestia/celestiacore.cpp:2992
-#, c-format
-msgid "%.6f%c %.6f%c %f km"
-msgstr "%.6f%c %.6f%c %f км"
-
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
-#, c-format
-msgid "Distance: %s\n"
-msgstr "Расстояние: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3022
-msgid "Star system barycenter\n"
-msgstr "Центр масс звёздной системы\n"
-
-#: ../src/celestia/celestiacore.cpp:3026
-#, c-format
-msgid "Abs (app) mag: %.2f (%.2f)\n"
-msgstr "Абс. (вид.) зв. величина: %.2f (%.2f)\n"
-
-#: ../src/celestia/celestiacore.cpp:3032
-#, c-format
-msgid "Luminosity: %sx Sun\n"
-msgstr "Светимость: %s солнечных\n"
-
-#: ../src/celestia/celestiacore.cpp:3038
-msgid "Neutron star"
-msgstr "Нейтронная звезда"
-
-#: ../src/celestia/celestiacore.cpp:3041
-msgid "Black hole"
-msgstr "Чёрная дыра"
-
-#: ../src/celestia/celestiacore.cpp:3046
-#, c-format
-msgid "Class: %s\n"
-msgstr "Класс: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3053
-#, c-format
-msgid "Surface temp: %s K\n"
-msgstr "Температура поверхности: %s К\n"
-
-#: ../src/celestia/celestiacore.cpp:3058
-#, c-format
-msgid "Radius: %s Rsun  (%s km)\n"
-msgstr "Радиус: %s солнечных  (%s км)\n"
-
-#: ../src/celestia/celestiacore.cpp:3064
-#, c-format
-msgid "Radius: %s km\n"
-msgstr "Радиус: %s км\n"
-
-#: ../src/celestia/celestiacore.cpp:3080
-msgid "Planetary companions present\n"
-msgstr "Присутствует планетарная система\n"
-
-#: ../src/celestia/celestiacore.cpp:3096
-#, c-format
-msgid "Distance from center: %s\n"
-msgstr "Расстояние от центра: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
-#, c-format
-msgid "Radius: %s\n"
-msgstr "Радиус: %s\n"
-
-#: ../src/celestia/celestiacore.cpp:3168
-#, c-format
-msgid "Phase angle: %.1f%s\n"
-msgstr "Фазовый угол: %.1f%s\n"
-
-#: ../src/celestia/celestiacore.cpp:3180
+#: ../src/celestia/celestiacore.cpp:2460
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Масса: %.2f земных\n"
 
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2471
+msgid "m/s"
+msgstr "м/с"
+
+#: ../src/celestia/celestiacore.cpp:2476
+msgid "km/s"
+msgstr "км/с"
+
+#: ../src/celestia/celestiacore.cpp:2486
+msgid "AU/s"
+msgstr "а.е./с"
+
+#: ../src/celestia/celestiacore.cpp:2491
+msgid "ly/s"
+msgstr "св. л./с"
+
+#: ../src/celestia/celestiacore.cpp:2494
+#, c-format
+msgid "Speed: %s %s\n"
+msgstr "Скорость: %s %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2558
+#, c-format
+msgid "Apparent diameter: %s\n"
+msgstr "Угловой размер: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2571
+#, c-format
+msgid "Apparent magnitude: %.1f\n"
+msgstr "Видимая звёздная величина: %.1f\n"
+
+#: ../src/celestia/celestiacore.cpp:2575
+#, c-format
+msgid "Absolute magnitude: %.1f\n"
+msgstr "Абсолютная звёздная величина: %.1f\n"
+
+#: ../src/celestia/celestiacore.cpp:2655
+#, c-format
+msgid "%.6f%c %.6f%c %f km"
+msgstr "%.6f%c %.6f%c %f км"
+
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
+#, c-format
+msgid "Distance: %s\n"
+msgstr "Расстояние: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Star system barycenter\n"
+msgstr "Центр масс звёздной системы\n"
+
+#: ../src/celestia/celestiacore.cpp:2689
+#, c-format
+msgid "Abs (app) mag: %.2f (%.2f)\n"
+msgstr "Абс. (вид.) зв. величина: %.2f (%.2f)\n"
+
+#: ../src/celestia/celestiacore.cpp:2695
+#, c-format
+msgid "Luminosity: %sx Sun\n"
+msgstr "Светимость: %s солнечных\n"
+
+#: ../src/celestia/celestiacore.cpp:2701
+msgid "Neutron star"
+msgstr "Нейтронная звезда"
+
+#: ../src/celestia/celestiacore.cpp:2704
+msgid "Black hole"
+msgstr "Чёрная дыра"
+
+#: ../src/celestia/celestiacore.cpp:2709
+#, c-format
+msgid "Class: %s\n"
+msgstr "Класс: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2716
+#, c-format
+msgid "Surface temp: %s K\n"
+msgstr "Температура поверхности: %s К\n"
+
+#: ../src/celestia/celestiacore.cpp:2721
+#, c-format
+msgid "Radius: %s Rsun  (%s km)\n"
+msgstr "Радиус: %s солнечных  (%s км)\n"
+
+#: ../src/celestia/celestiacore.cpp:2727
+#, c-format
+msgid "Radius: %s km\n"
+msgstr "Радиус: %s км\n"
+
+#: ../src/celestia/celestiacore.cpp:2743
+msgid "Planetary companions present\n"
+msgstr "Присутствует планетарная система\n"
+
+#: ../src/celestia/celestiacore.cpp:2759
+#, c-format
+msgid "Distance from center: %s\n"
+msgstr "Расстояние от центра: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
+#, c-format
+msgid "Radius: %s\n"
+msgstr "Радиус: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:2831
+#, c-format
+msgid "Phase angle: %.1f%s\n"
+msgstr "Фазовый угол: %.1f%s\n"
+
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Плотность: %.2f x 1000 кг/м^3\n"
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Температура: %.0f К\n"
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Прямой ход времени"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "Обратный ход времени"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Время остановлено"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, c-format
 msgid "%.6g x faster"
 msgstr "Ускорить время в %.6g раз(а)"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, c-format
 msgid "%.6g x slower"
 msgstr "Замедлить время в %.6g раз(а)"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Пауза)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, c-format
 msgid "Travelling (%s)\n"
 msgstr "Перемещение (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, c-format
 msgid "Travelling\n"
 msgstr "Перемещение\n"
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, c-format
 msgid "Track %s\n"
 msgstr "Следование %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, c-format
 msgid "Follow %s\n"
 msgstr "Наблюдение %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синхронное вращение %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Блокировка фазы %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, c-format
 msgid "Chase %s\n"
 msgstr "Сопровождение %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "Поле зрения: %s (%.2fx)\n"
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Солнце"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Название цели: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr "%dx%d при %f fps  %s"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Paused"
 msgstr "Пауза"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 msgid "Recording"
 msgstr "Запись"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пуск/Пауза    F12 Стоп"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Режим правки"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Загрузка каталога системы: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Загружается %s каталог: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Ошибка чтения файла конфигурации."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Ошибка инициализации SPICE библиотеки."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Ошибка чтения базы данных звёзд."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Ошибка открытия файла каталога объектов глубокого космоса %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Ошибка чтения базы данных объектов глубокого космоса %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Ошибка открытия каталога системы %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Ошибка открытия файла астеризмов %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Ошибка открытия файла границ созвездий %s.\n"
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Ошибка инициализации рендеринга"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Ошибка загрузки шрифта; текст не будет отображаться.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Ошибка чтения перекрёстного индекса %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Загруженный перекрёстный индекс %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Ошибка чтения файла названий звёзд\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, c-format
 msgid "Error opening %s\n"
 msgstr "Ошибка открытия %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Ошибка чтения файла названий звёзд\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Ошибка чтения файла звёзд\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Ошибка открытия каталога звёзд %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
+#, fuzzy, c-format
+msgid "%s Version: %s\n"
+msgstr "Версия: %@"
+
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Производитель: %@"
+
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Видеокарта: %@"
+
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Макс. кол-во текстур: "
+
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Макс. размер текстур: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Диапазон размеров точки: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Диапазон размеров точки: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Макс. размер кубической карты: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Ошибка открытия LuaHook '%s'"
-
-#: ../src/celestia/celestiacore.cpp:4976
-msgid "Unknown error loading hook script"
-msgstr "Неизвестная ошибка при загрузке hook-скрипта"
-
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
+msgid "Number of interpolators: %s\n"
 msgstr ""
-"ПРЕДУПРЕЖДЕНИЕ:\n"
-"\n"
-"Этот скрипт запрашивает разрешение на чтение/запись\n"
-"файлов и запуск внешних программ. Данное разрешение\n"
-"может нести опасность.\n"
-"Вы доверяете скрипту и хотите продолжить?\n"
-"\n"
-"y = да, ESC = закрыть скрипт, любая другая клавиша = нет"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
-"ПРЕДУПРЕЖДЕНИЕ:\n"
-"\n"
-"Этот скрипт запрашивает разрешение на чтение/запись\n"
-"файлов и запуск внешних программ. Данное разрешение\n"
-"может нести опасность.\n"
-"Вы доверяете скрипту и хотите продолжить?"
-
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:135
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
-"Программе не удалось инициализировать расширения OpenGL (ошибка %i)."
-"Качество графики будет снижено."
 
 #. if (glGetError())
 #. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
@@ -2360,14 +2553,14 @@ msgstr "Неправильный формат даты или времени"
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr "Введите дату в формате «мм/дд/гггг» и время как «чч:мм:сс»."
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Ошибка создания ogg-файла %s при захвате.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 msgid "Internal Ogg library error.\n"
 msgstr "Внутренняя ошибка библиотеки Ogg.\n"
 
@@ -2385,51 +2578,39 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - wrote %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr "Автоматически"
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr "Настраиваемо"
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
+#, fuzzy
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 "Celestia не может быть запущена, поскольку папка данных не была найдена, "
 "возможно, из-за неправильной установки."
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
-"Celestia не может быть запущена, поскольку папка CelestiaResources "
-"не была найдена, возможно, из-за неправильной установки."
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-"Программе не удалось инициализировать расширения OpenGL (ошибка %1). "
-"Качество графики было уменьшено."
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Обозреватель"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 msgid "Info Browser"
 msgstr "Панель данных"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Солнечная система"
 
@@ -2439,20 +2620,19 @@ msgstr "Солнечная система"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Звёзды"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 msgid "Deep Sky Objects"
 msgstr "Объекты глубокого космоса"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Поиск затмений"
 
@@ -2460,103 +2640,105 @@ msgstr "Поиск затмений"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Время"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 msgid "Guides"
 msgstr "Вспомогательные элементы"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 msgid "Full screen"
 msgstr "Во весь экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 msgid "Error opening bookmarks file"
 msgstr "Ошибка при открытии файла закладок"
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 msgid "Error Saving Bookmarks"
 msgstr "Ошибка записи закладок"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 msgid "Save Image"
 msgstr "Сохранить изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 msgid "Images (*.png *.jpg)"
 msgstr "Изображения (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Захват видео"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 msgid "Video (*.avi)"
 msgstr "Видео (*.avi)"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 msgid "Video (*.ogv)"
 msgstr "Видео (*.ogv)"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 msgid "Resolution:"
 msgstr "Разрешение:"
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 x %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "Частота кадров:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr "Изображение скопировано в буфер обмена"
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Ссылка скопирована"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 msgid "Pasting URL"
 msgstr "Вставить ссылку"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 msgid "Open Script"
 msgstr "Открыть сценарий"
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Сценарии Celestia (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 msgid "New bookmark"
 msgstr "Новая закладка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
-#, qt-format
+#: ../src/celestia/qt/qtappwin.cpp:1004
+#, fuzzy, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 "<html><p><b>Celestia 1.7.0 (Qt5 бета версия, коммит Git %1)</b></"
 "p><p>Авторское право (C) 2001-2018, команда разработчиков Celestia."
@@ -2570,251 +2752,307 @@ msgstr ""
 "href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/"
 "CelestiaProject/Celestia</a></html>"
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
-msgid "<b>OpenGL version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1039
+#, fuzzy
+msgid "Unknown compiler"
+msgstr "Неизвестно"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Поддерживаемые расширения"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Поддерживаемые расширения"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "О программе"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>Версия OpenGL: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Производитель: %@"
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Видеокарта: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "<b>Версия GLSL: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Макс. кол-во текстур: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Макс. размер текстур: </b>"
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-msgid "<b>Extensions:</b><br>\n"
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Диапазон размеров точки: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Диапазон размеров точки: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Макс. размер кубической карты: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "<b>Аргумент перицентра:</b> %L1%2"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Расширения:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "Информация OpenGL"
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Видеокарта: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 msgid "&Grab image"
 msgstr "Сохранить &изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 msgid "Capture &video"
 msgstr "&Записать видео"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 msgid "Shift+F10"
 msgstr "Сохранить &видео...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 msgid "&Copy image"
 msgstr "&Копировать изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-msgid "Copy &URL"
-msgstr "Ко&пировать ссылку"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-msgid "&Paste URL"
-msgstr "&Вставить ссылку"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Открыть сценарий..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 msgid "&Preferences..."
 msgstr "&Настройки..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "В&ыход"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навигация"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 msgid "Select Sun"
 msgstr "Выбрать Солнце"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 msgid "Center Selection"
 msgstr "Центрировать выбранное"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 msgid "Goto Selection"
 msgstr "Перейти к выбранному"
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Перейти к объекту..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "В&ремя"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 msgid "Set &time"
 msgstr "&Установить время"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 msgid "&Display"
 msgstr "&Отобразить"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 msgid "Dee&p Sky Objects"
 msgstr "&Объекты глубокого космоса"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 msgid "&Shadows"
 msgstr "&Тени"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Звёзды как…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 msgid "Texture &Resolution"
 msgstr "&Разрешение текстур"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 msgid "&FPS control"
 msgstr "Контроль &FPS"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Закладки"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Окно"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 msgid "&MultiView"
 msgstr "&Экраны"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Split view vertically"
 msgstr "Разделить экран по вертикали"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 msgid "Split view horizontally"
 msgstr "Разделить экран по горизонтали"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 msgid "Cycle views"
 msgstr "Переключить экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 msgid "Single view"
 msgstr "Один экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 msgid "Delete view"
 msgstr "Удалить экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 msgid "Frames visible"
 msgstr "Показывать рамки"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 msgid "Active frame visible"
 msgstr "Выделить экран рамкой"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 msgid "Synchronize time"
 msgstr "Синхронизировать время"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Справка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 msgid "Celestia Manual"
 msgstr "Руководство пользователя"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "О программе"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "Информация OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 msgid "Add Bookmark..."
 msgstr "Добавить закладку..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 msgid "Organize Bookmarks..."
 msgstr "Упорядочить закладки..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr "Пользовательский FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr "Значение FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -2823,52 +3061,52 @@ msgstr ""
 "Загрузка файлов данных: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Сценарии"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr "Название"
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 msgid "Description"
 msgstr "Описание"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 msgid "Bookmarks Menu"
 msgstr "Меню закладок"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr "Добавьте сюда закладки и они будут показаны в меню закладок."
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 msgid "Bookmarks Toolbar"
 msgstr "Панель закладок"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr "Добавьте сюда закладки и они будут показаны на панели закладок."
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 msgid "Error reading bookmarks file"
 msgstr "Ошибка чтения файла закладок"
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Закладки"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 msgid "Current simulation time"
 msgstr "Внутреннее время"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 msgid "Simulation time at activation"
 msgstr "Внутреннее время при активации"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 msgid "System time at activation"
 msgstr "Системное время при активации"
 
@@ -2876,72 +3114,70 @@ msgstr "Системное время при активации"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 msgid "New Folder"
 msgstr "Новая папка"
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr "Экв."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 msgid "Equatorial coordinate grid"
 msgstr "Экваториальная координатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr "Гал."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 msgid "Galactic coordinate grid"
 msgstr "Галактическая координатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr "Экл."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 msgid "Ecliptic coordinate grid"
 msgstr "Эклиптическая координатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr "Гор."
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 msgid "Horizontal coordinate grid"
 msgstr "Горизонтальная координатная сетка"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr "Эклип."
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 msgid "Ecliptic line"
 msgstr "Линия эклиптики"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 msgid "M"
 msgstr "М"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Метки"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 msgid "C"
 msgstr "С"
 
@@ -2949,54 +3185,51 @@ msgstr "С"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Созвездия"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 msgid "B"
 msgstr "Г"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 msgid "Constellation boundaries"
 msgstr "Границы созвездий"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 msgid "O"
 msgstr "О"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Орбиты"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Планеты"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Карликовые планеты"
 
@@ -3006,19 +3239,17 @@ msgstr "Карликовые планеты"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Спутники"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Малые спутники"
 
@@ -3028,12 +3259,12 @@ msgstr "Малые спутники"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Астероиды"
 
@@ -3043,12 +3274,12 @@ msgstr "Астероиды"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Кометы"
 
@@ -3058,14 +3289,15 @@ msgstr "Кометы"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Космич. аппараты"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 msgid "L"
 msgstr "Н"
 
@@ -3073,9 +3305,8 @@ msgstr "Н"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Названия"
 
@@ -3083,20 +3314,18 @@ msgstr "Названия"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Галактики"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Шаровые скопления"
 
@@ -3104,7 +3333,7 @@ msgstr "Шаровые скопления"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 msgid "Open clusters"
 msgstr "Рассеянные скопления"
@@ -3113,576 +3342,595 @@ msgstr "Рассеянные скопления"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Туманности"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Местоположения"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Рассеянные скопления"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Облака"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Свет ночной стороны"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Хвосты комет"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Атмосферы"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Тени на кольцах"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Тени затмений"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Тени облаков"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Низкое"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Среднее"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Высокое"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 msgid "Auto Magnitude"
 msgstr "Автонастройка зв. величины"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr "Отображение наименьшей звёздной величины на основе поля зрения"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 msgid "More Stars Visible"
 msgstr "Больше звёзд"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 msgid "Fewer Stars Visible"
 msgstr "Меньше звёзд"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 msgid "Points"
 msgstr "Точки"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 msgid "Fuzzy Points"
 msgstr "Размытые точки"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 msgid "Scaled Discs"
 msgstr "Диски"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 msgid "Light Time Delay"
 msgstr "Поправка на задержку света"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-msgid "Enable Vsync"
-msgstr "Включить Vsync"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
-msgstr "Предел автонастройки звёздной величины для поля зрения 45 градусов: %L1"
+msgstr ""
+"Предел автонастройки звёздной величины для поля зрения 45 градусов: %L1"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Предел звёздной величины: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Название"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Расстояние (св. л.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Вид. вел."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Абс. вел."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Тип"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 msgid "Closest Stars"
 msgstr "Ближайшие звёзды"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 msgid "Brightest Stars"
 msgstr "Ярчайшие звёзды"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 msgid "Filter"
 msgstr "Фильтр"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "С планетами"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 msgid "Multiple Stars"
 msgstr "Системы звёзд"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 msgid "Barycenters"
 msgstr "Центры масс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 msgid "Spectral Type"
 msgstr "Спектральный тип"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Обновить"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 msgid "Mark Selected"
 msgstr "Установить метку"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 msgid "Mark stars selected in list view"
 msgstr "Установить метки на выбранные звёзды"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 msgid "Unmark Selected"
 msgstr "Снять метку"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr "Снять метки с выбранных звёзд"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 msgid "Clear Markers"
 msgstr "Очистить метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr "Удалить все установленные метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Нет"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Ромб"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Треугольник"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Круг"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Стрелка влево"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Стрелка вправо"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Стрелка вверх"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Стрелка вниз"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Select marker symbol"
 msgstr "Вид метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 msgid "Select marker size"
 msgstr "Размер метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 msgid "Click to select marker color"
 msgstr "Цвет метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Label"
 msgstr "Название"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, qt-format
 msgid "%1 objects found"
 msgstr "Найдено объектов: %1"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr "Установить метку на выбранный объект глубокого космоса"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 msgid "Unmark DSOs selected in list view"
 msgstr "Снять метку с выбранного объекта глубокого космоса"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 msgid "Eclipsed body"
 msgstr "Затеняемый объект"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr "Затмевающий объект"
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 msgid "Start time"
 msgstr "Начало"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Продолжительность"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 msgid "Solar eclipses"
 msgstr "Солнечные затмения"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 msgid "Lunar eclipses"
 msgstr "Лунные затмения"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 msgid "All eclipses"
 msgstr "Все затмения"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 msgid "Search range"
 msgstr "Диапазон поиска"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 msgid "Find eclipses"
 msgstr "Вычислить все затмения"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, qt-format
 msgid "%1 is not a valid object"
 msgstr "%1 не является доспутимым объектом"
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr "Время начала позже времени окончания."
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 msgid "Finding eclipses..."
 msgstr "Поиск затмений..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 msgid "Set time to mid-eclipse"
 msgstr "Установить время затмения"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, qt-format
 msgid "Near %1"
 msgstr "Показать на %1"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, qt-format
 msgid "From surface of %1"
 msgstr "Показать от поверхности %1"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, qt-format
 msgid "Behind %1"
 msgstr "Показать от %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr "Ошибка: нет выделенного!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 msgid "Info"
 msgstr "Информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, qt-format
 msgid "Web info: %1"
 msgstr "В интернете: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Экваториальный радиус:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Размер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr "<b>Полярное сжатие: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Звёздные сутки:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Солнечные сутки:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr "лет"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "<b>Эксцентриситет:</b> %L1"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "<b>Период обращения:</b> %L1 %2"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 msgid "Orbit information"
 msgstr "Параметры орбиты"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Оскулирующие элементы на %1"
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Период обращения:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 msgid "AU"
 msgstr "а.е."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Большая полуось:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Эксцентриситет:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Наклонение:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Перицентрическое расстояние:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Апоцентрическое расстояние:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Долгота восходящего узла:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Аргумент перицентра:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Средняя аномалия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Период обращения (вычисленный):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>Прямое восхождение:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Склонение:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr "АЧТ срандарта D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 msgid "Classic colors"
 msgstr "Искажённые цвета"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 msgid "Local format"
 msgstr "Местное время"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 msgid "Time zone name"
 msgstr "Часовой пояс"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 msgid "UTC offset"
 msgstr "Смещение UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Начало"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3701,21 +3949,21 @@ msgid "&Select"
 msgstr "В&ыбрать"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Центрировать"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Перейти"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Наблюдение"
 
@@ -3728,211 +3976,88 @@ msgid "Visible"
 msgstr "Показывать"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "Снять &метку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Режим экрана"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Закрашенный квадрат"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Диск"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "Поставить &метку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Элементы графики"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 msgid "Show &Body Axes"
 msgstr "Показывать оси объекта"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 msgid "Show &Frame Axes"
 msgstr "Показывать оси каракаса"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 msgid "Show &Sun Direction"
 msgstr "Показывать направление к Солнцу"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 msgid "Show &Velocity Vector"
 msgstr "Показывать вектор движения"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 msgid "Show S&pin Vector"
 msgstr "Показывать вектор вращения"
 
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, qt-format
 msgid "Show &Direction to %1"
 msgstr "Показывать направление на %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 msgid "Show Planetographic &Grid"
 msgstr "Показывать планетографическую сетку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 msgid "Show &Terminator"
 msgstr "Показывать линию терминатора"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Альтернативная поверхность"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Нормали"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Космич. аппараты"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
-msgid "Other objects"
-msgstr "Другие объекты"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-msgid "Set Time"
-msgstr "Установить время"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Стандарт:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Всемирное время"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Местное время"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-msgid "Select Time Zone"
-msgstr "Часовой пояс"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-msgid "Date: "
-msgstr "Дата: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-msgid "Set Year"
-msgstr "Год"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-msgid "Set Month"
-msgstr "Месяц"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-msgid "Set Day"
-msgstr "День"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-msgid "Time: "
-msgstr "Время: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-msgid "Set Hours"
-msgstr "Часы"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ":"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-msgid "Set Minutes"
-msgstr "Минуты"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-msgid "Set Seconds"
-msgstr "Секунды"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Юлианская дата: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-msgid "Set Julian Date"
-msgstr "Дата в Юлианском формате"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-msgid "Set time"
-msgstr "Применить"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Центр масс"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-msgid "Star"
-msgstr "Звезда"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Планета"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-msgid "Dwarf planet"
-msgstr "Карликовая планета"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-msgid "Minor moon"
-msgstr "Малый спутник"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Астероид"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Комета"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-msgid "Reference point"
-msgstr "Ориентир"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-msgid "Component"
-msgstr "Компонент"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-msgid "Surface feature"
-msgstr "Особенность интерфейса"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-msgid "Asteroids & comets"
-msgstr "Астероиды и кометы"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-msgid "Reference points"
-msgstr "Ориентиры"
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
+msgid "Dwarf planets"
+msgstr "Карликовые планеты"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -3940,58 +4065,203 @@ msgstr "Ориентиры"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr "Малые луны"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Космич. аппараты"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+msgid "Other objects"
+msgstr "Другие объекты"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+msgid "Set Time"
+msgstr "Установить время"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Стандарт:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Всемирное время"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Местное время"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+msgid "Select Time Zone"
+msgstr "Часовой пояс"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+msgid "Date: "
+msgstr "Дата: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+msgid "Set Year"
+msgstr "Год"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+msgid "Set Month"
+msgstr "Месяц"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+msgid "Set Day"
+msgstr "День"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+msgid "Time: "
+msgstr "Время: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+msgid "Set Hours"
+msgstr "Часы"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ":"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+msgid "Set Minutes"
+msgstr "Минуты"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+msgid "Set Seconds"
+msgstr "Секунды"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Юлианская дата: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+msgid "Set Julian Date"
+msgstr "Дата в Юлианском формате"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+msgid "Set time"
+msgstr "Применить"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Центр масс"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+msgid "Star"
+msgstr "Звезда"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Планета"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+msgid "Dwarf planet"
+msgstr "Карликовая планета"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+msgid "Minor moon"
+msgstr "Малый спутник"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Астероид"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Комета"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+msgid "Reference point"
+msgstr "Ориентир"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+msgid "Component"
+msgstr "Компонент"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+msgid "Surface feature"
+msgstr "Особенность интерфейса"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+msgid "Asteroids & comets"
+msgstr "Астероиды и кометы"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+msgid "Reference points"
+msgstr "Ориентиры"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr "Компоненты"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 msgid "Surface features"
 msgstr "Особенности интерфейса"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Кольца"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 msgid "Group objects by class"
 msgstr "Группировать объекты по классу"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr "Установить метку на выбранные объекты"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 msgid "Reverse time"
 msgstr "Обратить ход времени"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "10x slower"
 msgstr "Замедлить время в 10 раз"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 msgid "2x slower"
 msgstr "Замедлить время в 2 раза"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 msgid "Pause time"
 msgstr "Приостановить ход времени"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 msgid "2x faster"
 msgstr "Ускорить время в 2 раза"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 msgid "10x faster"
 msgstr "Ускорить время в 10 раз"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 msgid "Set to current time"
 msgstr "Установить текущее время"
 
@@ -4055,7 +4325,6 @@ msgstr "Широта:"
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "рад."
 
@@ -4074,7 +4343,7 @@ msgstr "Описание:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Упорядочить..."
 
@@ -4103,17 +4372,6 @@ msgstr "&Настройки..."
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Объекты"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-msgid "Dwarf planets"
-msgstr "Карликовые планеты"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4192,49 +4450,43 @@ msgstr "Детали траекторий"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Координатные сетки"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Экваториальная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Эклиптическая"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Галактическая"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Горизонтальная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Фигуры"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Границы"
 
@@ -4265,7 +4517,6 @@ msgstr "Виды местоположений:"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Города"
 
@@ -4278,21 +4529,18 @@ msgstr "Места посадок"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Вулканы"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Обсерватории"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Кратеры"
 
@@ -4323,7 +4571,6 @@ msgstr "Моря (океаны)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Прочее"
 
@@ -4416,7 +4663,7 @@ msgstr "Стандарт даты:"
 msgid "Not an XBEL version 1.0 file."
 msgstr "Не файл XBEL версии 1.0."
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Настройки"
 
@@ -4653,21 +4900,21 @@ msgid "&About Celestia"
 msgstr "&О программе..."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "Ок"
 
@@ -4676,525 +4923,659 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2019, Команда разработки Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr "https://celestia.space/"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr ""
 "Celestia является бесплатной и распространяется без каких-либо гарантий."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "В разработке принимали участие:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Выбор объекта"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Название объекта"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Лицензия"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Управление программой"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Информация OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Установка времени"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Формат: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Установить текущее время"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Добавить закладку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Создать в >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Новая папка..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Каталог Солнечной системы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Перейти"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Объекты системы:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Каталог звёзд"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Ближайшие"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Ярчайшие"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-msgid "With planets"
-msgstr "С планетами"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Обновить"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Критерии поиска"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Количество звёзд в списке"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Путеводитель"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Перейти"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Выберите объект:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Перейти к объекту"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Объект"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Долгота"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Широта"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Расстояние"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Размер:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "Режим экрана"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "Разрешение"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Настройки"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-msgid "Show:"
-msgstr "Показывать:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-msgid "Display:"
-msgstr "Отображать:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Эклиптика"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-msgid "Body / Orbit / Label display"
-msgstr "Отображать тела/орбиты/названия"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Имена латиницей"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Информация"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Кратко"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Подробно"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Места посадок"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Горы"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Моря (океаны)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Долины"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Земли, области"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Показывать местоположения"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "Выбор местоположений"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-msgid "Show Label"
-msgstr "Названия"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "Минимальный размер местоположений"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:96
 msgid "Add New Bookmark Folder"
 msgstr "Добавить закладку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:99
 msgid "Folder Name"
 msgstr "Название папки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "Переименовать..."
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Управление программой"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "Переименование"
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "Режим экрана"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "Новое название"
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "Разрешение"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/win32/res/resource_strings.cpp:106
 msgid "Eclipse Finder"
 msgstr "Поиск затмений"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:107
 msgid "Compute"
 msgstr "Вычислить"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:108
 msgid "Set Date and Go to Planet"
 msgstr "Установить дату и перейти к планете"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:109
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:110
 msgid "From:"
 msgstr "От:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:111
 msgid "To:"
 msgstr "До:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:112
 msgid "On:"
 msgstr "В:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:113
 msgid "Search parameters"
 msgstr "Параметры поиска"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Солнечные затмения"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Выбор объекта"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Лунные затмения"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Название объекта"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Информация OpenGL"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Перейти к объекту"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Перейти"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Объект"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Долгота"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Широта"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Расстояние"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Лицензия"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "Выбор местоположений"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+msgid "Show Label"
+msgstr "Названия"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "Минимальный размер местоположений"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Размер:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "Переименовать..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "Переименование"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "Новое название"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Установка времени"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Формат: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Установить текущее время"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Каталог Солнечной системы"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Перейти"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Объекты системы:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Каталог звёзд"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Обновить"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Критерии поиска"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Количество звёзд в списке"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Путеводитель"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Выберите объект:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Настройки"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+msgid "Show:"
+msgstr "Показывать:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+msgid "Display:"
+msgstr "Отображать:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+msgid "Body / Orbit / Label display"
+msgstr "Отображать тела/орбиты/названия"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Информация"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "419"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "апр"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "фев"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "янв"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "июн"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "мар"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "мая"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "авг"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "дек"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "июл"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "ноя"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "окт"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "сен"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Спутник"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Дата"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Начало"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Производитель: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Оконный режим"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Видеокарта: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Невидимые"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Син&х. вращение"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Информация"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Показывать оси объекта"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Показывать оси каркаса"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Показывать направление к Солнцу"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Показывать вектор движения"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Показывать планетографическую сетку"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Показывать линию терминатора"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "С&путники"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Объекты системы"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+#, fuzzy
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+"Ваша система не поддерживает\n"
+"%@"
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Загрузка: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "ru"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Загрузка ссылки"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Версия: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Версия GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Макс. кол-во текстур: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Макс. размер текстур: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Макс. размер кубической карты: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Диапазон размеров точки: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Поддерживаемые расширения:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Оконный режим"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Невидимые"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Син&х. вращение"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Информация"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Показывать оси объекта"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Показывать оси каркаса"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Показывать направление к Солнцу"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Показывать вектор движения"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Показывать планетографическую сетку"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Показывать линию терминатора"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "С&путники"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Объекты системы"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Загрузка: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "ru"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Загрузка ссылки"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Ошибка открытия сценария"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Ошибка загрузки сценария"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Запуск сценария"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Часовой пояс"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Смещение UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Ошибка открытия файла сценария."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Неизвестная ошибка при загрузке hook-скрипта"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+"ПРЕДУПРЕЖДЕНИЕ:\n"
+"\n"
+"Этот скрипт запрашивает разрешение на чтение/запись\n"
+"файлов и запуск внешних программ. Данное разрешение\n"
+"может нести опасность.\n"
+"Вы доверяете скрипту и хотите продолжить?\n"
+"\n"
+"y = да, ESC = закрыть скрипт, любая другая клавиша = нет"
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+"ПРЕДУПРЕЖДЕНИЕ:\n"
+"\n"
+"Этот скрипт запрашивает разрешение на чтение/запись\n"
+"файлов и запуск внешних программ. Данное разрешение\n"
+"может нести опасность.\n"
+"Вы доверяете скрипту и хотите продолжить?"
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Ошибка открытия сценария '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Ошибка инициализации сценария"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Ошибка открытия LuaHook '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+msgid "Unknown error loading hook script"
+msgstr "Неизвестная ошибка при загрузке hook-скрипта"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, c-format
 msgid "Error openning %s or .\n"
 msgstr "Ошибка открытия %s или .\n"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Загрузка NV фрагмента программы: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Ошибка загрузки NV фрагмента программы: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Ошибка в фрагменте программы "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Инициализация NV фрагмента программы . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Все NV фрагменты программы успешно загружены.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Инициализация ABR фрагмента программы . . .\n"
+
+#, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr "%s: нераспознанный или неподдерживаемый тип файла изображения.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Загрузка NV шейдера: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Ошибка загрузки NV шейдера: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Ошибка в шейдере "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Загрузка ABR шейдера: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Ошибка загрузки ABR шейдера: "
+
+#~ msgid ", line "
+#~ msgstr ", строка "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Инициализация NV шейдеров . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Все NV шейдеры загружены успешно.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Инициализация ARB шейдеров . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Все ARB шейдеры загружены успешно.\n"
+
+#, c-format
+#~ msgid ""
+#~ "%s\n"
+#~ "Orientation: [%f, %f, %f], %.1f\n"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Ориентация: [%f, %f, %f], %.1f\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Неизвестная ошибка при открытии сценария"
+
+#, c-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Программе не удалось инициализировать расширения OpenGL (ошибка %i)."
+#~ "Качество графики будет снижено."
+
+#~ msgid ""
+#~ "Celestia is unable to run because the CelestiaResources folder was not "
+#~ "found, probably due to improper installation."
+#~ msgstr ""
+#~ "Celestia не может быть запущена, поскольку папка CelestiaResources не "
+#~ "была найдена, возможно, из-за неправильной установки."
+
+#, qt-format
+#~ msgid ""
+#~ "Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
+#~ "quality will be reduced."
+#~ msgstr ""
+#~ "Программе не удалось инициализировать расширения OpenGL (ошибка %1). "
+#~ "Качество графики было уменьшено."
+
+#~ msgid "Copy &URL"
+#~ msgstr "Ко&пировать ссылку"
+
+#~ msgid "&Paste URL"
+#~ msgstr "&Вставить ссылку"
+
+#~ msgid "Enable Vsync"
+#~ msgstr "Включить Vsync"
+
+#~ msgid "Nearest"
+#~ msgstr "Ближайшие"
+
+#~ msgid "Brightest"
+#~ msgstr "Ярчайшие"
+
+#~ msgid "With planets"
+#~ msgstr "С планетами"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Эклиптика"
+
+#~ msgid "Latin Names"
+#~ msgstr "Имена латиницей"
+
+#~ msgid "Terse"
+#~ msgstr "Кратко"
+
+#~ msgid "Verbose"
+#~ msgstr "Подробно"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Места посадок"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Горы"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Моря (океаны)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Долины"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Земли, области"
+
+#~ msgid "Label Features"
+#~ msgstr "Показывать местоположения"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Солнечные затмения"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Лунные затмения"
+
+#~ msgid "Vendor: "
+#~ msgstr "Производитель: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Версия GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Поддерживаемые расширения:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Ошибка открытия сценария"
+
+#~ msgid "Error loading script"
+#~ msgstr "Ошибка загрузки сценария"
+
+#~ msgid "Running script"
+#~ msgstr "Запуск сценария"
 
 #~ msgid "Kpc"
 #~ msgstr "кпк"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Merkúr"
 msgid "Venus"
 msgstr "Venuša"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Zem"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Mesiac"
 
@@ -47,140 +47,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymedes"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturn"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tetys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phoebe"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Urán"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptún"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereida"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Cháron"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluto"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Cháron"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Nouméa"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxie"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "SEVERNÁ AMERIKA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "JUŽNÁ AMERIKA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURÁZIA"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRÁLIA"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARKTÍDA"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "SEVERNÝ ATLANTICKÝ OCEÁN"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "JUŽNÝ ATLANTICKÝ OCEÁN"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "SEVERNÝ TICHÝ OCEÁN"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "JUŽNÝ TICHÝ OCEÁN"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "INDICKÝ OCEÁN"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "SEVERNÝ ĽADOVÝ OCEÁN"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abú Dabí"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Alžír"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ashgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asuncion"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Atény"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Peking"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Bejrut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belehrad"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlín"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Brusel"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bukurešť"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapešť"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Káhira"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Kapské Mesto"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Kišinev"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Konakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Kodaň"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damask"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Džibuti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dušanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltár"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Haag"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoj"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havana"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Džakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jeruzalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kábul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Kartum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kijev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuvajt"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "La'youn"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lisabon"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Londýn"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Male"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexico City"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadišo"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monako"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moskva"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Muškat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paríž"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Pénh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Praha"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangún"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Rijad"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Rím"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Maríno"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Soul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapur"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Srí Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Tchaj-pej"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Taškent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "T'bilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teherán"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripolis"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulanbátar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vatikán"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Viedeň"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Varšava"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Jerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Záhreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Mliečna cesta"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "MMM"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "VMM"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Barycentrum Slnečnej sústavy"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Letný čas"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "Štandardný čas"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Chyba pri otváraní obrázku "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Chyba pri čítaní konfiguračného súboru."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,88 +1482,59 @@ msgstr "Štandardný čas"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " telesá hlbokého vesmíru"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Načítava sa NV fragment program: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Chyba pri načítaní NV fragment programu: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Chyba vo fragment programe"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Inicializujú sa NV fragment programy . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Všetky NV fragment programy načítané úspešne. \n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Inicializujú sa ARB fragment programy . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxia (Hubblov typ: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Guľová hviezdokopa (polomer jadra: %4.2f', Kingova koncentrácia: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Načítava sa obrázok zo súboru "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": neznámy alebo nepodporovaný formát obrázku.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Chyba pri otváraní obrázku "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " nie je súbor typu PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Chyba pri čítaní súboru typu PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Načítava sa model: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Chyba pri čítaní modelu '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Hmlovina"
 
@@ -1309,92 +1542,92 @@ msgstr "Hmlovina"
 msgid "Open cluster"
 msgstr "Otvorená hviezdokopa"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Chyba v .ssc súbore (riadok "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "upozornenie viacnásobná definícia "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "zlý alternatívny povrch"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "zlé umiestnenie"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Zlá hlavička v krížovom indexe\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Zlá verzia pre krížový index\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Načítanie krížového indexu sa nepodarilo pri zázname "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " hviezdy v katalógu dvojhviezd\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Celkový počet hviezd: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Chyba v .stc súbore (riadok "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Neplatná hviezda: zlý spektrálny typ.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Neplatná hviezda: chýba spektrálny typ.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " neexistuje.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Neplatná hviezda: chýba rektascenzia\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Neplatná hviezda: chýba deklinácia.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Neplatná hviezda: chýba vzdialenosť.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Neplatná hviezda: chýba jasnosť.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1402,767 +1635,743 @@ msgstr ""
 "Neplatná hviezda: je potrebné špecifikovať absolútnu (nie zdanlivú) jasnosť "
 "hviezdy krátko po jej vzniku\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Vytvára sa dlaždicová textúra. Šírka="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Vytvára sa jednoduchá textúra: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Načítava sa NV vertex program: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Chyba pri načítaní NV vertex programu: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Chyba vo vertex programe "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Načítava sa ARB vertex program: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Chyba pri načítaní ARB vertex programu: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", riadok "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Inicializujú sa NV vertex programy . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Všetky NV vertex programy načítané úspešne.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Inicializujú sa ARB vertex programy . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Všetky ARB vertex programy načítané úspešne.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Chyba pri otváraní "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Chyba pri čítaní súboru typu PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Chyba pri čítaní súboru s obľúbenými položkami."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Chyba pri otváraní skriptového súboru."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Chyba pri otváraní skriptu '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Neznáma chyba pri otváraní skriptu"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Chyba pri inicializácii skriptu podprogramu"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Neplatný typ súboru"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Medzná hviezdna veľkosť-jasnosť: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Značky zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Značky vypnuté"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Prejsť na povrch"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Azimut režim zapnutý"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Azimut režim vypnutý"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Tvar hviezd: neostré body"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Tvar hviezd: body"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Zobrazenie hviezd: kotúče v mierke"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Chvosty komét zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Chvosty komét vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Spôsob vykresľovania: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Značky zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Značky vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Automatická hviezdna jasnosť zapnutá"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Automatická hviezdna jasnosť vypnutá"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Čas a skript sú pozastavené"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Čas je pozastavený"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Pokračovať"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Hviezdny katalóg..."
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Hviezdny katalóg..."
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Čas putovania svetla: %.4f rokov "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Čas putovania svetla:  %d min.  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Čas putovania svetla:  %d hod.  %d min.  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Počíta sa so spomalením cesty svetla"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Spomalenie cesty svetla vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Nepočíta sa so spomalením cesty svetla"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Používajú sa normálne povrchové textúry."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Používajú sa textúry podľa dostupných vedomostí."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Nasledovať"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Čas: Dopredu"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Čas: Dozadu"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Rýchlosť času"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Textúry"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Textúry"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Textúry"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Synchronizovať obežnú dráhu"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Zamknúť"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Prenasledovať"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Medzná hviezdna veľkosť-jasnosť: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Medzná hviezdna veľkosť pri 45 stupňoch:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Úroveň rozptýleného svetla:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Zosilnenie svetla"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Presvetlenie zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Presvetlenie vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Expozícia"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Chyba GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Pohľad je príliš malý na rozdelenie"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Pohľad pridaný"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "ly"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "AU"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " dní"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " hodín"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minút"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " sekúnd"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Rýchlosť: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Zdanlivý priemer: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Zdanlivá hviezdna jasnosť: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolútna hviezdna jasnosť: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Barycentrum (ťažisko) hviezdneho systému\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs. (zdan.) jasnosť: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Svietivosť: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Neutrónová hviezda"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Čierna diera"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Trieda: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Povrchová teplota: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Existujú planetárni súputníci\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Vzdialenosť od stredu: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fázový uhol: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Teplota: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  Miestny čas"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Skutočný čas"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Skutočný čas"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Čas zastavený"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " rýchlejšie"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " pomalšie"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pozastavený)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Cestovanie "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Cestovanie "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Sleduje sa "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Nasleduje sa "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchr. obeh nad "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Prenasleduje sa "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Slnko"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Názov cieľa: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " Pozastavené"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Nahrávanie"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Spustiť/Pozastaviť    F12 Ukončiť"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Režim zmien"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Načítava sa katalóg slnečnej sústavy: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Načítava sa katalóg slnečnej sústavy: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Chyba pri čítaní konfiguračného súboru."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Inicializácia knižnice SPICE sa nepodarila."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Nedá sa čítať databáza hviezd."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Chyba pri otváraní katalógu deepsky objektov."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Nedá sa čítať databáza hviezd."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Chyba pri otváraní katalógu Slnečnej sústavy.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Chyba pri otváraní súboru asterizmov."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Chyba pri otváraní súboru hraníc súhvezdí."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Inicializácia vykresľovania neúspešná"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Chyba pri načítaní fontu; text nebude viditeľný.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Chyba pri načítaní krížového indexu "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Krížový index načítaný "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Chyba pri načítaní súboru s názvami hviezd\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Chyba pri otváraní "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Chyba pri načítaní súboru s názvami hviezd\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Chyba pri čítaní súboru hviezd\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Chyba pri otváraní hviezdneho katalógu "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Chyba pri otváraní skriptu '%s'"
+msgid "%s Version: %s\n"
+msgstr "Verzia: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Neznáma chyba pri otváraní skriptu"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Dodávateľ: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Vykresľovací systém: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Max. počet simultánnych textúr: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Max. veľkosť textúry: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Rozsah veľkostí bodov: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Rozsah veľkostí bodov: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Maximálna veľkosť priestorovej mapy: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2359,14 +2568,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Chyba pri vytváraní ogg súboru %s na záznam videa.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Chyba internej knižnice Ogg."
@@ -2385,46 +2594,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - %d snímok zapísaných\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Hviezdny katalóg..."
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "&Informácie"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Slnečná sústava"
 
@@ -2434,21 +2634,20 @@ msgstr "Slnečná sústava"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Hviezdy"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " telesá hlbokého vesmíru"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Vyhľadávač zatmení..."
@@ -2457,466 +2656,517 @@ msgstr "Vyhľadávač zatmení..."
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Čas"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Sprievodca"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Celá obrazovka"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Nahrať video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Chyba pri otváraní súboru asterizmov."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Záložky"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Uložiť ako:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " nie je súbor typu PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Rozlíšenie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Snímok za sekundu:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "URL skopírované"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Načítava sa URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Otvoriť skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Vytvoriť nový priečinok záložiek v tomto menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
+msgid "Unknown compiler"
+msgstr "Neznáma chyba pri otváraní skriptu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
+#: ../src/celestia/qt/qtappwin.cpp:1043
 #, fuzzy
-msgid "<b>Renderer: </b>"
-msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
-msgstr "Verzia GLSL: "
-
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
-msgstr "Max. veľkosť textúry: "
-
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-#, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "supported"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1045
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Informácie o OpenGL"
+msgid "not supported"
+msgstr "Podporované rozšírenia:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "O Celestii"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Dodávateľ: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "Verzia GLSL: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Max. počet simultánnych textúr: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Max. veľkosť textúry: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Rozsah veľkostí bodov: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Rozsah veľkostí bodov: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Maximálna veľkosť priestorovej mapy: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Rovníková"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Podporované rozšírenia:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Vykresľovací systém: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "Súbor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Snímok obrazovky"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Snímok obrazovky...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Nahrať video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopírovať URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Kopírovať URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "URL skopírované"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Otvoriť skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Nastavenia Celestie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Ukončiť"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Vyhladzovanie\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigácia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "Vybrať"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Vycentrovať na výber\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Výber: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Prejsť k objektu..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 #, fuzzy
 msgid "&Time"
 msgstr "Čas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Nastaviť čas..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Zobrazenie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objekty"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Tiene prstencov"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Tvar &hviezd"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Rozlíšenie &textúr"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Ovládanie"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 #, fuzzy
 msgid "&Bookmarks"
 msgstr "Záložky"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Pohľad"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Pohľady"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Rozdeliť pohľad zvislo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Rozdeliť vodorovne\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Rozdeliť pohľad vodorovne"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Rozdeliť zvislo\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Prepnúť na ďalší pohľad"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Jediný pohľad"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Jediný pohľad\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Zrušiť pohľad"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Vymazať"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Ohraničenia pohľadov zobrazené"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktívny pohľad zvýraznený"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synchronizovať čas"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Pomoc"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "O Celestii"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Informácie o OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Pridať záložku"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizovať záložky"
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Načítava sa "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skripty"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Trvanie"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "Záložky"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Hlavný panel nástrojov"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Chyba pri čítaní súboru s obľúbenými položkami."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Záložky"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Nastaviť čas simulácie"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Nastaviť čas simulácie"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Čas"
@@ -2925,79 +3175,77 @@ msgstr "Čas"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Nový priečinok..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Zobraziť rovníkovú súradnicová sieť"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galaktická"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Ekliptická"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horizontálna"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Čiara ekliptiky"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Značky"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Vycentrovať na výber\tC"
@@ -3006,57 +3254,54 @@ msgstr "&Vycentrovať na výber\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Súhvezdia"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners, žiadne vertex programy</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Hranice súhvezdí"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Obežné dráhy"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planéty"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Trpasličie planéty"
 
@@ -3066,19 +3311,17 @@ msgstr "Trpasličie planéty"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Mesiace"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Malé mesiace"
 
@@ -3088,12 +3331,12 @@ msgstr "Malé mesiace"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroidy"
 
@@ -3103,12 +3346,12 @@ msgstr "Asteroidy"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Kométy"
 
@@ -3118,14 +3361,15 @@ msgstr "Kométy"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Kozmické lode"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x Rýchlejšie\tL"
@@ -3134,9 +3378,8 @@ msgstr "10x Rýchlejšie\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Názvy"
 
@@ -3144,20 +3387,18 @@ msgstr "Názvy"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxie"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Guľové hviezdokopy"
 
@@ -3165,7 +3406,7 @@ msgstr "Guľové hviezdokopy"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3175,615 +3416,632 @@ msgstr "Otvorené hviezdokopy"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Hmloviny"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Lokality"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Otvorené hviezdokopy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Oblaky"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Svetlá na nočnej strane"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Chvosty komét"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosféry"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Tiene prstencov"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Tiene zatmení"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Tiene oblakov"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Nízke"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Stredné"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Vysoké"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Automatická hviezdna jasnosť\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Zobraziť viac hviezd\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Zobraziť menej hviezd\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Body"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "N&eostré body"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&Kotúče v mierke"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Spomalenie cesty svetla vypnuté"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Alt-Azimut režim zapnutý"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Medzná hviezdna veľkosť pri 45 stupňoch:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Medzná hviezdna veľkosť-jasnosť: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Názov"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Vzdialenosť (ly-svet.roky)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Zdan. jasnosť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs. jasnosť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Hviezdy"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Najjasnejšie"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrovať hviezdy"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "S planétami"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Hviezdy"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Barycentrum (ťažisko)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Obnoviť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Označiť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximum hviezd v zozname"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Označiť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Značky"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Žiadny"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Kosoštvorec"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Trojuholník"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Štvorec"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Kruh"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Šípka doľava"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Šípka doprava"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Šípka hore"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Šípka dole"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Vybrať"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Veľkosť:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Vybrať"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Pomenovať útvary"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objekty"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Označiť"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "materské teleso '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Začiatok"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Trvanie"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Zatmenia Slnka"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Zatmenia Mesiaca"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Odznačiť &všetko"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Hľadať"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Zatmenia mesiacov"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Objekt: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Zatmenia Slnka"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Nastaviť čas na aktuálny"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Od:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Trvanie: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Informácie"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Informácie"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Vzdialenosť: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Veľkosť: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informačný text"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Tvar &hviezd"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Miestny formát"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Názov časového pásma"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Posun voči svetovému času"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Začiatok"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3802,21 +4060,21 @@ msgid "&Select"
 msgstr "Vybrať"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrovať"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Prejsť na"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Nasledovať"
 
@@ -3830,49 +4088,54 @@ msgid "Visible"
 msgstr "Aktívny pohľad zvýraznený"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Zrušiť označenie"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Zvoliť režim zobrazenia"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Vyplnený štvorec"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Kotúč/disk"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Označiť"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Referenčné značky"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Zobraziť osi telesa"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Zobraziť osi pohľadu"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Zobraziť smer k slnku"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Zobraziť vektor rýchlosti"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Zobraziť vektor rýchlosti"
@@ -3880,191 +4143,41 @@ msgstr "Zobraziť vektor rýchlosti"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Zobraziť smer k slnku"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Zobraziť planetografickú súradnicovú sieť"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Zobraziť terminátor"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternatívne povrchy"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normálne"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Kozmická loď"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objekty"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Nastaviť čas..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Časové pásmo: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Svetový čas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Miestny čas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Časové pásmo: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Dátum"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Nastaviť"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Nastaviť"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Nastaviť"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "Čas"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " hodín"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minút"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " sekúnd"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Juliánsky dátum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Juliánsky dátum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Nastaviť čas..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Barycentrum (ťažisko)"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planéta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Trpasličia planéta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Malé mesiace"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroid"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Kométa"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Referenčné značky"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Vypočítať"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Prejsť na povrch"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Neznáma chyba pri otváraní skriptu"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroidy"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Referenčné značky"
+msgid "Dwarf planets"
+msgstr "Trpasličie planéty"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4072,67 +4185,235 @@ msgstr "&Referenčné značky"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Malé mesiace"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Kozmická loď"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objekty"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Nastaviť čas..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Časové pásmo: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Svetový čas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Miestny čas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Časové pásmo: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Dátum"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Nastaviť"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Nastaviť"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Nastaviť"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "Čas"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " hodín"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minút"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " sekúnd"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Juliánsky dátum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Juliánsky dátum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Nastaviť čas..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Barycentrum (ťažisko)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planéta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Trpasličia planéta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Malé mesiace"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroid"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Kométa"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Referenčné značky"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Vypočítať"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Prejsť na povrch"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Neznáma chyba pri otváraní skriptu"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroidy"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Referenčné značky"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Iné útvary"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planéty"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objekty"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Spätný chod času"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x Pomalšie\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " pomalšie"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Pozastaviť čas"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " rýchlejšie"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x Rýchlejšie\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Nastaviť na aktuálny čas"
@@ -4204,7 +4485,6 @@ msgstr "Zemepisná šírka: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "polomerov"
 
@@ -4225,7 +4505,7 @@ msgstr "Rozlíšenie: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organizovať záložky"
 
@@ -4256,18 +4536,6 @@ msgstr "Nastavenia Celestie"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objekty"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Trpasličie planéty"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4358,49 +4626,43 @@ msgstr "Čiastočné trajektórie"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Súradnicové siete"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Rovníková"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptická"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktická"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horizontálna"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagramy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Hranice súhvezdí"
 
@@ -4434,7 +4696,6 @@ msgstr "zlé umiestnenie"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Mestá"
 
@@ -4448,21 +4709,18 @@ msgstr "Miesta pristátí"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Sopky"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatóriá"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Krátery"
 
@@ -4497,7 +4755,6 @@ msgstr "Maria (Moria)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Iné útvary"
 
@@ -4602,7 +4859,7 @@ msgstr "Zobrazenie"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Nastavenia"
 
@@ -4845,21 +5102,21 @@ msgid "&About Celestia"
 msgstr "&O Celestii"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4868,531 +5125,621 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2009, Vývojový tím Celestie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia je voľne šíriteľný softvér a je úplne bez záruky."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Autori"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Vybrať objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Názov objektu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licencia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Ovládanie Celestie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Informácie o ovládači OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Nastaviť čas simulácie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Formát:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Nastaviť na aktuálny čas"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Pridať záložku"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Vytvoriť v >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Nový priečinok..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Katalóg Slnečnej sústavy"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Pridať nový priečinok záložiek"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "Prejsť"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Názov priečinka"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Ovládanie Celestie"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "Zvoliť režim zobrazenia"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "Rozlíšenie"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Vyhľadávač zatmení..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Vypočítať"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Nastaviť dátum a prejsť k planéte"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Zavrieť"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Parametre vyhľadávania"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Vybrať objekt"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Objekty Slnečnej sústavy"
+msgid "Object Name"
+msgstr "Názov objektu"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Hviezdny katalóg"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Najbližšie"
+msgid "OpenGL Driver Info"
+msgstr "Informácie o ovládači OpenGL"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Najjasnejšie"
+msgid "Go to Object"
+msgstr "Prejsť k objektu"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "S planétami"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Obnoviť"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Kritériá vyhľadávania hviezd"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maximum hviezd v zozname"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Sprievodca"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 #, fuzzy
 msgid "Go To"
 msgstr "Prejsť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Vybrať cieľ:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Prejsť k objektu"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "Object"
 msgstr "Objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:124
 msgid "Long."
 msgstr "Zem. dĺžka"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:140
+#: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "Lat."
 msgstr "Zem. šírka"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Distance"
 msgstr "Vzdialenosť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Veľkosť:"
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licencia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "Zvoliť režim zobrazenia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "Rozlíšenie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Možnosti zobrazenia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Zobraziť"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Zobrazenie"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Čiara ekliptiky"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Dráhy / Názvy"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Latinské názvy"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Informačný text"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Stručný"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Podrobný"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Miesta pristátí"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Hory)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Moria)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Údolia)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Pevniny)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Pomenovať útvary"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Zobraziť útvary"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Pomenovať útvary"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Minimálna veľkosť útvaru s názvom"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Pridať nový priečinok záložiek"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Veľkosť:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Názov priečinka"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Premenovať..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Premenovať záložku alebo priečinok"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nový názov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Vyhľadávač zatmení..."
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Nastaviť čas simulácie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Vypočítať"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Formát:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Nastaviť dátum a prejsť k planéte"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Nastaviť na aktuálny čas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Zavrieť"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Katalóg Slnečnej sústavy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Od:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "Prejsť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Objekty Slnečnej sústavy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Hviezdny katalóg"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Parametre vyhľadávania"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Obnoviť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Zatmenia Slnka"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Kritériá vyhľadávania hviezd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Zatmenia Mesiaca"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maximum hviezd v zozname"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Sprievodca"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Vybrať cieľ:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Možnosti zobrazenia"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Zobraziť"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Zobrazenie"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Dráhy / Názvy"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Informačný text"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "41b"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jún"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Máj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Júl"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satelit"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Dátum"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Začiatok"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Dodávateľ: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Režim v okne"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Vykresľovací systém: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Neviditeľné objekty"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "S&ynchronizovať obežnú dráhu"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Informácie"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Zobraziť osi telesa"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Zobraziť osi pohľadu"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Zobraziť smer k slnku"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Zobraziť vektor rýchlosti"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Zobraziť planetografickú súradnicovú sieť"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Zobraziť terminátor"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satelity"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Obiehajúce telesá"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Načítava sa: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "sk"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Načítava sa URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Verzia: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Verzia GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Max. počet simultánnych textúr: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Max. veľkosť textúry: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Maximálna veľkosť priestorovej mapy: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Rozsah veľkostí bodov: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Podporované rozšírenia:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Režim v okne"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Neviditeľné objekty"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "S&ynchronizovať obežnú dráhu"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Informácie"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Zobraziť osi telesa"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Zobraziť osi pohľadu"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Zobraziť smer k slnku"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Zobraziť vektor rýchlosti"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Zobraziť planetografickú súradnicovú sieť"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Zobraziť terminátor"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satelity"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Obiehajúce telesá"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Načítava sa: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "sk"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Načítava sa URL"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Chyba pri otváraní skriptu"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Chyba pri čítaní skriptu"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Spúšťa sa skript"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Názov časového pásma"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Posun voči svetovému času"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Chyba pri otváraní skriptového súboru."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Neznáma chyba pri otváraní skriptu"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Chyba pri otváraní skriptu '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Chyba pri inicializácii skriptu podprogramu"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Chyba pri otváraní skriptu '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Neznáma chyba pri otváraní skriptu"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Chyba pri otváraní "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Načítava sa NV fragment program: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Chyba pri načítaní NV fragment programu: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Chyba vo fragment programe"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Inicializujú sa NV fragment programy . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Všetky NV fragment programy načítané úspešne. \n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Inicializujú sa ARB fragment programy . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": neznámy alebo nepodporovaný formát obrázku.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Načítava sa NV vertex program: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Chyba pri načítaní NV vertex programu: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Chyba vo vertex programe "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Načítava sa ARB vertex program: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Chyba pri načítaní ARB vertex programu: "
+
+#~ msgid ", line "
+#~ msgstr ", riadok "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Inicializujú sa NV vertex programy . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Všetky NV vertex programy načítané úspešne.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Inicializujú sa ARB vertex programy . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Všetky ARB vertex programy načítané úspešne.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Neznáma chyba pri otváraní skriptu"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Kopírovať URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "URL skopírované"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Alt-Azimut režim zapnutý"
+
+#~ msgid "Nearest"
+#~ msgstr "Najbližšie"
+
+#~ msgid "Brightest"
+#~ msgstr "Najjasnejšie"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "S planétami"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Čiara ekliptiky"
+
+#~ msgid "Latin Names"
+#~ msgstr "Latinské názvy"
+
+#~ msgid "Terse"
+#~ msgstr "Stručný"
+
+#~ msgid "Verbose"
+#~ msgstr "Podrobný"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Miesta pristátí"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Hory)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Moria)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Údolia)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Pevniny)"
+
+#~ msgid "Label Features"
+#~ msgstr "Pomenovať útvary"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Zatmenia Slnka"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Zatmenia Mesiaca"
+
+#~ msgid "Vendor: "
+#~ msgstr "Dodávateľ: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Verzia GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Podporované rozšírenia:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Chyba pri otváraní skriptu"
+
+#~ msgid "Error loading script"
+#~ msgstr "Chyba pri čítaní skriptu"
+
+#~ msgid "Running script"
+#~ msgstr "Spúšťa sa skript"
 
 #~ msgid "Invisible"
 #~ msgstr "Neviditeľný objekt"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 21:01+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "Merkurius"
 msgid "Venus"
 msgstr "Venus"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Jorden"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Måne"
 
@@ -47,140 +47,140 @@ msgstr "Phobos"
 msgid "Deimos"
 msgstr "Deimos"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Jupiter"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Amalthea"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Io"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Europa"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ganymede"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Callisto"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Saturnus"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Pandora"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Janus"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Mimas"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Enceladus"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Tethys"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Dione"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Rhea"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Titan"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Hyperion"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Iapetus"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Phobos"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Uranus"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Miranda"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Ariel"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Umbriel"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Titania"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Oberon"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Neptunus"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Larissa"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Proteus"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Triton"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Nereid"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Pluto-Charon"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Pluto"
 
@@ -189,1028 +189,1290 @@ msgid "Charon"
 msgstr "Charon"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Noumea"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Bamako"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Amalthea"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Callisto"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Jan"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Galaxer"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "NORDAMERIKA"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "SYDAMERIKA"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "EURASIEN"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "AUSTRALIEN"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "ANTARKTIS"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NORDATLANTEN"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "SYDATLANTEN"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NORRA STILLA HAVET"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "SÖDRA STILLA HAVET"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "INDISKA OCEANEN"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "NORRA ISHAVET"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Abuja"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Accra"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Alger"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Alofi"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Amman"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Ankara"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Apia"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Asjchabad"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Asmara"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Aten"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Avarua"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Baku"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Bamako"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Bangui"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Banjul"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Peking"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Beirut"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Berlin"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Bern"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Bissau"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Bogota"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Bryssel"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Bukarest"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Budapest"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Kairo"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Canberra"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Kapstaden"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Caracas"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Castries"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Colombo"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Conakry"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Köpenhamn"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Dakar"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Damaskus"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Dili"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Doha"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Douglas"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Dublin"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Dusjanbe"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Freetown"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "George Town"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Haag"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Harare"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Havanna"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Helsingfors"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Kabul"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Kampala"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Kiev"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Kigali"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Kingston"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Koror"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "La Paz"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Libreville"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Lima"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Lissabon"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Lome"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "London"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Luanda"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Madrid"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Majuro"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Malabo"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Manlig"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Managua"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Manama"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Manila"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Maputo"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Maseru"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Mexico City"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Minsk"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Monaco"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Moroni"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Moskva"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Muskat"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Nassau"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Niamey"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Noumea"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nukualofa"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Oslo"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Panama"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Paris"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Prag"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Praia"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "P'yŏngyang"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Quito"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Rabat"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Riga"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Rom"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Roseau"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Saipan"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "San Jose"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "San Juan"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "San Marino"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Sana"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Santiago"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Seoul"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "Förlikningsavtalet"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Singapore"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Skopje"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Sofia"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Stanley"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Sucre"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Suva"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Taipei"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Tasjkent"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Teheran"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Tel Aviv-Jaffa"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Tirana"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Tunis"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Valletta"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Vatikanstaten"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Victoria"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Wien"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Warszawa"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Wellington"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Vintergatan"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Stjärnsystemets masscentrum"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Sommartid"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "Standardtid"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Fel vid öppning av bildfil "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Fel vid läsning av konfigurationsfil."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1220,87 +1482,58 @@ msgstr "Standardtid"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " rymdobjekt"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Läser NV-fragmentprogram: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Fel vid läsning av NV-fragmentprogram: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Fel i fragmentprogram "
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Initierar NV-fragmentprogram . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Alla NV-fragmentprogram lästa.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Initierar ARB-fragmentprogram . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galax (Hubble-typ: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Läser bild från fil "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ": okänd eller ej stödd bildfilstyp.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Fel vid öppning av bildfil "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " är inte en PNG-fil.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Fel vid läsning av PNG-bildfil "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Läser modell: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Fel vid inläsning av modell '"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Nebulosa"
 
@@ -1308,92 +1541,92 @@ msgstr "Nebulosa"
 msgid "Open cluster"
 msgstr "Öppen stjärnhop"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Fel i .ssc-fil (rad "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "varning för dubbla definitioner av "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "felaktig alternativ yta"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "felaktig plats"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Felaktigt huvud för korsindex\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Felaktig version för korsindex\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Läsning av korsindex misslyckades på post "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " stjärnor i binärdatabasen\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Totalt antal stjärnor: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Fel i .stc-fil (rad "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ogiltig stjärna: felaktig spektraltyp.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ogiltig stjärna: saknar spektraltyp.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " finns ej.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ogiltig stjärna: saknar rektascension\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Ogiltig stjärna: saknar deklination.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Ogiltig stjärna: saknar avstånd.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ogiltig stjärna: saknar magnitud.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1401,767 +1634,743 @@ msgstr ""
 "Felaktig stjärna: absolut (inte apparent) magnitud måste anges för en "
 "stjärna nära ursprung\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Skapar rutad textur. Bredd="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Skapar vanlig textur: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Läser NV-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Fel vid läsning av NV-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Fel i vertexprogram "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Läser ARB-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Fel vid inläsning av ARB-vertexprogram: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", rad "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Initierar NV-vertexprogram . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Alla NV-vertexprogram lästa.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Initierar ARB-vertexprogram . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Alla ARB-vertexprogram lästa.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Fel vid öppning av "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Fel vid läsning av PNG-bildfil "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Fel vid läsning av favoritfil."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Fel vid öppning av skriptfil."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Fel vid öppning av skript '%s'"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Okänt fel vid öppning av skript"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Initiering av skriptets medrutin misslyckades"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Ogiltig filtyp"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudgräns: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Markörer aktiverade"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Markörer inaktiverade"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Gå till yta"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-azimutläge aktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-azimutläge inaktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Visa stjärnor som: suddiga punkter"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Visa stjärnor som: punkter"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Visa stjärnor som: skalenliga skivor"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Kometsvansar aktiverade"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Kometsvansar inaktiverade"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Renderingsläge: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-azimutläge aktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-azimutläge inaktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Automagnitud aktiverad"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Automagnitud inaktiverad"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Tid och skript är pausade"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Tiden är pausad"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Återuppta"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Totalt antal stjärnor: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Totalt antal stjärnor: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Ljusets restid:  %.4f år "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Ljusets restid:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Ljusets restid:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "Fördröjning för ljusets resa inberäknad"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Fördröjning för ljusets resa avstängd"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Fördröjning för ljusets resa ignoreras"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Använder normala yttexturer."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Använder yttexturer utanför kunskapsgräns."
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Följ"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Tid: Framåt"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Tid: Bakåt"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Tidsfrekvens"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturer"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturer"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturer"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Synkronisera omloppsbana"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Lås"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Jaga"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudgräns: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automagnitudgräns på 45 grader:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Nivå för omgivande ljus: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Ljusförstärkning"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Överstrålning aktiverad"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Överstrålning inaktiverad"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Exponering"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL-fel: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Vy för liten för att delas upp"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Lade till vy"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "lå"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "au"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " dagar"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " timmar"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " minuter"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " sekunder"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " lå/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Hastighet: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Apparent diameter: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Apparent magnitud: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolut magnitud: "
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Avstånd: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Stjärnsystemets masscentrum\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (ungefärlig) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Ljusstyrka: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Neutronstjärna"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Svart hål"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klass: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Yttemperatur: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Radie: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Radie: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Följeslagare till stjärnan finns\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Avstånd från centrum: "
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radie: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fasvinkel: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Realtid"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Realtid"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Tid stoppad"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " snabbare"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " långsammare"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Pausad)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Reser "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Reser "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Spåra "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Följ "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synkronisera omloppsbana "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Jaga"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Sol"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Målnamn: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "  Pausad"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Spelar in"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Paus     F12 Stopp"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Redigeringsläge"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Läser solsystemskatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Läser solsystemskatalog: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Fel vid läsning av konfigurationsfil."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Initiering av SPICE-biblioteket misslyckades."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Kan inte läsa stjärndatabas."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Fel vid öppning av deep-sky-katalog "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Kan inte läsa stjärndatabas."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Fel vid öppning av solsystemskatalog.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Fel vid öppning av asterismfil."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Fel vid öppning av filer för begränsning av stjärnbilder."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Misslyckades med att initiera renderare"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Fel vid läsning av typsnitt; text kommer inte att vara synlig.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Fel vid läsning av korsindex "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Läste in korsindex "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Fel vid läsning av stjärnnamnsfil\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Fel vid öppning av "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Fel vid läsning av stjärnnamnsfil\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Fel vid läsning av stjärnfil\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Fel vid öppning av stjärnkatalog "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Fel vid öppning av skript '%s'"
+msgid "%s Version: %s\n"
+msgstr "Version: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Okänt fel vid öppning av skript"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Tillverkare: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Uppritare: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Max samtidiga texturer: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Max texturstorlek: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Intervall för punktstorlek: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Intervall för punktstorlek: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Max kubmappstorlek: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2358,14 +2567,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Fel vid skapande av ogg-filen %s för fångst.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Internt fel i Ogg-bibliotek."
@@ -2384,46 +2593,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - skrev %d frames\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Himlabläddrare"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "Himlabläddrare"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Solsystemet"
 
@@ -2433,21 +2633,20 @@ msgstr "Solsystemet"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Stjärnor"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " rymdobjekt"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Förmörkelsefinnare"
@@ -2456,463 +2655,514 @@ msgstr "Förmörkelsefinnare"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Tid"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Turnéguide"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "Helskärm"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Fånga &film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Fel vid öppning av asterismfil."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Lägg till bokmärke..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Spara som:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " är inte en PNG-fil.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Upplösning: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Bildfrekvens:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Kopierad URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Läser url"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "Ö&ppna skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Skapa en ny bokmärkesmapp i denna meny"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "Okänt fel vid öppning av skript"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "Utökningar som stöds:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "Utökningar som stöds:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Om Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0-skuggspråk</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Tillverkare: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL-version: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Max samtidiga texturer: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "Max texturstorlek: "
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Intervall för punktstorlek: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Intervall för punktstorlek: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Max kubmappstorlek: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Radie: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
-msgid "OpenGL Info"
-msgstr "OpenGL-Info"
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Uppritare: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Arkiv"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Fånga bild"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Fånga &bild...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Fånga &film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopiera URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Kopiera URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Kopierad URL"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Ö&ppna skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Inställningar för Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Avsluta"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Kantutjämning\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigering"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Välj"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrera valt objekt\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Val: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Gå till objekt..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tid"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Ställ tid..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Visa"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Markerade objekt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Visa molnskuggor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Stjärnutseende"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Texturens upplösning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Kontroller"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Bokmärken"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Visa"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vyer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dela vy vertikalt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dela vy &horisontellt\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dela vy horisontellt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dela vy &vertikalt\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Växla vy"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Enkel vy"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Enkel vy\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Ta bort vy"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Ta bort"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Synliga ramar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktiva ramar synliga"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synkronisera tid"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Hjälp"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Inställningar för Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Om Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+msgid "OpenGL Info"
+msgstr "OpenGL-Info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Lägg till bokmärke"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organisera bokmärken..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Läser "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skript"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Längd"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Bokmärken"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Huvudverktygsrad"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Fel vid läsning av favoritfil."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Bokmärken"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Ställ in simuleringstid"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Ställ in simuleringstid"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Tid"
@@ -2921,79 +3171,77 @@ msgstr "Tid"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Ny mapp..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Visa himlarutnät"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Galaktisk"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Himlarutnät"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Horisontell"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Ekliptika"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Markörer"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Centrera valt objekt\tC"
@@ -3002,57 +3250,54 @@ msgstr "&Centrera valt objekt\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Stjärnbilder"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA-kombinerare, inga vertexprogram</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Gränser för stjärnbilder"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "OK"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Omloppsbanor"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Planeter"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Dvärgplaneter"
 
@@ -3062,19 +3307,17 @@ msgstr "Dvärgplaneter"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Månar"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Mindre månar"
 
@@ -3084,12 +3327,12 @@ msgstr "Mindre månar"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroider"
 
@@ -3099,12 +3342,12 @@ msgstr "Asteroider"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Kometer"
 
@@ -3114,14 +3357,15 @@ msgstr "Kometer"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Rymdfarkoster"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x &snabbare\tL"
@@ -3130,9 +3374,8 @@ msgstr "10x &snabbare\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Etiketter"
 
@@ -3140,20 +3383,18 @@ msgstr "Etiketter"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Galaxer"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Klotformiga stjärnhopar"
 
@@ -3161,7 +3402,7 @@ msgstr "Klotformiga stjärnhopar"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3171,615 +3412,632 @@ msgstr "Öppna stjärnhopar"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Nebulosor"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Platser"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Öppna stjärnhopar"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Moln"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Ljus på nattsidan"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Kometsvansar"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Atmosfärer"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Ringskuggor"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Förmörkelseskuggor"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Molnskuggor"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Låg"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Medel"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Hög"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Automagnitud\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Fler synliga stjärnor\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Färre synliga stjärnor\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Punkter"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&Suddiga punkter"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "Nedskalade &skivor"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Fördröjning för ljusets resa avstängd"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "Alt-azimutläge aktiverat"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Automagnitudgräns på 45 grader:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudgräns: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Namn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "App. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Abs. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Visa stjärnor"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Stjärnor"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrera stjärnor"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "Med planeter"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Visa stjärnor"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Masscentrum "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Markera"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximalt antal stjärnor visade i lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Markera"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markörer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Diamant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Triangel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Kvadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Cirkel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Vänsterpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Högerpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Uppåtpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Nedåtpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Välj &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Storlek:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Välj &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Etikettfunktioner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objekt"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Markera"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "föräldrakropp '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Starta helskärm"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Längd"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Solförmörkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Månförmörkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Avmarkera &alla"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Intervall för punktstorlek: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Månförmörkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Välj &objekt..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Solförmörkelser"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Ställ tid till nu"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Läser bild från fil "
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Avstånd (lj)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Storlek: %1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informationstext"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Stjärnutseende"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Lokalt format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Namn på tidszon"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Avvikelse från UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Start"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3798,21 +4056,21 @@ msgid "&Select"
 msgstr "&Välj"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "&Centrera"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Gå till"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Följ"
 
@@ -3826,49 +4084,54 @@ msgid "Visible"
 msgstr "Aktiva ramar synliga"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Avmarkera"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Välj visningsläge"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Fylld fyrkant"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Disk"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Markera"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Referensvektorer"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Visa kroppsaxlar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Visa ramaxlar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Visa solriktning"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Visa hastighetsvektor"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Visa hastighetsvektor"
@@ -3876,191 +4139,41 @@ msgstr "Visa hastighetsvektor"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Visa solriktning"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Visa planetografiskt rutnät"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Visa terminator"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Alternativa ytor"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Rymdfarkost"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Objekt"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Ställ tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Tidszon: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Universaltid"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "Lokal tid"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Namn på tidszon"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Datum"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Ställ tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Ställ tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Ställ tid..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Tid"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " timmar"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " minuter"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " sekunder"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Julianskt datum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Julianskt datum: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Ställ tid..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-#, fuzzy
-msgid "Barycenter"
-msgstr "Masscentrum "
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Planet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Dvärgplanet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Mindre månar"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Asteroid"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Komet"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Referensvektorer"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Beräkna"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Gå till yta"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Okänt fel vid öppning av skript"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Asteroider"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Referensvektorer"
+msgid "Dwarf planets"
+msgstr "Dvärgplaneter"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4068,67 +4181,235 @@ msgstr "&Referensvektorer"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Mindre månar"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Rymdfarkost"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Objekt"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Ställ tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Tidszon: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Universaltid"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "Lokal tid"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Namn på tidszon"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Datum"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Ställ tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Ställ tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Ställ tid..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Tid"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " timmar"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " minuter"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " sekunder"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Julianskt datum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Julianskt datum: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Ställ tid..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#, fuzzy
+msgid "Barycenter"
+msgstr "Masscentrum "
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Planet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Dvärgplanet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Mindre månar"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Asteroid"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Komet"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Referensvektorer"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Beräkna"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Gå till yta"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Okänt fel vid öppning av skript"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Asteroider"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Referensvektorer"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Övriga funktioner"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Planeter"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objekt"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Omvänd tid"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x &långsammare\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " långsammare"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Pausa tid"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " snabbare"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x &snabbare\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Ställ in till aktuell tid"
@@ -4200,7 +4481,6 @@ msgstr "Latitud: "
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "radii"
 
@@ -4221,7 +4501,7 @@ msgstr "Upplösning: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Organisera bokmärken"
 
@@ -4252,18 +4532,6 @@ msgstr "Inställningar för Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Objekt"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Dvärgplaneter"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4354,14 +4622,13 @@ msgstr "Partiella banor"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Rutnät"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 #, fuzzy
 msgid "Equatorial"
 msgstr "Visa himlarutnät"
@@ -4369,35 +4636,30 @@ msgstr "Visa himlarutnät"
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Ekliptika"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Galaktisk"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Horisontell"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Diagram"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Gränser"
 
@@ -4431,7 +4693,6 @@ msgstr "Visa etiketter på platser"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Städer"
 
@@ -4445,21 +4706,18 @@ msgstr "Landningsplatser"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Vulkaner"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Observatorier"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Kratrar"
 
@@ -4494,7 +4752,6 @@ msgstr "Maria (Hav)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Övriga funktioner"
 
@@ -4599,7 +4856,7 @@ msgstr "Visa"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Inställningar"
 
@@ -4840,21 +5097,21 @@ msgid "&About Celestia"
 msgstr "&Om Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "OK"
 
@@ -4863,530 +5120,620 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright © 2001-2009, Celestias utvecklingsgrupp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia är fri programvara och absolut ingen garanti gäller."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Upphovsmän"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Välj objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Objektnamn"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Licens"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Kontrollera Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Info om OpenGL-drivrutin"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Ställ in simuleringstid"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Format: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Ställ in till aktuell tid"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Lägg till bokmärke"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Skapa i >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Ny mapp..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Bläddra i stjärnsystemet"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Lägg till ny bokmärkesmapp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Gå till"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Mappnamn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Stjärnsystemobjekt"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Kontrollera Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Stjärnbläddrare"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Närmaste"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Ljusstarkast"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "Med planeter"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "Uppdate&ra"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Kriteria för stjärnsökning"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Maximalt antal stjärnor visade i lista"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Turnéguide"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Gå till"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Välj ditt mål:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Gå till objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Objekt"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Long."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Lat."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Avstånd"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Storlek:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Välj visningsläge"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Upplösning"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "Visningsalternativ"
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Förmörkelsefinnare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "Visa"
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Beräkna"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "Visa"
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Ställ in datum och gå till planet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Ekliptika"
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Stäng"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "Omloppsbanor / Etiketter"
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Från:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Latinska namn"
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "Informationstext"
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Fåordig"
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Sökparametrar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Informativ"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Välj objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Landningsplatser"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Objektnamn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Berg)"
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Info om OpenGL-drivrutin"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Hav)"
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Gå till objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Dalar)"
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Gå till"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Landmassa)"
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Objekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Etikettfunktioner"
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Long."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Lat."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Avstånd"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Licens"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
 msgid "Show Features"
 msgstr "Visa funktioner"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:133
 #, fuzzy
 msgid "Show Label"
 msgstr "Etikettfunktioner"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "Minimum Labeled Feature Size"
 msgstr "Minsta objektsstorlek för visning av etiketter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Lägg till ny bokmärkesmapp"
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Storlek:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Mappnamn"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:141
 msgid "Rename..."
 msgstr "Byt namn..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
+#: ../src/celestia/win32/res/resource_strings.cpp:143
 msgid "Rename Bookmark or Folder"
 msgstr "Byt namn på bokmärke eller mapp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/res/resource_strings.cpp:146
 msgid "New Name"
 msgstr "Nytt namn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Förmörkelsefinnare"
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Ställ in simuleringstid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Beräkna"
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Ställ in datum och gå till planet"
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Ställ in till aktuell tid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Stäng"
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Bläddra i stjärnsystemet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Från:"
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Gå till"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Stjärnsystemobjekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Stjärnbläddrare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Sökparametrar"
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "Uppdate&ra"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Solförmörkelser"
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Kriteria för stjärnsökning"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Månförmörkelser"
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Maximalt antal stjärnor visade i lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Turnéguide"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Välj ditt mål:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "Visningsalternativ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "Visa"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "Visa"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "Omloppsbanor / Etiketter"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "Informationstext"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "41d"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Maj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Sep"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Satellit"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Datum"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Tillverkare: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Fönsterläge"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Uppritare: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Osynliga"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "S&ynkronisera omloppsbana"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Visa kroppsaxlar"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Visa ramaxlar"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Visa solriktning"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Visa hastighetsvektor"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Visa planetografiskt rutnät"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Visa terminator"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Satelliter"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Himlakroppar i omloppsbana"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Läser: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "sv"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Läser url"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Version: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL-version: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Max samtidiga texturer: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Max texturstorlek: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Max kubmappstorlek: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Intervall för punktstorlek: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Utökningar som stöds:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Fönsterläge"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Osynliga"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "S&ynkronisera omloppsbana"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Info"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Visa kroppsaxlar"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Visa ramaxlar"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Visa solriktning"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Visa hastighetsvektor"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Visa planetografiskt rutnät"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Visa terminator"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Satelliter"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Himlakroppar i omloppsbana"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Läser: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "sv"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Läser url"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Fel vid öppning av skript"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Fel vid läsning av skript"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Kör skript"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Namn på tidszon"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Avvikelse från UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Fel vid öppning av skriptfil."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Okänt fel vid öppning av skript"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "Fel vid öppning av skript '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Initiering av skriptets medrutin misslyckades"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "Fel vid öppning av skript '%s'"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Okänt fel vid öppning av skript"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Fel vid öppning av "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Läser NV-fragmentprogram: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Fel vid läsning av NV-fragmentprogram: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Fel i fragmentprogram "
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Initierar NV-fragmentprogram . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Alla NV-fragmentprogram lästa.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Initierar ARB-fragmentprogram . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ": okänd eller ej stödd bildfilstyp.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Läser NV-vertexprogram: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Fel vid läsning av NV-vertexprogram: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Fel i vertexprogram "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Läser ARB-vertexprogram: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Fel vid inläsning av ARB-vertexprogram: "
+
+#~ msgid ", line "
+#~ msgstr ", rad "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Initierar NV-vertexprogram . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Alla NV-vertexprogram lästa.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Initierar ARB-vertexprogram . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Alla ARB-vertexprogram lästa.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Okänt fel vid öppning av skript"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Kopiera URL"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Kopierad URL"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "Alt-azimutläge aktiverat"
+
+#~ msgid "Nearest"
+#~ msgstr "Närmaste"
+
+#~ msgid "Brightest"
+#~ msgstr "Ljusstarkast"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "Med planeter"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Ekliptika"
+
+#~ msgid "Latin Names"
+#~ msgstr "Latinska namn"
+
+#~ msgid "Terse"
+#~ msgstr "Fåordig"
+
+#~ msgid "Verbose"
+#~ msgstr "Informativ"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Landningsplatser"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Berg)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Hav)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Dalar)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Landmassa)"
+
+#~ msgid "Label Features"
+#~ msgstr "Etikettfunktioner"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Solförmörkelser"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Månförmörkelser"
+
+#~ msgid "Vendor: "
+#~ msgstr "Tillverkare: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL-version: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Utökningar som stöds:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Fel vid öppning av skript"
+
+#~ msgid "Error loading script"
+#~ msgstr "Fel vid läsning av skript"
+
+#~ msgid "Running script"
+#~ msgstr "Kör skript"
 
 #~ msgid "Invisible"
 #~ msgstr "Osynlig"

--- a/po/tr.po
+++ b/po/tr.po
@@ -15,10 +15,10 @@ msgstr ""
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>, 2020\n"
 "Language-Team: Turkish (https://www.transifex.com/celestia/teams/93131/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: ../data/data.cpp:1
@@ -811,6 +811,10 @@ msgstr "Havana"
 msgid "Helsinki"
 msgstr "Helsinki"
 
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
 #: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Honiara"
@@ -1054,6 +1058,10 @@ msgstr "Noumea"
 #: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
+
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
 
 #: ../data/data.cpp:259
 msgid "Nuuk"
@@ -1462,12 +1470,14 @@ msgstr ""
 msgid "%s: Bad configuration file.\n"
 msgstr ""
 
+#.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
 #. for (int i = 0; i < nDSOs; ++i)
 #. {
 #. if(DSOs[i]->getAbsoluteMagnitude() == DSO_DEFAULT_ABS_MAGNITUDE)
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
+#.
 #: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
@@ -1617,8 +1627,8 @@ msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
-"Geçersiz yıldız: mutlak (görünür değil) kadir orijin yakınındaki yıldız için"
-" belirtilmelidir\n"
+"Geçersiz yıldız: mutlak (görünür değil) kadir orijin yakınındaki yıldız için "
+"belirtilmelidir\n"
 
 #: ../src/celengine/stardb.cpp:1411
 #, c-format
@@ -1914,26 +1924,22 @@ msgstr "ab"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2403
-#: ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
 #: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2409
-#: ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2432
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
 #: ../src/celestia/qt/qtinfopanel.cpp:196
 #: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr "gün"
 
-#: ../src/celestia/celestiacore.cpp:2437
-#: ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
 #: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr "saat"
@@ -2344,8 +2350,7 @@ msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
-#. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not
-#. available--",""), desc];
+#. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
 #. else
 #: ../src/celestia/macosx/CGLInfo.m:53
 #, objc-format
@@ -2390,11 +2395,14 @@ msgstr "Eklentiler:"
 
 #: ../src/celestia/macosx/CelestiaController.m:161
 msgid ""
-"It appears that the \"CelestiaResources\" directory has not been properly installed in the correct location as indicated in the installation instructions. \n"
+"It appears that the \"CelestiaResources\" directory has not been properly "
+"installed in the correct location as indicated in the installation "
+"instructions. \n"
 "\n"
 "Please correct this and try again."
 msgstr ""
-"Öyle görünüyor ki \"CelestiaResources\" klasörü kurulum talimatlarında yazıldığı gibi doğru yere düzgün bir şekilde kurulmamış. \n"
+"Öyle görünüyor ki \"CelestiaResources\" klasörü kurulum talimatlarında "
+"yazıldığı gibi doğru yere düzgün bir şekilde kurulmamış. \n"
 "\n"
 "Lütfen bunu düzeltin ve tekrar deneyin."
 
@@ -2409,11 +2417,11 @@ msgstr "Kritik Hata"
 #: ../src/celestia/macosx/CelestiaController.m:323
 #, objc-format
 msgid ""
-"It appears you are running Celestia on %s hardware. Do you wish to install a"
-" workaround?"
+"It appears you are running Celestia on %s hardware. Do you wish to install a "
+"workaround?"
 msgstr ""
-"Öyle görünüyor ki Celestia'yı %s donanımında çalıştırıyorsunuz. Bir düzeltme"
-" kurmak ister misiniz?"
+"Öyle görünüyor ki Celestia'yı %s donanımında çalıştırıyorsunuz. Bir düzeltme "
+"kurmak ister misiniz?"
 
 #: ../src/celestia/macosx/CelestiaController.m:324
 #, objc-format
@@ -2547,8 +2555,8 @@ msgstr "İç Ogg kütüphanesi hatası.\n"
 #: ../src/celestia/oggtheoracapture.cpp:311
 #, c-format
 msgid ""
-"OggTheoraCapture::start() - Theora video: %s %.2f(%d/%d) fps quality %d "
-"%dx%d offset (%dx%d)\n"
+"OggTheoraCapture::start() - Theora video: %s %.2f(%d/%d) fps quality %d %dx"
+"%d offset (%dx%d)\n"
 msgstr ""
 
 #: ../src/celestia/oggtheoracapture.cpp:426
@@ -2566,8 +2574,8 @@ msgstr "Özel"
 
 #: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directory was not found, probably"
-" due to improper installation."
+"Celestia is unable to run because the data directory was not found, probably "
+"due to improper installation."
 msgstr ""
 
 #: ../src/celestia/qt/qtappwin.cpp:263
@@ -2606,8 +2614,7 @@ msgstr "Yıldızlar"
 msgid "Deep Sky Objects"
 msgstr "Derin Uzay Cisimleri"
 
-#: ../src/celestia/qt/qtappwin.cpp:325
-#: ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Olay Bulucu"
@@ -2704,18 +2711,17 @@ msgstr "Yeni yer imi"
 #: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt "
-"library: %5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright"
-" (C) 2001-2020 by the Celestia Development Team.<br>Celestia is free "
-"software. You can redistribute it and/or modify it under the terms of the "
-"GNU General Public License as published by the Free Software Foundation; "
-"either version 2 of the License, or (at your option) any later "
-"version.</p><p>Main site: <a "
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
 "href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>GitHub"
-" project: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
 #: ../src/celestia/qt/qtappwin.cpp:1039
@@ -3070,8 +3076,7 @@ msgid "System time at activation"
 msgstr "Aktifleştirmedeki sistem zamanı"
 
 #. i18n: file: ../src/celestia/qt/newbookmarkfolder.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. newBookmarkFolderDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
 #: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
@@ -3180,9 +3185,9 @@ msgstr "Yörüngeler"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111
 #: ../src/celestia/qt/qtselectionpopup.cpp:387
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581
-#: ../src/celestia/qt/rc.cpp:75 ../src/celestia/qt/rc.cpp:156
-#: ../src/celestia/qt/rc.cpp:222 ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
+#: ../src/celestia/win32/winmain.cpp:1449
 #: ../src/celestia/win32/winmain.cpp:1484
 #: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
@@ -3202,9 +3207,9 @@ msgstr "Cüce gezegenler"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
 #: ../src/celestia/qt/qtselectionpopup.cpp:393
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583
-#: ../src/celestia/qt/rc.cpp:81 ../src/celestia/qt/rc.cpp:162
-#: ../src/celestia/qt/rc.cpp:228 ../src/celestia/win32/winmain.cpp:1447
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Uydular"
 
@@ -3222,9 +3227,9 @@ msgstr "Küçük Uydular"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
 #: ../src/celestia/qt/qtselectionpopup.cpp:399
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742
-#: ../src/celestia/qt/rc.cpp:87 ../src/celestia/qt/rc.cpp:168
-#: ../src/celestia/qt/rc.cpp:234 ../src/celestia/win32/winmain.cpp:1441
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Asteroitler"
 
@@ -3237,9 +3242,9 @@ msgstr "Asteroitler"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750
-#: ../src/celestia/qt/rc.cpp:90 ../src/celestia/qt/rc.cpp:171
-#: ../src/celestia/qt/rc.cpp:237 ../src/celestia/win32/winmain.cpp:1443
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Kuyruklu yıldızlar"
 
@@ -3251,9 +3256,8 @@ msgstr "Kuyruklu yıldızlar"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746
-#: ../src/celestia/qt/rc.cpp:93 ../src/celestia/qt/rc.cpp:174
-#: ../src/celestia/qt/rc.cpp:240
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Uzay araçları"
 
@@ -4024,9 +4028,8 @@ msgstr "Cüce gezegenler"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:396
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591
-#: ../src/celestia/qt/rc.cpp:84 ../src/celestia/qt/rc.cpp:165
-#: ../src/celestia/qt/rc.cpp:231
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr "Küçük uydular"
 
@@ -4298,8 +4301,7 @@ msgid "Description:"
 msgstr "Açıklama:"
 
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. organizeBookmarksDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
 #: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 21:02+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -27,12 +27,12 @@ msgstr "Меркурій"
 msgid "Venus"
 msgstr "Венера"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "Земля"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "Місяць"
 
@@ -48,140 +48,140 @@ msgstr "Фобос"
 msgid "Deimos"
 msgstr "Деймос"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "Юпітер"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "Амальтея"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "Іо"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "Європа"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "Ганімед"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "Каллісто"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "Сатурн"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "Прометей"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "Пандора"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "Епіметей"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "Янус"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "Мімас"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "Енцелад"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "Тетіс"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "Діона"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "Рея"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "Титан"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "Гіперіон"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "Япет"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "Феба"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "Уран"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "Міранда"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "Аріель"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "Умбріель"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "Титанія"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "Оберон"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "Нептун"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "Ларісса"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "Протей"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "Тритон"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "Нереїда"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "Плутон-Харон"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "Плутон"
 
@@ -190,1028 +190,1290 @@ msgid "Charon"
 msgstr "Харон"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "Нумеа"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "Бамако"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "Амальтея"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "Каллісто"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "Січ"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "Порт-Віла"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "Галактики"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "ПІВНІЧНА АМЕРИКА"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "ПІВДЕННА АМЕРИКА"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "ЄВРАЗІЯ"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "АФРИКА"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "АВСТРАЛІЯ"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "АНТАРКТИДА"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ПІВНІЧНИЙ АТЛАНТИЧНИЙ ОКЕАН"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ПІВДЕННИЙ АТЛАНТИЧНИЙ ОКЕАН"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ПІВНІЧНИЙ ТИХИЙ ОКЕАН"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ПІВДЕННИЙ ТИХИЙ ОКЕАН"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "ІНДІЙСЬКИЙ ОКЕАН"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "АРКТИЧНИЙ ОКЕАН"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "Абу-Дабі"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "Аккра"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "Адамстаун"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "Аддис-Абеба"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "Алжир"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "Алофі"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "Амман"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "Амстердам"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "Андорра-ла-Велья"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "Анкара"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Антананаріву"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "Апья"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ашгабат"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "Асмера"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Астана"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "Асунсьйон"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "Афіни"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "Баку"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "Бамако"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "Бандар-Сері-Бегаван"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "Бангкок"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "Бангі"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "Банджул"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "Бас-Тер"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Бастер"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "Пекін"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "Бейрут"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "Белград"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "Бельмопан"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "Берлін"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "Берн"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Бішкек"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "Бісау"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "Блумфонтейн"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "Богота"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "Бразиліа"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "Братислава"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "Браззавіль"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "Бриджтаун"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "Брюссель"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "Бухарест"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "Будапешт"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "Буенос-Айрес"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "Каїр"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "Канберра"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "Кейптаун"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "Каракас"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "Кастрі"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "Каєнна"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "Шарлотта-Амалія"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "Кишинів"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "Коломбо"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "Конакрі"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "Копенгаген"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "Котону"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "Дакар"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Дар-ес-Салам"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "Дакка"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "Ділі"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "Джибуті"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "Доха"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "Дуглас"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "Дублін"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "Душанбе"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Фонгафале"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "Фор-де-Франс"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "Фрітаун"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "Габороне"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "Джорджтаун"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "Джорджтаун"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "Гібралтар"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "Гранд-Терк"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "Гватемала"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Аґанья"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "Гаага"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "Гамільтон"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "Хараре"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "Гавана"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "Гельсінкі"
 
-#: ../data/data.cpp:139
+#: ??
+msgid "Hong Kong"
+msgstr ""
+
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "Хоніара"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "Ісламабад"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "Джеймстаун"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "Єрусалим"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "Кабул"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "Кампала"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "Київ"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "Кігалі"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "Кінгстон"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "Кінгстаун"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "Кіншаса"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "Корор"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "Куала-Лумпур"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "Кувейт"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "Ель-Аюн"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "Ла-Пас"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "Лібревіль"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "Лілонгве"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "Ліма"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "Лісабон"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Лобамба"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "Ломе"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "Лондон"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Лонг'єрб'єн"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "Луанда"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "Люксембург"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "Мадрид"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "Маджуро"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "Малабо"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "Мале"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "Манагуа"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "Манама"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "Маніла"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "Мапуто"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "Масеру"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "Мбабане"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "Мехіко"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "Мінськ"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "Могадішо"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "Монако"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "Монровія"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "Монтевідео"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "Мороні"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "Москва"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "Маскат"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "Найробі"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "Нассау"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "Нджамена"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "Нью-Делі"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "Ніамей"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "Нікосія"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "Нумеа"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: ../data/data.cpp:201
+#: ??
+msgid "Nur-Sultan"
+msgstr ""
+
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Нуук"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "Ораньєстад"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "Осло"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "Оттава"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "Уагадугу"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Паго-Паго"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Палікір"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "Панама"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Папеете"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "Парамарибо"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "Париж"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "Пномпень"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "Плімут"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "Порт-Луї"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "Порт-Морсбі"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "Порт-о-Пренс"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "Порт-оф-Спейн"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "Порто-Ново"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "Порт-Віла"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "Прага"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "Прая"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "Преторія"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "Пхеньян"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "Кіто"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "Рабат"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "Рангун"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "Рейк'явік"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "Рига"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "Ер-Ріядд"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Род-Таун"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "Рим"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "Розо"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "Сент-Джорджес"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "Сент-Гелієр"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "Сент-Джонс"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "Сент-Пітер-Порт"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "Сен-Дені"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "Сент-П'єр"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "Сан-Хосе"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "Сан-Хуан"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "Сан-Марино"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "Сан-Сальвадор"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "Сана"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "Сантьяго"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "Санто-Домінго"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "Сан-Томе"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "Сараєво"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "Сеул"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "Сеттлмент"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "Сингапур"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "Скоп'є"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "Софія"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шрі-Джаяварденепура-Котте"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "Стенлі"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "Стокгольм"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "Сукре"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "Сува"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "Тайбей"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "Таллінн"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "Тарава"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "Тбілісі"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "Тегусігальпа"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "Тегеран"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "Тель-Авівв"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "Тхімпху"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "Тирана"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "Токіо"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "Торсгавн"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "Тріполі"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "Туніс"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Улан-Батор"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "Валетта"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "Веллі"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "Місто Ватикан"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "Вікторія"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "Відень"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "В'єнтьян"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Вільнюс"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "Вашингтон, округ Колумбія"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "Веллінгтон"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "Західний острів"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "Віллемстад"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "Віндгук"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "Ямусукро"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "Яунде"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Округ Ярен"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "Єреван"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "Загреб"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Молочний шлях"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "Мала Магелланова Хмара"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "Велика Магелланова Хмара"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "Центр тяжіння зоряної системи"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "Лтн"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "Стд"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "Помилка під час відкриття файла зображення "
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "Помилка під час читання файла налаштувань."
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1221,89 +1483,58 @@ msgstr "Стд"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr " віддалені об’єкти"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "Завантаження програми фрагментів NV: "
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "Помилка під час завантаження програми фрагмента NV: "
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "Помилка у програмі фрагментів"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "Ініціалізація програми фрагментів NV . . .\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "Всі програми фрагментів NV успішно завантажено.\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "Ініціалізація програм фрагментів ABR . . .\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Галактика (тип за Хабблом: %s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Кулясте скупчення (радіус ядра: %4.2f', концентрація за Кінгом: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "Завантаження зображення з файла "
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ""
-": не вдалося встановити тип зображення або зображення належить до типу, який "
-"не підтримується.\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "Помилка під час відкриття файла зображення "
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " не є файлом PNG.\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "Помилка під час читання файла зображення PNG "
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "Завантаження моделі: "
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "Помилка під час завантаження моделі «"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "Туманність"
 
@@ -1311,92 +1542,92 @@ msgstr "Туманність"
 msgid "Open cluster"
 msgstr "Розсіяне скупчення"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr "Помилка у файлі .ssc (рядок "
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "попередження про подвійне визначення "
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "помилкова альтернативна поверхня"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "помилкове розташування"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "Помилковий заголовок для покажчика\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "Помилкова версія для покажчика\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "Помилка під час завантаження покажчика на запису "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " зірок у двійковій базі даних\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "Загальна кількість зірок: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr "Помилка у файлі .stc (рядок "
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Некоректний запис: помилковий спектральний тип.\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Некоректний запис: не вказано спектрального типу.\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " не існує.\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "Некоректний запис: не вказано пряме сходження\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "Некоректний запис: не вказано схилення.\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "Некоректний запис: не вказана відстань.\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Некоректний запис: не вказано зоряної величини.\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
@@ -1404,771 +1635,743 @@ msgstr ""
 "Некоректний запис: слід задати абсолютну (а не видиму) величину для зірки "
 "поряд з початком координат\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "Створення плиткових текстур. Ширина="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "Створення звичайної текстури: "
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "Завантаження вершинної програми NV: "
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "Помилка під час завантаження вершинної програми NV: "
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "Помилка у вершинній програмі "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "Завантаження вершинної програми ABR: "
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "Помилка під час завантаження вершинної програми ABR: "
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr ", рядок "
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "Ініціалізація вершинних програм NV . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "Всі вершинні програми NV успішно завантажено.\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "Ініціалізація вершинних програм ARB . . .\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "Всі вершинні програми ARB успішно завантажено.\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "Помилка відкриття"
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "Помилка під час читання файла зображення PNG "
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "Помилка під час читання файла обраного."
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "Помилка під час відкриття файла скрипту."
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr ""
-"Помилка під час відкриття скрипту:\n"
-"«%s»"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "Невідома помилка під час відкриття скрипту"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "Помилка під час ініціалізації підпрограми скрипту"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "Некоректний тип файла"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Межа величини: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "Позначки увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "Позначки вимкнено"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "Перейти до поверхні"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "Режим «висота-азимут» увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "Режим «висота-азимут» вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "Стиль зірок: розпливчаті крапки"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "Стиль зірок: крапки"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "Стиль зірок: масштабовані диски"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "Хвости комет увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "Хвости комет вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "Шлях відтворення: OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "&Особливий"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "&Звичайний"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "Автозбільшення увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "Автозбільшення вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "Час та скрипт призупинено"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "Час зупинено"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "Поновити"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "   Колір зірок особливий"
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "   Колір зірок особливий"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Світлове запізнювання:  %.4f р "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Світлове запізнювання:  %d хв  %.1f сек"
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Світлове запізнювання:  %d год  %d хв  %.1f сек"
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "З врахуванням світлового запізнювання"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "Без врахування світлового запізнювання"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "Світлове запізнювання ігнорується"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "Використання нормальних текстур поверхонь."
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "Використання межі знань текстур поверхонь"
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "Стеження"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "Час: вперед"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "Час: назад"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Швидкість"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "Текстури"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Текстури"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "Текстури"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "Синхронна орбіта"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "Заблокувати"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "Гонитва"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Межа величини: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Межа автозбільшення на 45 градусів:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Рівень розсіювання світла:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "Підсилення світла"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "Блимання увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "Блимання вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "Експозиція"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "Помилка GL: "
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "Зображення дуже мале для поділу"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "Доданий перегляд"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "св. р."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "а. о."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr " м/с"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " днів"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " годин"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " хвилин"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " секунд"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "Період обертання: "
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr " м/с"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr " км/с"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr " а. о./с"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " св. р./с"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "Швидкість: "
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Видимий діаметр: "
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Видима зоряна величина: "
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Абсолютна величина:"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Відстань: "
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "Центр тяжіння зоряної системи \n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Абс. (вид.) величина: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "Світність: "
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "Нейтронна зірка"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "Чорна дірка"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Клас: "
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "Темп. поверхні: "
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "Має планетарну систему\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Відстань від центру:"
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Фазовий кут: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "Температура: "
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  НТ"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Реальний час"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-Реальний час"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "Час зупинений"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " раз швидше"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " раз повільніше"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (Призупинено)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "Кд/с: "
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "Подорож "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "Подорож "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Траєкторія "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Стеження "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синхронна орбіта "
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Гонитва "
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "Сонце"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "Назва цілі: "
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr "  Призупинено"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  Запис"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пуск/Пауза    F12 Зупинка"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "Режим редагування"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "Завантаження каталогу зоряної системи: "
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "Завантаження каталогу зоряної системи: "
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "Помилка під час читання файла налаштувань."
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "Помилка під час ініціалізації бібліотеки SPICE."
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "Не вдалося прочитати базу даних зірок."
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "Помилка під час відкриття каталогу віддалених об’єктів."
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "Не вдалося прочитати базу даних зірок."
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "Помилка під час відкриття каталогу сонячної системи.\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "Помилка під час відкриття файла астероїдів."
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "Помилка під час відкриття файла меж сузір’їв."
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "Помилка ініціалізації відображення"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Помилка під час завантаження шрифту; текст не буде видимим.\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "Помилка під час читання покажчика "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "Завантажено покажчик "
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "Помилка під час читання назв у файлі зірок\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "Помилка відкриття"
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "Помилка під час читання назв у файлі зірок\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "Помилка під час читання файла зірок\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "Помилка під час відкриття каталогу зірок "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr ""
-"Помилка під час відкриття скрипту:\n"
-"«%s»"
+msgid "%s Version: %s\n"
+msgstr "Версія: "
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "Невідома помилка під час відкриття скрипту"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "Виробник: "
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "Відеокарта: "
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "Максимальна кількість текстур одночасно: "
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "Максимальний розмір текстури: "
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "Діапазон розмірів точки: "
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "Діапазон розмірів точки: "
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "Макс. розмір кубічної карти: "
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2365,14 +2568,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "Помилка під час створення файла ogg %s для ролика.\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "Помилка у внутрішній бібліотеці OGG."
@@ -2391,46 +2594,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() — записано %d кадрів\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "Переглядач неба"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "&Інформація"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "Сонячна система"
 
@@ -2440,21 +2634,20 @@ msgstr "Сонячна система"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "Зірки"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " віддалені об’єкти"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "Пошук затемнень"
@@ -2463,464 +2656,515 @@ msgstr "Пошук затемнень"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "Час"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "Путівник"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "На повний екран"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Захопити &відео...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Помилка під час відкриття файла астероїдів."
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Закладки"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "Зберегти як:"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " не є файлом PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "Роздільна здатність: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Частота кадрів:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "Копійована адреса"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Завантаження адреси"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "&Відкрити скрипт..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "Створити теку закладок у цьому меню"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
-msgstr "<b>OpenGL 1.1 без додатків</b>"
+msgid "Unknown compiler"
+msgstr "Невідома помилка під час відкриття скрипту"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
+#: ../src/celestia/qt/qtappwin.cpp:1043
 #, fuzzy
-msgid "<b>Renderer: </b>"
-msgstr "<b>OpenGL 1.1 без додатків</b>"
-
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
-msgstr "Версія GLSL: "
-
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
-msgstr "Максимальний розмір текстури: "
-
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
-#, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "supported"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1045
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "Інформація щодо OpenGL"
+msgid "not supported"
+msgstr "Підтримувані додатки:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "Про Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
+msgstr "<b>OpenGL 1.1 без додатків</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "Виробник: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
+msgstr "<b>OpenGL 1.1 без додатків</b>"
+
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
+msgstr "Версія GLSL: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "Максимальна кількість текстур одночасно: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
+msgstr "Максимальний розмір текстури: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "Діапазон розмірів точки: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "Діапазон розмірів точки: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "Макс. розмір кубічної карти: "
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "Екваторіальна"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
+#, fuzzy
+msgid "<b>Supported extensions:</b><br>\n"
+msgstr "Підтримувані додатки:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1153
+#, fuzzy
+msgid "Renderer Info"
+msgstr "Відеокарта: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "Захопити зображення"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "Захопити &зображення...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Захопити &відео...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "Копіювати адресу"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "Копіювати адресу"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "Копійована адреса"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Відкрити скрипт..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Налаштування Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Ви&йти"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Згладжування\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навігація"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "В&ибрати"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Розташувати по центру\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Вибор: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Перейти до об'єкта..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Час"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "Встановити час..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "Показ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Об'єкти"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "Тіні від кілець"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Стиль &зірок"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Р&оздільна здатність"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Засоби керування"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Закладки"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Перегляд"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "Мультиперегляд"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Розділити перегляд вертикально"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Розділити &горизонтально\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Розділити перегляд горизонтально"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Розділити &вертикально\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "Циклічний перегляд"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "Єдина область"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Єдине вікно\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "Вилучити вікно"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "Вилучити"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "Видимі роздільники"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Видимі роздільники активного"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Синхронізувати час"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Довідка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "Про Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "Інформація щодо OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Додати закладку"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Упорядкувати закладки..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Завантаження"
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Скрипти"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "Тривалість"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "&Закладки"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "Головна панель інструментів"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "Помилка під час читання файла обраного."
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "Закладки"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "Встановити час імітації"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "Встановити час імітації"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "Час"
@@ -2929,79 +3173,77 @@ msgstr "Час"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "Створити теку..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "Показувати екваторіальну сітку"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "Галактика"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "Екліптика"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "Горизонтальна"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "Лінія екліптики"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr " м/с"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "Позначки"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "&Розташувати по центру\tC"
@@ -3010,57 +3252,54 @@ msgstr "&Розташувати по центру\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "Сузір'я"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>Блоки обчислень NVIDIA, без вершинних програм</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "Межі сузір'їв"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "Гаразд"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "Орбіти"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "Планети"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "Карликові планети"
 
@@ -3070,19 +3309,17 @@ msgstr "Карликові планети"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "Місяці"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "Малі планети"
 
@@ -3092,12 +3329,12 @@ msgstr "Малі планети"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "Астероїди"
 
@@ -3107,12 +3344,12 @@ msgstr "Астероїди"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "Комети"
 
@@ -3122,14 +3359,15 @@ msgstr "Комети"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "Космічні кораблі"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "При&скорення у 10 разів\tL"
@@ -3138,9 +3376,8 @@ msgstr "При&скорення у 10 разів\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "Мітки"
 
@@ -3148,20 +3385,18 @@ msgstr "Мітки"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "Галактики"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "Сферичні скупчення"
 
@@ -3169,7 +3404,7 @@ msgstr "Сферичні скупчення"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3179,616 +3414,633 @@ msgstr "Розсіяні скупчення"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "Туманності"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "Місця"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "Розсіяні скупчення"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "Хмари"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "Вогні нічного боку"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "Хвости комет"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "Атмосфери"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "Тіні від кілець"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "Тіні затемнення"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "Тіні хмар"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "Низька"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "Помірна"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "Висока"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "Автоматична величина\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "Більше зірок\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "Менше зірок\t["
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "&Точки"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "&Розмиті точки"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "&Диски"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "Без врахування світлового запізнювання"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "&Особливий"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "Межа автозбільшення на 45 градусів:  %.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "Межа величини: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "Назва"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "Відстань (у св.р.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "Вид. величина"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "Абс. величина"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "Тип"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Зірки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Найяскравіша"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "Фільтрування зірок"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "З планетами"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Зірки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "Баріцентр"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "Оновлення"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Позначити"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Максимальна кількість зірок у списку"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Позначити"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Позначки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "Немає"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "Ромб"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "Трикутник"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "Коло"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "Стрілка ліворуч"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "Стрілка праворуч"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "Стрілка вгору"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "Стрілка вниз"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "В&ибрати"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "Розмір:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "В&ибрати"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "Назва об'єктiв"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Об'єкти"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Позначити"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "головне тіло «"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "Початок"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "Тривалість"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "Сонячні затемнення"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "Місячні затемнення"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "Зняти &всі позначки"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "Пошук"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "Місячні затемнення"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "Об'єкт: "
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "Сонячні затемнення"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "Встановити теперішній час"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "Від:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "Тривалість: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "&Інформація"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Інформація"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "Відстань: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "Розмір: %1 Мб"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "Інформаційний текст"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "а. о."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 #, fuzzy
 msgid "Blackbody D65"
 msgstr "   Колір зірок особливий"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "Стиль &зірок"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "Місцевий формат"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "Часовий пояс"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "Відступ від UTC"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "Початок"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3807,21 +4059,21 @@ msgid "&Select"
 msgstr "В&ибрати"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "По &центру"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "&Перейти"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "&Спостерігати"
 
@@ -3835,49 +4087,54 @@ msgid "Visible"
 msgstr "Видимі роздільники активного"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "&Зняти позначку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "Виберіть режим дисплею"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "Заповнений квадрат"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "Диск"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "&Позначити"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "&Базові позначки"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "Показувати осі тіла"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "Показувати осі вікна"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "Показувати напрямок на сонце"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "Показувати вектор швидкості"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "Показувати вектор швидкості"
@@ -3885,190 +4142,41 @@ msgstr "Показувати вектор швидкості"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "Показувати напрямок на сонце"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "Показувати планетографічну сітку"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "Показувати термінатор"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "&Альтернативні поверхні"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "Звичайні"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "Космічні кораблі"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "Об'єкти"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "Встановити час..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "Часовий пояс:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "Всесвітній час"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "За місцевим часом"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "Часовий пояс:"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "Дата"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "Встановити"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "Встановити"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "Встановити"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "&Час"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " годин"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " хвилин"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " секунд"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "Дата за юліанським календарем: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "Дата за юліанським календарем: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "Встановити час..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "Баріцентр"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "Планета"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
-msgstr "Карликова планета"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "Малі планети"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "Астероїд"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "Комета"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "&Базові позначки"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "Підрахувати"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "Перейти до поверхні"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "Невідома помилка під час відкриття скрипту"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "Астероїди"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "&Базові позначки"
+msgid "Dwarf planets"
+msgstr "Карликові планети"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4076,67 +4184,234 @@ msgstr "&Базові позначки"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "Малі планети"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "Космічні кораблі"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "Об'єкти"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "Встановити час..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "Часовий пояс:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "Всесвітній час"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "За місцевим часом"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "Часовий пояс:"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "Дата"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "Встановити"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "Встановити"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "Встановити"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "&Час"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " годин"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " хвилин"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " секунд"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "Дата за юліанським календарем: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "Дата за юліанським календарем: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "Встановити час..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "Баріцентр"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "Планета"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "Карликова планета"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "Малі планети"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "Астероїд"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "Комета"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "&Базові позначки"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "Підрахувати"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "Перейти до поверхні"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "Невідома помилка під час відкриття скрипту"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "Астероїди"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "&Базові позначки"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "Інші особливості"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "Планети"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Об'єкти"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "Змінити напрямок часу"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "С&повільнення у 10 разів\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " раз повільніше"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "Призупинити час"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " раз швидше"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "При&скорення у 10 разів\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "Встановити поточний час системи"
@@ -4208,7 +4483,6 @@ msgstr "Широта:"
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "радіуси"
 
@@ -4229,7 +4503,7 @@ msgstr "Роздільна здатність: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "Впорядкувати закладку"
 
@@ -4260,18 +4534,6 @@ msgstr "Налаштування Celestia"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "Об'єкти"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "Карликові планети"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4362,49 +4624,43 @@ msgstr "Часткові траєкторії"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "Сітки"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "Екваторіальна"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "Екліптика"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "Галактика"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "Горизонтальна"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "Діаграми"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "Межі"
 
@@ -4438,7 +4694,6 @@ msgstr "помилкове розташування"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "Міста"
 
@@ -4452,21 +4707,18 @@ msgstr "Місця посадок"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "Вулкани"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "Обсерваторії"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "Кратери"
 
@@ -4501,7 +4753,6 @@ msgstr "Maria (Моря)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "Інші особливості"
 
@@ -4606,7 +4857,7 @@ msgstr "Показ"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "Налаштування"
 
@@ -4844,21 +5095,21 @@ msgid "&About Celestia"
 msgstr "&Про Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "OK"
 msgstr "Гаразд"
 
@@ -4867,532 +5118,628 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr ""
 "Авторські права на програму належать Команді з розробки Celestia, ©2001–2009."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr ""
 "Celestia є вільним програмним забезпеченням і розповсюджується без будь-яких "
 "гарантій."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "Автори"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Кріс Лавр"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "Виберіть об'єкт"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "Назва об'єкта"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "Ліцензія"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Засоби керування Celestia"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "Інформація про драйвер OpenGL"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "Встановити час імітації"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "Формат: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "Встановити поточний час системи"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "Додати закладку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "Створити у >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "Створити теку..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "Переглядач зоряної системи"
+#: ../src/celestia/win32/res/resource_strings.cpp:96
+msgid "Add New Bookmark Folder"
+msgstr "Додати нову теку закладок"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "&Перейти до"
+#: ../src/celestia/win32/res/resource_strings.cpp:99
+msgid "Folder Name"
+msgstr "Назва теки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "Об'єкти зоряної системи"
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Засоби керування Celestia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "Переглядач зірок"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "Найближчі"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "Найяскравіша"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "З планетами"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "&Оновити"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "Критерій пошуку зірки"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "Максимальна кількість зірок у списку"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "Путівник"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "Перейти до"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "Оберіть призначення:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "Перейти до об'єкту"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "Об'єкт"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "Довг."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "Шир."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "Відстань"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "Розмір:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:102
 msgid "Select Display Mode"
 msgstr "Виберіть режим дисплею"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:103
 msgid "Resolution"
 msgstr "Роздільна здатність"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:148
+#: ../src/celestia/win32/res/resource_strings.cpp:106
+msgid "Eclipse Finder"
+msgstr "Пошук затемнень"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:107
+msgid "Compute"
+msgstr "Підрахувати"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:108
+msgid "Set Date and Go to Planet"
+msgstr "Встановити дату і перейти до планети"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:109
+msgid "Close"
+msgstr "Закрити"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:110
+msgid "From:"
+msgstr "Від:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:111
+msgid "To:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:112
+msgid "On:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:113
+msgid "Search parameters"
+msgstr "Параметри пошуку"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "Виберіть об'єкт"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "Назва об'єкта"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "Інформація про драйвер OpenGL"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "Перейти до об'єкту"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "Перейти до"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "Об'єкт"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "Довг."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "Шир."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "Відстань"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "Ліцензія"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "Показувати об’єкти"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+msgid "Show Label"
+msgstr "Назва об'єктiв"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "Мінімальний розмір об’єкта для позначення"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "Розмір:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "Перейменувати..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "Перейменувати закладку або теку"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "Нова назва"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "Встановити час імітації"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "Формат: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "Встановити поточний час системи"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "Переглядач зоряної системи"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "&Перейти до"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "Об'єкти зоряної системи"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "Переглядач зірок"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "&Оновити"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "Критерій пошуку зірки"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "Максимальна кількість зірок у списку"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "Путівник"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "Оберіть призначення:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
 msgid "View Options"
 msgstr "Перегляд параметрів"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:149
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 #, fuzzy
 msgid "Show:"
 msgstr "Показувати"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:173
 #, fuzzy
 msgid "Display:"
 msgstr "Показ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "Лінія екліптики"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:175
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Орбіти / Мітки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "Назви латиною"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Information Text"
 msgstr "Інформаційний текст"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "Коротко"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "Докладно"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "Місця посадок"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "Montes (Гори)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "Maria (Моря)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "Valles (Долини)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "Terrae (Масиви материків)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "Позначити об’єкти"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "Показувати об’єкти"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-msgid "Show Label"
-msgstr "Назва об'єктiв"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "Мінімальний розмір об’єкта для позначення"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
-msgid "Add New Bookmark Folder"
-msgstr "Додати нову теку закладок"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:211
-msgid "Folder Name"
-msgstr "Назва теки"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "Перейменувати..."
-
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "Перейменувати закладку або теку"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "Нова назва"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:222
-msgid "Eclipse Finder"
-msgstr "Пошук затемнень"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:223
-msgid "Compute"
-msgstr "Підрахувати"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:224
-msgid "Set Date and Go to Planet"
-msgstr "Встановити дату і перейти до планети"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:225
-msgid "Close"
-msgstr "Закрити"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:226
-msgid "From:"
-msgstr "Від:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:227
-msgid "To:"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:228
-msgid "On:"
-msgstr ""
-
-#: ../src/celestia/win32/res/resource_strings.cpp:229
-msgid "Search parameters"
-msgstr "Параметри пошуку"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "Сонячні затемнення"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "Місячні затемнення"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "422"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "Кві"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "Лют"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "Січ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "Чер"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "Бер"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "Тра"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "Сер"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "Гру"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "Лип"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "Лис"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "Жов"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "Вер"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "Супутник"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "Дата"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "Початок"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "Виробник: "
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "Віконний режим"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "Відеокарта: "
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "Невидимі об’єкти"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "Син&хронна орбіта"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "&Інформація"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "Показувати осі тіла"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "Показувати осі вікна"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "Показувати напрямок на сонце"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "Показувати вектор швидкості"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "Показувати планетографічну сітку"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "Показувати термінатор"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "&Супутники"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "Тіла, що обертаються"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "Завантаження: "
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "uk"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "Завантаження адреси"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "Версія: "
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "Версія GLSL: "
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "Максимальна кількість текстур одночасно: "
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "Максимальний розмір текстури: "
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "Макс. розмір кубічної карти: "
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "Діапазон розмірів точки: "
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "Підтримувані додатки:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "Віконний режим"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "Невидимі об’єкти"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "Син&хронна орбіта"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "&Інформація"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "Показувати осі тіла"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "Показувати осі вікна"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "Показувати напрямок на сонце"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "Показувати вектор швидкості"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "Показувати планетографічну сітку"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "Показувати термінатор"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "&Супутники"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "Тіла, що обертаються"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "Завантаження: "
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "uk"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "Завантаження адреси"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "Помилка відкриття скрипту"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "Помилка завантаження скрипту"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "Виконання скрипту"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "Часовий пояс"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "Відступ від UTC"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "Помилка під час відкриття файла скрипту."
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "Невідома помилка під час відкриття скрипту"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr ""
+"Помилка під час відкриття скрипту:\n"
+"«%s»"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "Помилка під час ініціалізації підпрограми скрипту"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr ""
+"Помилка під час відкриття скрипту:\n"
+"«%s»"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "Невідома помилка під час відкриття скрипту"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "Помилка відкриття"
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "Завантаження програми фрагментів NV: "
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "Помилка під час завантаження програми фрагмента NV: "
+
+#~ msgid "Error in fragment program "
+#~ msgstr "Помилка у програмі фрагментів"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "Ініціалізація програми фрагментів NV . . .\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "Всі програми фрагментів NV успішно завантажено.\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "Ініціалізація програм фрагментів ABR . . .\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ""
+#~ ": не вдалося встановити тип зображення або зображення належить до типу, "
+#~ "який не підтримується.\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "Завантаження вершинної програми NV: "
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "Помилка під час завантаження вершинної програми NV: "
+
+#~ msgid "Error in vertex program "
+#~ msgstr "Помилка у вершинній програмі "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "Завантаження вершинної програми ABR: "
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "Помилка під час завантаження вершинної програми ABR: "
+
+#~ msgid ", line "
+#~ msgstr ", рядок "
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "Ініціалізація вершинних програм NV . . .\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "Всі вершинні програми NV успішно завантажено.\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "Ініціалізація вершинних програм ARB . . .\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "Всі вершинні програми ARB успішно завантажено.\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "Невідома помилка під час відкриття скрипту"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "Копіювати адресу"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "Копійована адреса"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "&Особливий"
+
+#~ msgid "Nearest"
+#~ msgstr "Найближчі"
+
+#~ msgid "Brightest"
+#~ msgstr "Найяскравіша"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "З планетами"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "Лінія екліптики"
+
+#~ msgid "Latin Names"
+#~ msgstr "Назви латиною"
+
+#~ msgid "Terse"
+#~ msgstr "Коротко"
+
+#~ msgid "Verbose"
+#~ msgstr "Докладно"
+
+#~ msgid "Landing Sites"
+#~ msgstr "Місця посадок"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "Montes (Гори)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "Maria (Моря)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "Valles (Долини)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "Terrae (Масиви материків)"
+
+#~ msgid "Label Features"
+#~ msgstr "Позначити об’єкти"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "Сонячні затемнення"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "Місячні затемнення"
+
+#~ msgid "Vendor: "
+#~ msgstr "Виробник: "
+
+#~ msgid "GLSL version: "
+#~ msgstr "Версія GLSL: "
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "Підтримувані додатки:"
+
+#~ msgid "Error opening script"
+#~ msgstr "Помилка відкриття скрипту"
+
+#~ msgid "Error loading script"
+#~ msgstr "Помилка завантаження скрипту"
+
+#~ msgid "Running script"
+#~ msgstr "Виконання скрипту"
 
 #~ msgid "Invisible"
 #~ msgstr "Невидиме тіло"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -811,6 +811,10 @@ msgstr "哈瓦那"
 msgid "Helsinki"
 msgstr "赫尔辛基"
 
+#: ??
+msgid "Hong Kong"
+msgstr "香港"
+
 #: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "霍尼亚拉"
@@ -1054,6 +1058,10 @@ msgstr "努美阿"
 #: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "努库阿洛法"
+
+#: ??
+msgid "Nur-Sultan"
+msgstr "努尔苏丹"
 
 #: ../data/data.cpp:259
 msgid "Nuuk"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14,11 +14,12 @@ msgstr ""
 "POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>, 2020\n"
-"Language-Team: Chinese (China) (https://www.transifex.com/celestia/teams/93131/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/celestia/"
+"teams/93131/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../data/data.cpp:1
@@ -1470,12 +1471,14 @@ msgstr ""
 msgid "%s: Bad configuration file.\n"
 msgstr ""
 
+#.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
 #. for (int i = 0; i < nDSOs; ++i)
 #. {
 #. if(DSOs[i]->getAbsoluteMagnitude() == DSO_DEFAULT_ABS_MAGNITUDE)
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
+#.
 #: ../src/celengine/dsodb.cpp:375
 #, c-format
 msgid "Loaded %i deep space objects\n"
@@ -1920,26 +1923,22 @@ msgstr "AU"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2403
-#: ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
 #: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2409
-#: ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2432
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
 #: ../src/celestia/qt/qtinfopanel.cpp:196
 #: ../src/celestia/qt/qtinfopanel.cpp:246
 msgid "days"
 msgstr "d"
 
-#: ../src/celestia/celestiacore.cpp:2437
-#: ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
 #: ../src/celestia/qt/qtinfopanel.cpp:192
 msgid "hours"
 msgstr "h"
@@ -2350,8 +2349,7 @@ msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
-#. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not
-#. available--",""), desc];
+#. result = [NSString stringWithFormat:NSLocalizedString(@"%@: --not available--",""), desc];
 #. else
 #: ../src/celestia/macosx/CGLInfo.m:53
 #, objc-format
@@ -2396,7 +2394,9 @@ msgstr "扩展："
 
 #: ../src/celestia/macosx/CelestiaController.m:161
 msgid ""
-"It appears that the \"CelestiaResources\" directory has not been properly installed in the correct location as indicated in the installation instructions. \n"
+"It appears that the \"CelestiaResources\" directory has not been properly "
+"installed in the correct location as indicated in the installation "
+"instructions. \n"
 "\n"
 "Please correct this and try again."
 msgstr ""
@@ -2415,8 +2415,8 @@ msgstr "致命错误"
 #: ../src/celestia/macosx/CelestiaController.m:323
 #, objc-format
 msgid ""
-"It appears you are running Celestia on %s hardware. Do you wish to install a"
-" workaround?"
+"It appears you are running Celestia on %s hardware. Do you wish to install a "
+"workaround?"
 msgstr "您正尝试在 %s 的硬件上运行 Celestia。是否需要安装一个工作区？"
 
 #: ../src/celestia/macosx/CelestiaController.m:324
@@ -2424,7 +2424,9 @@ msgstr "您正尝试在 %s 的硬件上运行 Celestia。是否需要安装一�
 msgid ""
 "A shell script will be run to modify your %@, adding an IgnoreGLExtensions "
 "directive. This can prevent freezing issues."
-msgstr "我们将运行一个 Shell 脚本来修改您的 %@，并添加一个 IgnoreGLExtensions 指令。这可以防止冻结问题。"
+msgstr ""
+"我们将运行一个 Shell 脚本来修改您的 %@，并添加一个 IgnoreGLExtensions 指令。"
+"这可以防止冻结问题。"
 
 #: ../src/celestia/macosx/CelestiaController.m:325
 msgid "Yes"
@@ -2447,7 +2449,8 @@ msgstr "您的原始 %@ 已经备份。"
 msgid ""
 "There was a problem installing the workaround. You can attempt to perform "
 "the workaround manually by following the instructions in the README."
-msgstr "安装工作区时出现了一个问题。您可以尝试按照 ReadMe 文件去执行工作区手册。"
+msgstr ""
+"安装工作区时出现了一个问题。您可以尝试按照 ReadMe 文件去执行工作区手册。"
 
 #: ../src/celestia/macosx/CelestiaController.m:467
 msgid "Quit Celestia?"
@@ -2549,11 +2552,11 @@ msgstr "内部 OGG 库出错\n"
 #: ../src/celestia/oggtheoracapture.cpp:311
 #, c-format
 msgid ""
-"OggTheoraCapture::start() - Theora video: %s %.2f(%d/%d) fps quality %d "
-"%dx%d offset (%dx%d)\n"
+"OggTheoraCapture::start() - Theora video: %s %.2f(%d/%d) fps quality %d %dx"
+"%d offset (%dx%d)\n"
 msgstr ""
-"OggTheoraCapture::start() - Theora 影像：%s %.2f（%d/%d）FPS 质量 %d %d×%d 位移 "
-"(%d×%d)\n"
+"OggTheoraCapture::start() - Theora 影像：%s %.2f（%d/%d）FPS 质量 %d %d×%d 位"
+"移 (%d×%d)\n"
 
 #: ../src/celestia/oggtheoracapture.cpp:426
 #, c-format
@@ -2570,8 +2573,8 @@ msgstr "自定义"
 
 #: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directory was not found, probably"
-" due to improper installation."
+"Celestia is unable to run because the data directory was not found, probably "
+"due to improper installation."
 msgstr ""
 
 #: ../src/celestia/qt/qtappwin.cpp:263
@@ -2610,8 +2613,7 @@ msgstr "恒星"
 msgid "Deep Sky Objects"
 msgstr "深空天体"
 
-#: ../src/celestia/qt/qtappwin.cpp:325
-#: ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "事件查找器"
@@ -2708,18 +2710,17 @@ msgstr "新建书签"
 #: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt "
-"library: %5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright"
-" (C) 2001-2020 by the Celestia Development Team.<br>Celestia is free "
-"software. You can redistribute it and/or modify it under the terms of the "
-"GNU General Public License as published by the Free Software Foundation; "
-"either version 2 of the License, or (at your option) any later "
-"version.</p><p>Main site: <a "
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
 "href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>GitHub"
-" project: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
 #: ../src/celestia/qt/qtappwin.cpp:1039
@@ -3076,8 +3077,7 @@ msgid "System time at activation"
 msgstr "激活的系统时间"
 
 #. i18n: file: ../src/celestia/qt/newbookmarkfolder.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. newBookmarkFolderDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
 #: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
@@ -3186,9 +3186,9 @@ msgstr "轨道"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111
 #: ../src/celestia/qt/qtselectionpopup.cpp:387
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581
-#: ../src/celestia/qt/rc.cpp:75 ../src/celestia/qt/rc.cpp:156
-#: ../src/celestia/qt/rc.cpp:222 ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
+#: ../src/celestia/win32/winmain.cpp:1449
 #: ../src/celestia/win32/winmain.cpp:1484
 #: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
@@ -3208,9 +3208,9 @@ msgstr "矮行星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
 #: ../src/celestia/qt/qtselectionpopup.cpp:393
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583
-#: ../src/celestia/qt/rc.cpp:81 ../src/celestia/qt/rc.cpp:162
-#: ../src/celestia/qt/rc.cpp:228 ../src/celestia/win32/winmain.cpp:1447
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "卫星"
 
@@ -3228,9 +3228,9 @@ msgstr "子卫星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
 #: ../src/celestia/qt/qtselectionpopup.cpp:399
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742
-#: ../src/celestia/qt/rc.cpp:87 ../src/celestia/qt/rc.cpp:168
-#: ../src/celestia/qt/rc.cpp:234 ../src/celestia/win32/winmain.cpp:1441
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "小行星"
 
@@ -3243,9 +3243,9 @@ msgstr "小行星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750
-#: ../src/celestia/qt/rc.cpp:90 ../src/celestia/qt/rc.cpp:171
-#: ../src/celestia/qt/rc.cpp:237 ../src/celestia/win32/winmain.cpp:1443
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "彗星"
 
@@ -3257,9 +3257,8 @@ msgstr "彗星"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746
-#: ../src/celestia/qt/rc.cpp:93 ../src/celestia/qt/rc.cpp:174
-#: ../src/celestia/qt/rc.cpp:240
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "航天器"
 
@@ -4030,9 +4029,8 @@ msgstr "矮行星"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:396
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591
-#: ../src/celestia/qt/rc.cpp:84 ../src/celestia/qt/rc.cpp:165
-#: ../src/celestia/qt/rc.cpp:231
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 msgid "Minor moons"
 msgstr "子卫星"
 
@@ -4304,8 +4302,7 @@ msgid "Description:"
 msgstr "描述："
 
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. organizeBookmarksDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
 #: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -576,6 +576,10 @@ msgstr "哈瓦那"
 msgid "Helsinki"
 msgstr "赫爾辛基"
 
+#: ??
+msgid "Hong Kong"
+msgstr "香港"
+
 #: ../data/data.cpp:139
 msgid "Honiara"
 msgstr "荷尼阿拉"
@@ -819,6 +823,10 @@ msgstr "諾美亞"
 #: ../data/data.cpp:200
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
+
+#: ??
+msgid "Nur-Sultan"
+msgstr "努爾-蘇丹"
 
 #: ../data/data.cpp:201
 msgid "Nuuk"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2019-02-14 21:37+0300\n"
+"POT-Creation-Date: 2020-07-14 09:41+0300\n"
 "PO-Revision-Date: 2018-05-28 21:03+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -26,12 +26,12 @@ msgstr "水星"
 msgid "Venus"
 msgstr "金星"
 
-#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:598
-#: ../src/celestia/win32/wineclipses.cpp:319
+#: ../data/data.cpp:3 ../src/celestia/qt/qteventfinder.cpp:271
+#: ../src/celestia/win32/wineclipses.cpp:289
 msgid "Earth"
 msgstr "地球"
 
-#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:518
+#: ../data/data.cpp:4 ../src/celestia/qt/qtsolarsystembrowser.cpp:554
 msgid "Moon"
 msgstr "月球"
 
@@ -47,140 +47,140 @@ msgstr "火衛一(Phobos)"
 msgid "Deimos"
 msgstr "火衛二(Deimos)"
 
-#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:599
-#: ../src/celestia/win32/wineclipses.cpp:320
+#: ../data/data.cpp:8 ../src/celestia/qt/qteventfinder.cpp:272
+#: ../src/celestia/win32/wineclipses.cpp:290
 msgid "Jupiter"
 msgstr "木星"
 
 #: ../data/data.cpp:9
-msgid "Amalthea"
-msgstr "木衛五(Amalthea)"
-
-#: ../data/data.cpp:10
 msgid "Io"
 msgstr "木衛一(Io)"
 
-#: ../data/data.cpp:11
+#: ../data/data.cpp:10
 msgid "Europa"
 msgstr "木衛二(Europa)"
 
-#: ../data/data.cpp:12
+#: ../data/data.cpp:11
 msgid "Ganymede"
 msgstr "木衛三(Ganymede)"
 
-#: ../data/data.cpp:13
+#: ../data/data.cpp:12
 msgid "Callisto"
 msgstr "木衛四(Callisto)"
 
-#: ../data/data.cpp:14 ../src/celestia/qt/qteventfinder.cpp:600
-#: ../src/celestia/win32/wineclipses.cpp:321
+#: ../data/data.cpp:13 ../src/celestia/qt/qteventfinder.cpp:273
+#: ../src/celestia/win32/wineclipses.cpp:291
 msgid "Saturn"
 msgstr "土星"
 
-#: ../data/data.cpp:15
+#: ../data/data.cpp:14
 msgid "Prometheus"
 msgstr "土衛十六(Prometheus)"
 
-#: ../data/data.cpp:16
+#: ../data/data.cpp:15
 msgid "Pandora"
 msgstr "土衛十七(Pandora)"
 
-#: ../data/data.cpp:17
+#: ../data/data.cpp:16
 msgid "Epimetheus"
 msgstr "土衛十一(Epimetheus)"
 
-#: ../data/data.cpp:18
+#: ../data/data.cpp:17
 msgid "Janus"
 msgstr "土衛十(Janus)"
 
-#: ../data/data.cpp:19
+#: ../data/data.cpp:18
 msgid "Mimas"
 msgstr "土衛一(Mimas)"
 
-#: ../data/data.cpp:20
+#: ../data/data.cpp:19
 msgid "Enceladus"
 msgstr "土衛二(Enceladus)"
 
-#: ../data/data.cpp:21
+#: ../data/data.cpp:20
 msgid "Tethys"
 msgstr "土衛三(Tethys)"
 
-#: ../data/data.cpp:22
+#: ../data/data.cpp:21
 msgid "Dione"
 msgstr "土衛四(Dione)"
 
-#: ../data/data.cpp:23
+#: ../data/data.cpp:22
 msgid "Rhea"
 msgstr "土衛五(Rhea)"
 
-#: ../data/data.cpp:24
+#: ../data/data.cpp:23
 msgid "Titan"
 msgstr "土衛六(Titan)"
 
-#: ../data/data.cpp:25
+#: ../data/data.cpp:24
 msgid "Hyperion"
 msgstr "土衛七(Hyperion)"
 
-#: ../data/data.cpp:26
+#: ../data/data.cpp:25
 msgid "Iapetus"
 msgstr "土衛八(Iapetus)"
 
-#: ../data/data.cpp:27
+#: ../data/data.cpp:26
 msgid "Phoebe"
 msgstr "土衛九(Phoebe)"
 
-#: ../data/data.cpp:28 ../src/celestia/qt/qteventfinder.cpp:601
-#: ../src/celestia/win32/wineclipses.cpp:322
+#: ../data/data.cpp:27 ../src/celestia/qt/qteventfinder.cpp:274
+#: ../src/celestia/win32/wineclipses.cpp:292
 msgid "Uranus"
 msgstr "天王星"
 
-#: ../data/data.cpp:29
+#: ../data/data.cpp:28
 msgid "Miranda"
 msgstr "天衛五(Miranda)"
 
-#: ../data/data.cpp:30
+#: ../data/data.cpp:29
 msgid "Ariel"
 msgstr "天衛一(Ariel)"
 
-#: ../data/data.cpp:31
+#: ../data/data.cpp:30
 msgid "Umbriel"
 msgstr "天衛二(Umbriel)"
 
-#: ../data/data.cpp:32
+#: ../data/data.cpp:31
 msgid "Titania"
 msgstr "天衛三(Titania)"
 
-#: ../data/data.cpp:33
+#: ../data/data.cpp:32
 msgid "Oberon"
 msgstr "天衛四(Oberon)"
 
-#: ../data/data.cpp:34 ../src/celestia/qt/qteventfinder.cpp:602
-#: ../src/celestia/win32/wineclipses.cpp:323
+#: ../data/data.cpp:33 ../src/celestia/qt/qteventfinder.cpp:275
+#: ../src/celestia/win32/wineclipses.cpp:293
 msgid "Neptune"
 msgstr "海王星"
 
-#: ../data/data.cpp:35
+#: ../data/data.cpp:34
 msgid "Larissa"
 msgstr "海衛七(Larissa)"
 
-#: ../data/data.cpp:36
+#: ../data/data.cpp:35
 msgid "Proteus"
 msgstr "海衛八(Proteus)"
 
-#: ../data/data.cpp:37
+#: ../data/data.cpp:36
 msgid "Triton"
 msgstr "海衛一(Triton)"
 
-#: ../data/data.cpp:38
+#: ../data/data.cpp:37
 msgid "Nereid"
 msgstr "海衛二(Nereid)"
+
+#: ../data/data.cpp:38
+msgid "Ceres"
+msgstr ""
 
 #: ../data/data.cpp:39
 msgid "Pluto-Charon"
 msgstr "冥王星-冥衛一(Pluto-Charon)"
 
-#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:603
-#: ../src/celestia/win32/wineclipses.cpp:324
+#: ../data/data.cpp:40 ../src/celestia/qt/qteventfinder.cpp:276
+#: ../src/celestia/win32/wineclipses.cpp:294
 msgid "Pluto"
 msgstr "冥王星"
 
@@ -189,390 +189,629 @@ msgid "Charon"
 msgstr "冥衛一(Charon)"
 
 #: ../data/data.cpp:42
+msgid "Styx"
+msgstr ""
+
+#: ../data/data.cpp:43
+msgid "Nix"
+msgstr ""
+
+#: ../data/data.cpp:44
+msgid "Kerberos"
+msgstr ""
+
+#: ../data/data.cpp:45
+msgid "Hydra"
+msgstr ""
+
+#: ../data/data.cpp:46
+#, fuzzy
+msgid "Haumea"
+msgstr "諾美亞"
+
+#: ../data/data.cpp:47
+#, fuzzy
+msgid "Namaka"
+msgstr "巴馬科"
+
+#: ../data/data.cpp:48
+msgid "Hi'iaka"
+msgstr ""
+
+#: ../data/data.cpp:49
+msgid "Makemake"
+msgstr ""
+
+#: ../data/data.cpp:50
+msgid "S-2015 136472 I"
+msgstr ""
+
+#: ../data/data.cpp:51
+msgid "Eris"
+msgstr ""
+
+#: ../data/data.cpp:52
+msgid "Dysnomia"
+msgstr ""
+
+#: ../data/data.cpp:53
+msgid "Metis"
+msgstr ""
+
+#: ../data/data.cpp:54
+msgid "Adrastea"
+msgstr ""
+
+#: ../data/data.cpp:55
+msgid "Amalthea"
+msgstr "木衛五(Amalthea)"
+
+#: ../data/data.cpp:56
+msgid "Thebe"
+msgstr ""
+
+#: ../data/data.cpp:57
+msgid "Themisto"
+msgstr ""
+
+#: ../data/data.cpp:58
+msgid "Leda"
+msgstr ""
+
+#: ../data/data.cpp:59
+msgid "Himalia"
+msgstr ""
+
+#: ../data/data.cpp:60
+msgid "Lysithea"
+msgstr ""
+
+#: ../data/data.cpp:61
+msgid "Elara"
+msgstr ""
+
+#: ../data/data.cpp:62
+msgid "Iocaste"
+msgstr ""
+
+#: ../data/data.cpp:63
+msgid "Praxidike"
+msgstr ""
+
+#: ../data/data.cpp:64
+msgid "Harpalyke"
+msgstr ""
+
+#: ../data/data.cpp:65
+msgid "Ananke"
+msgstr ""
+
+#: ../data/data.cpp:66
+msgid "Isonoe"
+msgstr ""
+
+#: ../data/data.cpp:67
+msgid "Erinome"
+msgstr ""
+
+#: ../data/data.cpp:68
+msgid "Taygete"
+msgstr ""
+
+#: ../data/data.cpp:69
+msgid "Chaldene"
+msgstr ""
+
+#: ../data/data.cpp:70
+msgid "Carme"
+msgstr ""
+
+#: ../data/data.cpp:71
+msgid "Pasiphae"
+msgstr ""
+
+#: ../data/data.cpp:72
+msgid "Kalyke"
+msgstr ""
+
+#: ../data/data.cpp:73
+msgid "Megaclite"
+msgstr ""
+
+#: ../data/data.cpp:74
+msgid "Sinope"
+msgstr ""
+
+#: ../data/data.cpp:75
+#, fuzzy
+msgid "Callirrhoe"
+msgstr "木衛四(Callisto)"
+
+#: ../data/data.cpp:76
+#, fuzzy
+msgid "Pan"
+msgstr "1"
+
+#: ../data/data.cpp:77
+msgid "Atlas"
+msgstr ""
+
+#: ../data/data.cpp:78
+#, fuzzy
+msgid "Telesto"
+msgstr "Celestia"
+
+#: ../data/data.cpp:79
+msgid "Calypso"
+msgstr ""
+
+#: ../data/data.cpp:80
+msgid "Helene"
+msgstr ""
+
+#: ../data/data.cpp:81
+msgid "Cordelia"
+msgstr ""
+
+#: ../data/data.cpp:82
+msgid "Ophelia"
+msgstr ""
+
+#: ../data/data.cpp:83
+msgid "Bianca"
+msgstr ""
+
+#: ../data/data.cpp:84
+msgid "Cressida"
+msgstr ""
+
+#: ../data/data.cpp:85
+msgid "Desdemona"
+msgstr ""
+
+#: ../data/data.cpp:86
+msgid "Juliet"
+msgstr ""
+
+#: ../data/data.cpp:87
+#, fuzzy
+msgid "Portia"
+msgstr "維拉港"
+
+#: ../data/data.cpp:88
+msgid "Rosalind"
+msgstr ""
+
+#: ../data/data.cpp:89
+msgid "Belinda"
+msgstr ""
+
+#: ../data/data.cpp:90
+msgid "Puck"
+msgstr ""
+
+#: ../data/data.cpp:91
+msgid "Caliban"
+msgstr ""
+
+#: ../data/data.cpp:92
+msgid "Stephano"
+msgstr ""
+
+#: ../data/data.cpp:93
+msgid "Sycorax"
+msgstr ""
+
+#: ../data/data.cpp:94
+msgid "Prospero"
+msgstr ""
+
+#: ../data/data.cpp:95
+msgid "Setebos"
+msgstr ""
+
+#: ../data/data.cpp:96
+msgid "Naiad"
+msgstr ""
+
+#: ../data/data.cpp:97
+msgid "Thalassa"
+msgstr ""
+
+#: ../data/data.cpp:98
+msgid "Despina"
+msgstr ""
+
+#: ../data/data.cpp:99
+#, fuzzy
+msgid "Galatea"
+msgstr "星系"
+
+#: ../data/data.cpp:100
 msgid "NORTH AMERICA"
 msgstr "北美洲"
 
-#: ../data/data.cpp:43
+#: ../data/data.cpp:101
 msgid "SOUTH AMERICA"
 msgstr "南美洲"
 
-#: ../data/data.cpp:44
+#: ../data/data.cpp:102
 msgid "EURASIA"
 msgstr "歐亞大陸"
 
-#: ../data/data.cpp:45
+#: ../data/data.cpp:103
 msgid "AFRICA"
 msgstr "非洲"
 
-#: ../data/data.cpp:46
+#: ../data/data.cpp:104
 msgid "AUSTRALIA"
 msgstr "澳大利亞"
 
-#: ../data/data.cpp:47
+#: ../data/data.cpp:105
 msgid "ANTARCTICA"
 msgstr "南極洲"
 
-#: ../data/data.cpp:48
+#: ../data/data.cpp:106
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "北大西洋"
 
-#: ../data/data.cpp:49
+#: ../data/data.cpp:107
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "南大西洋"
 
-#: ../data/data.cpp:50
+#: ../data/data.cpp:108
 msgid "NORTH PACIFIC OCEAN"
 msgstr "北太平洋"
 
-#: ../data/data.cpp:51
+#: ../data/data.cpp:109
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "南太平洋"
 
-#: ../data/data.cpp:52
+#: ../data/data.cpp:110
 msgid "INDIAN OCEAN"
 msgstr "印度洋"
 
-#: ../data/data.cpp:53
+#: ../data/data.cpp:111
 msgid "ARCTIC OCEAN"
 msgstr "北極海"
 
-#: ../data/data.cpp:54
+#: ../data/data.cpp:112
 msgid "Abu Dhabi"
 msgstr "阿布達比"
 
-#: ../data/data.cpp:55
+#: ../data/data.cpp:113
 msgid "Abuja"
 msgstr "阿布札"
 
-#: ../data/data.cpp:56
+#: ../data/data.cpp:114
 msgid "Accra"
 msgstr "阿克拉"
 
-#: ../data/data.cpp:57
+#: ../data/data.cpp:115
 msgid "Adamstown"
 msgstr "亞當斯鎮"
 
-#: ../data/data.cpp:58
+#: ../data/data.cpp:116
 msgid "Addis Ababa"
 msgstr "阿迪斯阿貝巴"
 
-#: ../data/data.cpp:59
+#: ../data/data.cpp:117
 msgid "Algiers"
 msgstr "阿爾及爾"
 
-#: ../data/data.cpp:60
+#: ../data/data.cpp:118
 msgid "Alofi"
 msgstr "亞羅菲"
 
-#: ../data/data.cpp:61
+#: ../data/data.cpp:119
 msgid "Amman"
 msgstr "安曼"
 
-#: ../data/data.cpp:62
+#: ../data/data.cpp:120
 msgid "Amsterdam"
 msgstr "阿姆斯特丹"
 
-#: ../data/data.cpp:63
+#: ../data/data.cpp:121
 msgid "Andorra la Vella"
 msgstr "安道爾"
 
-#: ../data/data.cpp:64
+#: ../data/data.cpp:122
 msgid "Ankara"
 msgstr "安哥拉"
 
-#: ../data/data.cpp:65
+#: ../data/data.cpp:123
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: ../data/data.cpp:66
+#: ../data/data.cpp:124
 msgid "Apia"
 msgstr "亞庇"
 
-#: ../data/data.cpp:67
+#: ../data/data.cpp:125
 msgid "Ashgabat"
 msgstr "Ashgabat"
 
-#: ../data/data.cpp:68
+#: ../data/data.cpp:126
 msgid "Asmara"
 msgstr "阿斯馬拉"
 
-#: ../data/data.cpp:69
+#: ../data/data.cpp:127
 msgid "Astana"
 msgstr "Astana"
 
-#: ../data/data.cpp:70
+#: ../data/data.cpp:128
 msgid "Asuncion"
 msgstr "亞松森"
 
-#: ../data/data.cpp:71
+#: ../data/data.cpp:129
 msgid "Athens"
 msgstr "雅典"
 
-#: ../data/data.cpp:72
+#: ../data/data.cpp:130
 msgid "Avarua"
 msgstr "阿瓦路亞"
 
-#: ../data/data.cpp:73
+#: ../data/data.cpp:131
 msgid "Baghdad"
 msgstr "巴格達"
 
-#: ../data/data.cpp:74
+#: ../data/data.cpp:132
 msgid "Baku"
 msgstr "巴庫"
 
-#: ../data/data.cpp:75
+#: ../data/data.cpp:133
 msgid "Bamako"
 msgstr "巴馬科"
 
-#: ../data/data.cpp:76
+#: ../data/data.cpp:134
 msgid "Bandar Seri Begawan"
 msgstr "斯里巴卡旺"
 
-#: ../data/data.cpp:77
+#: ../data/data.cpp:135
 msgid "Bangkok"
 msgstr "曼谷"
 
-#: ../data/data.cpp:78
+#: ../data/data.cpp:136
 msgid "Bangui"
 msgstr "班基"
 
-#: ../data/data.cpp:79
+#: ../data/data.cpp:137
 msgid "Banjul"
 msgstr "斑竹"
 
-#: ../data/data.cpp:80
+#: ../data/data.cpp:138
 msgid "Basse-Terre"
 msgstr "巴士地"
 
-#: ../data/data.cpp:81
+#: ../data/data.cpp:139
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: ../data/data.cpp:82
+#: ../data/data.cpp:140
 msgid "Beijing"
 msgstr "北京"
 
-#: ../data/data.cpp:83
+#: ../data/data.cpp:141
 msgid "Beirut"
 msgstr "貝魯特"
 
-#: ../data/data.cpp:84
+#: ../data/data.cpp:142
 msgid "Belgrade"
 msgstr "貝爾格萊德"
 
-#: ../data/data.cpp:85
+#: ../data/data.cpp:143
 msgid "Belmopan"
 msgstr "貝爾墨邦"
 
-#: ../data/data.cpp:86
+#: ../data/data.cpp:144
 msgid "Berlin"
 msgstr "柏林"
 
-#: ../data/data.cpp:87
+#: ../data/data.cpp:145
 msgid "Bern"
 msgstr "伯恩"
 
-#: ../data/data.cpp:88
+#: ../data/data.cpp:146
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: ../data/data.cpp:89
+#: ../data/data.cpp:147
 msgid "Bissau"
 msgstr "比索"
 
-#: ../data/data.cpp:90
+#: ../data/data.cpp:148
 msgid "Bloemfontein"
 msgstr "布隆泉"
 
-#: ../data/data.cpp:91
+#: ../data/data.cpp:149
 msgid "Bogota"
 msgstr "波哥大"
 
-#: ../data/data.cpp:92
+#: ../data/data.cpp:150
 msgid "Brasilia"
 msgstr "巴西利亞"
 
-#: ../data/data.cpp:93
+#: ../data/data.cpp:151
 msgid "Bratislava"
 msgstr "布拉提拉瓦"
 
-#: ../data/data.cpp:94
+#: ../data/data.cpp:152
 msgid "Brazzaville"
 msgstr "布拉薩市"
 
-#: ../data/data.cpp:95
+#: ../data/data.cpp:153
 msgid "Bridgetown"
 msgstr "橋鎮"
 
-#: ../data/data.cpp:96
+#: ../data/data.cpp:154
 msgid "Brussels"
 msgstr "布魯塞爾"
 
-#: ../data/data.cpp:97
+#: ../data/data.cpp:155
 msgid "Bucharest"
 msgstr "布加勒斯"
 
-#: ../data/data.cpp:98
+#: ../data/data.cpp:156
 msgid "Budapest"
 msgstr "布達佩斯"
 
-#: ../data/data.cpp:99
+#: ../data/data.cpp:157
 msgid "Buenos Aires"
 msgstr "布宜諾賽利斯"
 
-#: ../data/data.cpp:100
+#: ../data/data.cpp:158
 msgid "Bujumbura"
 msgstr "布松布拉"
 
-#: ../data/data.cpp:101
+#: ../data/data.cpp:159
 msgid "Cairo"
 msgstr "開羅"
 
-#: ../data/data.cpp:102
+#: ../data/data.cpp:160
 msgid "Canberra"
 msgstr "坎培拉"
 
-#: ../data/data.cpp:103
+#: ../data/data.cpp:161
 msgid "Cape Town"
 msgstr "開普頓"
 
-#: ../data/data.cpp:104
+#: ../data/data.cpp:162
 msgid "Caracas"
 msgstr "卡拉卡斯"
 
-#: ../data/data.cpp:105
+#: ../data/data.cpp:163
 msgid "Castries"
 msgstr "卡斯翠"
 
-#: ../data/data.cpp:106
+#: ../data/data.cpp:164
 msgid "Cayenne"
 msgstr "開雲"
 
-#: ../data/data.cpp:107
+#: ../data/data.cpp:165
 msgid "Charlotte Amalie"
 msgstr "沙洛特阿馬略"
 
-#: ../data/data.cpp:108
+#: ../data/data.cpp:166
 msgid "Chisinau"
 msgstr "奇西瑙"
 
-#: ../data/data.cpp:109
+#: ../data/data.cpp:167
 msgid "Colombo"
 msgstr "可倫坡"
 
-#: ../data/data.cpp:110
+#: ../data/data.cpp:168
 msgid "Conakry"
 msgstr "柯那克里"
 
-#: ../data/data.cpp:111
+#: ../data/data.cpp:169
 msgid "Copenhagen"
 msgstr "哥本哈根"
 
-#: ../data/data.cpp:112
+#: ../data/data.cpp:170
 msgid "Cotonou"
 msgstr "柯都努"
 
-#: ../data/data.cpp:113
+#: ../data/data.cpp:171
 msgid "Dakar"
 msgstr "達卡"
 
-#: ../data/data.cpp:114
+#: ../data/data.cpp:172
 msgid "Damascus"
 msgstr "大馬士革"
 
-#: ../data/data.cpp:115
+#: ../data/data.cpp:173
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: ../data/data.cpp:116
+#: ../data/data.cpp:174
 msgid "Dhaka"
 msgstr "達卡"
 
-#: ../data/data.cpp:117
+#: ../data/data.cpp:175
 msgid "Dili"
 msgstr "狄力"
 
-#: ../data/data.cpp:118
+#: ../data/data.cpp:176
 msgid "Djibouti"
 msgstr "吉布地"
 
-#: ../data/data.cpp:119
+#: ../data/data.cpp:177
 msgid "Doha"
 msgstr "杜哈"
 
-#: ../data/data.cpp:120
+#: ../data/data.cpp:178
 msgid "Douglas"
 msgstr "道格拉斯"
 
-#: ../data/data.cpp:121
+#: ../data/data.cpp:179
 msgid "Dublin"
 msgstr "都柏林"
 
-#: ../data/data.cpp:122
+#: ../data/data.cpp:180
 msgid "Dushanbe"
 msgstr "杜尚貝"
 
-#: ../data/data.cpp:123
+#: ../data/data.cpp:181
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: ../data/data.cpp:124
+#: ../data/data.cpp:182
 msgid "Fort-de-France"
 msgstr "法蘭西堡"
 
-#: ../data/data.cpp:125
+#: ../data/data.cpp:183
 msgid "Freetown"
 msgstr "自由城"
 
-#: ../data/data.cpp:126
+#: ../data/data.cpp:184
 msgid "Gaborone"
 msgstr "嘉柏隆里"
 
-#: ../data/data.cpp:127
+#: ../data/data.cpp:185
 msgid "George Town"
 msgstr "喬治鎮"
 
-#: ../data/data.cpp:128
+#: ../data/data.cpp:186
 msgid "Georgetown"
 msgstr "喬治市"
 
-#: ../data/data.cpp:129
+#: ../data/data.cpp:187
 msgid "Gibraltar"
 msgstr "直布羅陀"
 
-#: ../data/data.cpp:130
+#: ../data/data.cpp:188
 msgid "Grand Turk"
 msgstr "大特克"
 
-#: ../data/data.cpp:131
+#: ../data/data.cpp:189
 msgid "Guatemala"
 msgstr "瓜地馬拉"
 
-#: ../data/data.cpp:132
+#: ../data/data.cpp:190
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: ../data/data.cpp:133
+#: ../data/data.cpp:191
 msgid "The Hague"
 msgstr "海牙"
 
-#: ../data/data.cpp:134
+#: ../data/data.cpp:192
 msgid "Hamilton"
 msgstr "漢米頓"
 
-#: ../data/data.cpp:135
+#: ../data/data.cpp:193
 msgid "Hanoi"
 msgstr "河內"
 
-#: ../data/data.cpp:136
+#: ../data/data.cpp:194
 msgid "Harare"
 msgstr "哈拉雷"
 
-#: ../data/data.cpp:137
+#: ../data/data.cpp:195
 msgid "Havana"
 msgstr "哈瓦那"
 
-#: ../data/data.cpp:138
+#: ../data/data.cpp:196
 msgid "Helsinki"
 msgstr "赫爾辛基"
 
@@ -580,247 +819,247 @@ msgstr "赫爾辛基"
 msgid "Hong Kong"
 msgstr "香港"
 
-#: ../data/data.cpp:139
+#: ../data/data.cpp:197
 msgid "Honiara"
 msgstr "荷尼阿拉"
 
-#: ../data/data.cpp:140
+#: ../data/data.cpp:198
 msgid "Islamabad"
 msgstr "伊斯蘭馬巴德"
 
-#: ../data/data.cpp:141
+#: ../data/data.cpp:199
 msgid "Jakarta"
 msgstr "雅加達"
 
-#: ../data/data.cpp:142
+#: ../data/data.cpp:200
 msgid "Jamestown"
 msgstr "詹姆斯鎮"
 
-#: ../data/data.cpp:143
+#: ../data/data.cpp:201
 msgid "Jerusalem"
 msgstr "耶路撒冷"
 
-#: ../data/data.cpp:144
+#: ../data/data.cpp:202
 msgid "Kabul"
 msgstr "喀布爾"
 
-#: ../data/data.cpp:145
+#: ../data/data.cpp:203
 msgid "Kampala"
 msgstr "坎帕拉"
 
-#: ../data/data.cpp:146
+#: ../data/data.cpp:204
 msgid "Kathmandu"
 msgstr "加德滿都"
 
-#: ../data/data.cpp:147
+#: ../data/data.cpp:205
 msgid "Khartoum"
 msgstr "卡土穆"
 
-#: ../data/data.cpp:148
+#: ../data/data.cpp:206
 msgid "Kiev"
 msgstr "基輔"
 
-#: ../data/data.cpp:149
+#: ../data/data.cpp:207
 msgid "Kigali"
 msgstr "吉佳利"
 
-#: ../data/data.cpp:150 ../data/data.cpp:151
+#: ../data/data.cpp:208 ../data/data.cpp:209
 msgid "Kingston"
 msgstr "京斯頓"
 
-#: ../data/data.cpp:152
+#: ../data/data.cpp:210
 msgid "Kingstown"
 msgstr "金斯頓"
 
-#: ../data/data.cpp:153
+#: ../data/data.cpp:211
 msgid "Kinshasa"
 msgstr "金夏沙"
 
-#: ../data/data.cpp:154
+#: ../data/data.cpp:212
 msgid "Koror"
 msgstr "科羅爾"
 
-#: ../data/data.cpp:155
+#: ../data/data.cpp:213
 msgid "Kuala Lumpur"
 msgstr "吉隆坡"
 
-#: ../data/data.cpp:156
+#: ../data/data.cpp:214
 msgid "Kuwait"
 msgstr "科威特"
 
-#: ../data/data.cpp:157
+#: ../data/data.cpp:215
 msgid "La'youn"
 msgstr "La'youn"
 
-#: ../data/data.cpp:158
+#: ../data/data.cpp:216
 msgid "La Paz"
 msgstr "拉巴斯"
 
-#: ../data/data.cpp:159
+#: ../data/data.cpp:217
 msgid "Libreville"
 msgstr "自由市"
 
-#: ../data/data.cpp:160
+#: ../data/data.cpp:218
 msgid "Lilongwe"
 msgstr "里朗威"
 
-#: ../data/data.cpp:161
+#: ../data/data.cpp:219
 msgid "Lima"
 msgstr "來瑪"
 
-#: ../data/data.cpp:162
+#: ../data/data.cpp:220
 msgid "Lisbon"
 msgstr "里斯本"
 
-#: ../data/data.cpp:163
+#: ../data/data.cpp:221
 msgid "Ljubljana"
 msgstr "留布利安納"
 
-#: ../data/data.cpp:164
+#: ../data/data.cpp:222
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: ../data/data.cpp:165
+#: ../data/data.cpp:223
 msgid "Lome"
 msgstr "洛梅"
 
-#: ../data/data.cpp:166
+#: ../data/data.cpp:224
 msgid "London"
 msgstr "倫敦"
 
-#: ../data/data.cpp:167
+#: ../data/data.cpp:225
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: ../data/data.cpp:168
+#: ../data/data.cpp:226
 msgid "Luanda"
 msgstr "羅安達"
 
-#: ../data/data.cpp:169
+#: ../data/data.cpp:227
 msgid "Lusaka"
 msgstr "路沙卡"
 
-#: ../data/data.cpp:170
+#: ../data/data.cpp:228
 msgid "Luxembourg"
 msgstr "盧森堡"
 
-#: ../data/data.cpp:171
+#: ../data/data.cpp:229
 msgid "Madrid"
 msgstr "馬德里"
 
-#: ../data/data.cpp:172
+#: ../data/data.cpp:230
 msgid "Majuro"
 msgstr "馬久羅"
 
-#: ../data/data.cpp:173
+#: ../data/data.cpp:231
 msgid "Malabo"
 msgstr "馬拉繃"
 
-#: ../data/data.cpp:174
+#: ../data/data.cpp:232
 msgid "Male"
 msgstr "瑪律"
 
-#: ../data/data.cpp:175
+#: ../data/data.cpp:233
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: ../data/data.cpp:176
+#: ../data/data.cpp:234
 msgid "Managua"
 msgstr "馬拿瓜"
 
-#: ../data/data.cpp:177
+#: ../data/data.cpp:235
 msgid "Manama"
 msgstr "麥納瑪"
 
-#: ../data/data.cpp:178
+#: ../data/data.cpp:236
 msgid "Manila"
 msgstr "馬尼拉"
 
-#: ../data/data.cpp:179
+#: ../data/data.cpp:237
 msgid "Maputo"
 msgstr "馬布多"
 
-#: ../data/data.cpp:180
+#: ../data/data.cpp:238
 msgid "Maseru"
 msgstr "馬塞魯"
 
-#: ../data/data.cpp:181
+#: ../data/data.cpp:239
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: ../data/data.cpp:182
+#: ../data/data.cpp:240
 msgid "Mbabane"
 msgstr "墨巴本"
 
-#: ../data/data.cpp:183
+#: ../data/data.cpp:241
 msgid "Mexico City"
 msgstr "墨西哥城"
 
-#: ../data/data.cpp:184
+#: ../data/data.cpp:242
 msgid "Minsk"
 msgstr "明斯克"
 
-#: ../data/data.cpp:185
+#: ../data/data.cpp:243
 msgid "Mogadishu"
 msgstr "摩加迪休"
 
-#: ../data/data.cpp:186
+#: ../data/data.cpp:244
 msgid "Monaco"
 msgstr "摩納哥"
 
-#: ../data/data.cpp:187
+#: ../data/data.cpp:245
 msgid "Monrovia"
 msgstr "蒙羅維亞"
 
-#: ../data/data.cpp:188
+#: ../data/data.cpp:246
 msgid "Montevideo"
 msgstr "蒙特維多"
 
-#: ../data/data.cpp:189
+#: ../data/data.cpp:247
 msgid "Moroni"
 msgstr "莫洛尼"
 
-#: ../data/data.cpp:190
+#: ../data/data.cpp:248
 msgid "Moscow"
 msgstr "莫斯科"
 
-#: ../data/data.cpp:191
+#: ../data/data.cpp:249
 msgid "Muscat"
 msgstr "馬斯喀特"
 
-#: ../data/data.cpp:192
+#: ../data/data.cpp:250
 msgid "Nairobi"
 msgstr "奈洛比"
 
-#: ../data/data.cpp:193
+#: ../data/data.cpp:251
 msgid "Nassau"
 msgstr "納索"
 
-#: ../data/data.cpp:194
+#: ../data/data.cpp:252
 msgid "N'Djamena"
 msgstr "恩將納"
 
-#: ../data/data.cpp:195
+#: ../data/data.cpp:253
 msgid "New Delhi"
 msgstr "新德里"
 
-#: ../data/data.cpp:196
+#: ../data/data.cpp:254
 msgid "Niamey"
 msgstr "尼阿美"
 
-#: ../data/data.cpp:197
+#: ../data/data.cpp:255
 msgid "Nicosia"
 msgstr "尼古西亞"
 
-#: ../data/data.cpp:198
+#: ../data/data.cpp:256
 msgid "Nouakchott"
 msgstr "諾克少"
 
-#: ../data/data.cpp:199
+#: ../data/data.cpp:257
 msgid "Noumea"
 msgstr "諾美亞"
 
-#: ../data/data.cpp:200
+#: ../data/data.cpp:258
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
@@ -828,397 +1067,412 @@ msgstr "Nuku'alofa"
 msgid "Nur-Sultan"
 msgstr "努爾-蘇丹"
 
-#: ../data/data.cpp:201
+#: ../data/data.cpp:259
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: ../data/data.cpp:202
+#: ../data/data.cpp:260
 msgid "Oranjestad"
 msgstr "奧蘭葉斯塔"
 
-#: ../data/data.cpp:203
+#: ../data/data.cpp:261
 msgid "Oslo"
 msgstr "奧斯陸"
 
-#: ../data/data.cpp:204
+#: ../data/data.cpp:262
 msgid "Ottawa"
 msgstr "渥太華"
 
-#: ../data/data.cpp:205
+#: ../data/data.cpp:263
 msgid "Ouagadougou"
 msgstr "瓦加杜古"
 
-#: ../data/data.cpp:206
+#: ../data/data.cpp:264
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: ../data/data.cpp:207
+#: ../data/data.cpp:265
 msgid "Palikir"
 msgstr "Palikir"
 
-#: ../data/data.cpp:208
+#: ../data/data.cpp:266
 msgid "Panama"
 msgstr "巴拿馬"
 
-#: ../data/data.cpp:209
+#: ../data/data.cpp:267
 msgid "Papeete"
 msgstr "Papeete"
 
-#: ../data/data.cpp:210
+#: ../data/data.cpp:268
 msgid "Paramaribo"
 msgstr "巴拉馬利波"
 
-#: ../data/data.cpp:211
+#: ../data/data.cpp:269
 msgid "Paris"
 msgstr "巴黎"
 
-#: ../data/data.cpp:212
+#: ../data/data.cpp:270
 msgid "Phnom Penh"
 msgstr "金邊"
 
-#: ../data/data.cpp:213
+#: ../data/data.cpp:271
 msgid "Plymouth"
 msgstr "普利茅斯"
 
-#: ../data/data.cpp:214
+#: ../data/data.cpp:272
 msgid "Port Louis"
 msgstr "路易士港"
 
-#: ../data/data.cpp:215
+#: ../data/data.cpp:273
 msgid "Port Moresby"
 msgstr "摩爾斯貝港"
 
-#: ../data/data.cpp:216
+#: ../data/data.cpp:274
 msgid "Port-au-Prince"
 msgstr "太子港"
 
-#: ../data/data.cpp:217
+#: ../data/data.cpp:275
 msgid "Port-of-Spain"
 msgstr "西班牙港"
 
-#: ../data/data.cpp:218
+#: ../data/data.cpp:276
 msgid "Porto-Novo"
 msgstr "新港/諾弗港"
 
-#: ../data/data.cpp:219
+#: ../data/data.cpp:277
 msgid "Port-Vila"
 msgstr "維拉港"
 
-#: ../data/data.cpp:220
+#: ../data/data.cpp:278
 msgid "Prague"
 msgstr "布拉格"
 
-#: ../data/data.cpp:221
+#: ../data/data.cpp:279
 msgid "Praia"
 msgstr "培亞"
 
-#: ../data/data.cpp:222
+#: ../data/data.cpp:280
 msgid "Pretoria"
 msgstr "普利托里亞"
 
-#: ../data/data.cpp:223
+#: ../data/data.cpp:281
 msgid "P'yongyang"
 msgstr "平壤"
 
-#: ../data/data.cpp:224
+#: ../data/data.cpp:282
 msgid "Quito"
 msgstr "基多"
 
-#: ../data/data.cpp:225
+#: ../data/data.cpp:283
 msgid "Rabat"
 msgstr "拉巴特"
 
-#: ../data/data.cpp:226
+#: ../data/data.cpp:284
 msgid "Rangoon"
 msgstr "仰光"
 
-#: ../data/data.cpp:227
+#: ../data/data.cpp:285
 msgid "Reykjavik"
 msgstr "雷克雅維克"
 
-#: ../data/data.cpp:228
+#: ../data/data.cpp:286
 msgid "Riga"
 msgstr "里加"
 
-#: ../data/data.cpp:229
+#: ../data/data.cpp:287
 msgid "Riyadh"
 msgstr "利雅德"
 
-#: ../data/data.cpp:230
+#: ../data/data.cpp:288
 msgid "Road Town"
 msgstr "Road Town"
 
-#: ../data/data.cpp:231
+#: ../data/data.cpp:289
 msgid "Rome"
 msgstr "羅姆"
 
-#: ../data/data.cpp:232
+#: ../data/data.cpp:290
 msgid "Roseau"
 msgstr "羅梭"
 
-#: ../data/data.cpp:233
+#: ../data/data.cpp:291
 msgid "Saint George's"
 msgstr "聖喬治"
 
-#: ../data/data.cpp:234
+#: ../data/data.cpp:292
 msgid "Saint Helier"
 msgstr "聖赫列"
 
-#: ../data/data.cpp:235
+#: ../data/data.cpp:293
 msgid "Saint John's"
 msgstr "聖約翰"
 
-#: ../data/data.cpp:236
+#: ../data/data.cpp:294
 msgid "Saint Peter Port"
 msgstr "聖彼得港"
 
-#: ../data/data.cpp:237
+#: ../data/data.cpp:295
 msgid "Saint-Denis"
 msgstr "聖丹尼"
 
-#: ../data/data.cpp:238
+#: ../data/data.cpp:296
 msgid "Saint-Pierre"
 msgstr "聖匹"
 
-#: ../data/data.cpp:239
+#: ../data/data.cpp:297
 msgid "Saipan"
 msgstr "塞班"
 
-#: ../data/data.cpp:240
+#: ../data/data.cpp:298
 msgid "San Jose"
 msgstr "聖約瑟"
 
-#: ../data/data.cpp:241
+#: ../data/data.cpp:299
 msgid "San Juan"
 msgstr "聖胡安"
 
-#: ../data/data.cpp:242
+#: ../data/data.cpp:300
 msgid "San Marino"
 msgstr "聖馬力諾"
 
-#: ../data/data.cpp:243
+#: ../data/data.cpp:301
 msgid "San Salvador"
 msgstr "聖薩爾瓦多"
 
-#: ../data/data.cpp:244
+#: ../data/data.cpp:302
 msgid "Sanaa"
 msgstr "沙那"
 
-#: ../data/data.cpp:245
+#: ../data/data.cpp:303
 msgid "Santiago"
 msgstr "聖地牙哥"
 
-#: ../data/data.cpp:246
+#: ../data/data.cpp:304
 msgid "Santo Domingo"
 msgstr "聖多明哥"
 
-#: ../data/data.cpp:247
+#: ../data/data.cpp:305
 msgid "Sao Tome"
 msgstr "聖多美"
 
-#: ../data/data.cpp:248
+#: ../data/data.cpp:306
 msgid "Sarajevo"
 msgstr "沙拉耶佛"
 
-#: ../data/data.cpp:249
+#: ../data/data.cpp:307
 msgid "Seoul"
 msgstr "首爾"
 
-#: ../data/data.cpp:250
+#: ../data/data.cpp:308
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: ../data/data.cpp:251
+#: ../data/data.cpp:309
 msgid "Singapore"
 msgstr "新加坡"
 
-#: ../data/data.cpp:252
+#: ../data/data.cpp:310
 msgid "Skopje"
 msgstr "斯科普耶"
 
-#: ../data/data.cpp:253
+#: ../data/data.cpp:311
 msgid "Sofia"
 msgstr "索非亞"
 
-#: ../data/data.cpp:254
+#: ../data/data.cpp:312
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: ../data/data.cpp:255
+#: ../data/data.cpp:313
 msgid "Stanley"
 msgstr "史坦萊"
 
-#: ../data/data.cpp:256
+#: ../data/data.cpp:314
 msgid "Stockholm"
 msgstr "斯德哥爾摩"
 
-#: ../data/data.cpp:257
+#: ../data/data.cpp:315
 msgid "Sucre"
 msgstr "蘇克雷"
 
-#: ../data/data.cpp:258
+#: ../data/data.cpp:316
 msgid "Suva"
 msgstr "蘇瓦"
 
-#: ../data/data.cpp:259
+#: ../data/data.cpp:317
 msgid "Taipei"
 msgstr "台北"
 
-#: ../data/data.cpp:260
+#: ../data/data.cpp:318
 msgid "Tallinn"
 msgstr "塔林"
 
-#: ../data/data.cpp:261
+#: ../data/data.cpp:319
 msgid "Tarawa"
 msgstr "塔拉瓦"
 
-#: ../data/data.cpp:262
+#: ../data/data.cpp:320
 msgid "Tashkent"
 msgstr "塔什干"
 
-#: ../data/data.cpp:263
+#: ../data/data.cpp:321
 msgid "T'bilisi"
 msgstr "提弗利司"
 
-#: ../data/data.cpp:264
+#: ../data/data.cpp:322
 msgid "Tegucigalpa"
 msgstr "德古斯加巴"
 
-#: ../data/data.cpp:265
+#: ../data/data.cpp:323
 msgid "Tehran"
 msgstr "德黑蘭"
 
-#: ../data/data.cpp:266
+#: ../data/data.cpp:324
 msgid "Tel Aviv"
 msgstr "特拉維夫"
 
-#: ../data/data.cpp:267
+#: ../data/data.cpp:325
 msgid "Thimphu"
 msgstr "辛布"
 
-#: ../data/data.cpp:268
+#: ../data/data.cpp:326
 msgid "Tirana"
 msgstr "地拉那"
 
-#: ../data/data.cpp:269
+#: ../data/data.cpp:327
 msgid "Tokyo"
 msgstr "東京"
 
-#: ../data/data.cpp:270
+#: ../data/data.cpp:328
 msgid "Torshavn"
 msgstr "托沙文"
 
-#: ../data/data.cpp:271
+#: ../data/data.cpp:329
 msgid "Tripoli"
 msgstr "的黎波里"
 
-#: ../data/data.cpp:272
+#: ../data/data.cpp:330
 msgid "Tunis"
 msgstr "突尼斯"
 
-#: ../data/data.cpp:273
+#: ../data/data.cpp:331
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: ../data/data.cpp:274
+#: ../data/data.cpp:332
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: ../data/data.cpp:275
+#: ../data/data.cpp:333
 msgid "Valletta"
 msgstr "法勒他"
 
-#: ../data/data.cpp:276
+#: ../data/data.cpp:334
 msgid "The Valley"
 msgstr "The Valley"
 
-#: ../data/data.cpp:277
+#: ../data/data.cpp:335
 msgid "Vatican City"
 msgstr "梵蒂岡"
 
-#: ../data/data.cpp:278 ../data/data.cpp:279
+#: ../data/data.cpp:336 ../data/data.cpp:337
 msgid "Victoria"
 msgstr "維多利亞"
 
-#: ../data/data.cpp:280
+#: ../data/data.cpp:338
 msgid "Vienna"
 msgstr "維也納"
 
-#: ../data/data.cpp:281
+#: ../data/data.cpp:339
 msgid "Vientiane"
 msgstr "永珍"
 
-#: ../data/data.cpp:282
+#: ../data/data.cpp:340
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: ../data/data.cpp:283
+#: ../data/data.cpp:341
 msgid "Warsaw"
 msgstr "華沙"
 
-#: ../data/data.cpp:284
+#: ../data/data.cpp:342
 msgid "Washington D.C."
 msgstr "華盛頓特區"
 
-#: ../data/data.cpp:285
+#: ../data/data.cpp:343
 msgid "Wellington"
 msgstr "威靈頓"
 
-#: ../data/data.cpp:286
+#: ../data/data.cpp:344
 msgid "West Island"
 msgstr "West Island"
 
-#: ../data/data.cpp:287
+#: ../data/data.cpp:345
 msgid "Willemstad"
 msgstr "維倫斯塔"
 
-#: ../data/data.cpp:288
+#: ../data/data.cpp:346
 msgid "Windhoek"
 msgstr "文胡克"
 
-#: ../data/data.cpp:289
+#: ../data/data.cpp:347
 msgid "Yamoussoukro"
 msgstr "雅穆索戈"
 
-#: ../data/data.cpp:290
+#: ../data/data.cpp:348
 msgid "Yaounde"
 msgstr "雅溫德"
 
-#: ../data/data.cpp:291
+#: ../data/data.cpp:349
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: ../data/data.cpp:292
+#: ../data/data.cpp:350
 msgid "Yerevan"
 msgstr "葉勒凡"
 
-#: ../data/data.cpp:293
+#: ../data/data.cpp:351
 msgid "Zagreb"
 msgstr "札格拉布"
 
-#: ../data/data.cpp:294
+#: ../data/data.cpp:352
 msgid "Milky Way"
 msgstr "Milky Way 銀河"
 
-#: ../data/data.cpp:295
+#: ../data/data.cpp:353
 msgid "SMC"
 msgstr "SMC"
 
-#: ../data/data.cpp:296
+#: ../data/data.cpp:354
 msgid "LMC"
 msgstr "LMC"
 
-#: ../data/data.cpp:297
+#: ../data/data.cpp:355
 msgid "Solar System Barycenter"
 msgstr "太陽系質量中心"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "DST"
 msgstr "日光節約時間"
 
-#: ../src/celengine/astro.cpp:732
+#: ../src/celengine/astro.cpp:703
 msgid "STD"
 msgstr "標準時間"
+
+#: ../src/celengine/configreader.cpp:19
+#, fuzzy, c-format
+msgid "Error opening config file '%s'.\n"
+msgstr "影像檔案開啟失敗"
+
+#: ../src/celengine/configreader.cpp:29
+#, c-format
+msgid "%s:%d 'Configuration' expected.\n"
+msgstr ""
+
+#: ../src/celengine/configreader.cpp:37
+#, fuzzy, c-format
+msgid "%s: Bad configuration file.\n"
+msgstr "讀取設定檔時發生錯誤。"
 
 #.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
@@ -1228,87 +1482,58 @@ msgstr "標準時間"
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
 #.
-#: ../src/celengine/dsodb.cpp:368
+#: ../src/celengine/dsodb.cpp:375
 #, fuzzy, c-format
 msgid "Loaded %i deep space objects\n"
 msgstr "深太空天體"
 
-#: ../src/celengine/fragmentprog.cpp:92
-msgid "Loading NV fragment program: "
-msgstr "載入 NV 片段程式中:"
-
-#: ../src/celengine/fragmentprog.cpp:97
-msgid "Error loading NV fragment program: "
-msgstr "讀取 NV 片段程式時發生錯誤:"
-
-#: ../src/celengine/fragmentprog.cpp:114
-msgid "Error in fragment program "
-msgstr "片段程式發生錯誤"
-
-#: ../src/celengine/fragmentprog.cpp:125
-msgid "Initializing NV fragment programs . . .\n"
-msgstr "初始化 NV 片段程式中...\n"
-
-#: ../src/celengine/fragmentprog.cpp:141
-msgid "All NV fragment programs loaded successfully.\n"
-msgstr "所有 NV 片段程式已成功載入。\n"
-
-#: ../src/celengine/fragmentprog.cpp:149
-msgid "Initializing ARB fragment programs . . .\n"
-msgstr "初始化 ARB 片段程式中...\n"
-
-#: ../src/celengine/galaxy.cpp:193
+#: ../src/celengine/galaxy.cpp:209
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "星系 (哈伯分類:%s)"
 
-#: ../src/celengine/globular.cpp:256
+#: ../src/celengine/globular.cpp:238
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "球狀星團 (核半徑: %4.2f', King 聚度: %4.2f)"
 
-#: ../src/celengine/image.cpp:319
+#: ../src/celengine/image.cpp:320
 #, fuzzy, c-format
 msgid "Loading image from file %s\n"
 msgstr "從檔案讀取影像"
 
-#: ../src/celengine/image.cpp:337
-#, fuzzy, c-format
-msgid "%s: unrecognized or unsupported image file type.\n"
-msgstr ":無法辨識或未支援的影像格式。\n"
-
-#: ../src/celengine/image.cpp:600
+#: ../src/celengine/image.cpp:530
 #, fuzzy, c-format
 msgid "Error opening image file %s\n"
 msgstr "影像檔案開啟失敗"
 
-#: ../src/celengine/image.cpp:608
+#: ../src/celengine/image.cpp:538
 #, fuzzy, c-format
 msgid "Error: %s is not a PNG file.\n"
 msgstr " 並不是一個PNG檔案。\n"
 
-#: ../src/celengine/image.cpp:634
+#: ../src/celengine/image.cpp:564
 #, fuzzy, c-format
 msgid "Error reading PNG image file %s\n"
 msgstr "讀取PNG影像檔發生錯誤"
 
-#: ../src/celengine/meshmanager.cpp:112
+#: ../src/celengine/meshmanager.cpp:120
 #, fuzzy, c-format
 msgid "Loading model: %s\n"
 msgstr "載入模式:"
 
-#: ../src/celengine/meshmanager.cpp:193
+#: ../src/celengine/meshmanager.cpp:201
 #, c-format
 msgid ""
 "   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:203
+#: ../src/celengine/meshmanager.cpp:211
 #, fuzzy, c-format
 msgid "Error loading model '%s'\n"
 msgstr "載入模式錯誤"
 
-#: ../src/celengine/nebula.cpp:39
+#: ../src/celengine/nebula.cpp:40
 msgid "Nebula"
 msgstr "星雲"
 
@@ -1316,858 +1541,834 @@ msgstr "星雲"
 msgid "Open cluster"
 msgstr "疏散星團"
 
-#: ../src/celengine/solarsys.cpp:79
+#: ../src/celengine/solarsys.cpp:80
 #, fuzzy, c-format
 msgid "Error in .ssc file (line %d): "
 msgstr ".ssc 檔案發生錯誤 (行號:"
 
-#: ../src/celengine/solarsys.cpp:1218 ../src/celengine/solarsys.cpp:1286
+#: ../src/celengine/solarsys.cpp:1221 ../src/celengine/solarsys.cpp:1284
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1229
+#: ../src/celengine/solarsys.cpp:1232
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "雙重定義警告-"
 
-#: ../src/celengine/solarsys.cpp:1265
+#: ../src/celengine/solarsys.cpp:1263
 msgid "bad alternate surface"
 msgstr "錯誤的替代表面"
 
-#: ../src/celengine/solarsys.cpp:1280
+#: ../src/celengine/solarsys.cpp:1278
 msgid "bad location"
 msgstr "錯誤的位置"
 
-#: ../src/celengine/stardb.cpp:558
+#: ../src/celengine/stardb.cpp:568
 msgid "Bad header for cross index\n"
 msgstr "錯誤的跨索引標頭\n"
 
-#: ../src/celengine/stardb.cpp:572
+#: ../src/celengine/stardb.cpp:582
 msgid "Bad version for cross index\n"
 msgstr "錯誤的跨索引版本\n"
 
-#: ../src/celengine/stardb.cpp:592
+#: ../src/celengine/stardb.cpp:602
 #, fuzzy, c-format
 msgid "Loading cross index failed at record %u\n"
 msgstr "載入跨索引失敗，於紀錄 "
 
-#: ../src/celengine/stardb.cpp:676
+#: ../src/celengine/stardb.cpp:686
 #, fuzzy, c-format
 msgid "Bad spectral type in star database, star #%u\n"
 msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
 
-#: ../src/celengine/stardb.cpp:691
+#: ../src/celengine/stardb.cpp:701
 #, fuzzy, c-format
 msgid "%d stars in binary database\n"
 msgstr " 個恆星在雙星資料庫裡\n"
 
-#: ../src/celengine/stardb.cpp:715
+#: ../src/celengine/stardb.cpp:725
 #, fuzzy, c-format
 msgid "Total star count: %d\n"
 msgstr "全部恆星數: "
 
-#: ../src/celengine/stardb.cpp:749
+#: ../src/celengine/stardb.cpp:759
 #, fuzzy, c-format
 msgid "Error in .stc file (line %i): %s\n"
 msgstr " .stc檔案內有錯誤 (行號:"
 
-#: ../src/celengine/stardb.cpp:779
+#: ../src/celengine/stardb.cpp:789
 msgid "Invalid star: bad spectral type.\n"
 msgstr "無效的恆星內容:錯誤的光譜型。\n"
 
-#: ../src/celengine/stardb.cpp:788
+#: ../src/celengine/stardb.cpp:798
 msgid "Invalid star: missing spectral type.\n"
 msgstr "無效的恆星內容:遺漏光譜型。\n"
 
-#: ../src/celengine/stardb.cpp:975
+#: ../src/celengine/stardb.cpp:985
 #, fuzzy, c-format
 msgid "Barycenter %s does not exist.\n"
 msgstr " 不存在。\n"
 
-#: ../src/celengine/stardb.cpp:1031
+#: ../src/celengine/stardb.cpp:1041
 msgid "Invalid star: missing right ascension\n"
 msgstr "無效的恆星內容:遺漏赤經\n"
 
-#: ../src/celengine/stardb.cpp:1044
+#: ../src/celengine/stardb.cpp:1054
 msgid "Invalid star: missing declination.\n"
 msgstr "無效的恆星內容:遺漏赤緯。\n"
 
-#: ../src/celengine/stardb.cpp:1057
+#: ../src/celengine/stardb.cpp:1067
 msgid "Invalid star: missing distance.\n"
 msgstr "無效的恆星內容:遺漏距離。\n"
 
-#: ../src/celengine/stardb.cpp:1089
+#: ../src/celengine/stardb.cpp:1099
 msgid "Invalid star: missing magnitude.\n"
 msgstr "無效的恆星內容:遺漏星等。\n"
 
-#: ../src/celengine/stardb.cpp:1106
+#: ../src/celengine/stardb.cpp:1116
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr "無效的恆星內容:靠近原點恆星的絕對星等(非視星等)一定要輸入\n"
 
-#: ../src/celengine/stardb.cpp:1397
+#: ../src/celengine/stardb.cpp:1411
 #, c-format
 msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:929
+#: ../src/celengine/texture.cpp:1019
 #, fuzzy, c-format
 msgid "Creating tiled texture. Width=%i, max=%i\n"
 msgstr "產生平舖紋理。寬度="
 
-#: ../src/celengine/texture.cpp:934
+#: ../src/celengine/texture.cpp:1024
 #, fuzzy, c-format
 msgid "Creating ordinary texture: %ix%i\n"
 msgstr "產生一般紋理:"
 
-#: ../src/celengine/vertexprog.cpp:114
-msgid "Loading NV vertex program: "
-msgstr "載入 NV 頂點程式:"
-
-#: ../src/celengine/vertexprog.cpp:119
-msgid "Error loading NV vertex program: "
-msgstr "載入 NV 頂點程式時發生錯誤:"
-
-#: ../src/celengine/vertexprog.cpp:136 ../src/celengine/vertexprog.cpp:195
-msgid "Error in vertex program "
-msgstr "頂點程式發生錯誤 "
-
-#: ../src/celengine/vertexprog.cpp:163
-msgid "Loading ARB vertex program: "
-msgstr "載入 ARB 頂點程式:"
-
-#: ../src/celengine/vertexprog.cpp:168
-msgid "Error loading ARB vertex program: "
-msgstr "載入 ARB 頂點程式時發生錯誤:"
-
-#: ../src/celengine/vertexprog.cpp:196
-msgid ", line "
-msgstr "，行號:"
-
-#: ../src/celengine/vertexprog.cpp:208
-msgid "Initializing NV vertex programs . . .\n"
-msgstr "初始化 NV 頂點程式中...\n"
-
-#: ../src/celengine/vertexprog.cpp:240
-msgid "All NV vertex programs loaded successfully.\n"
-msgstr "所有的 NV 頂點程式均已成功載入。\n"
-
-#: ../src/celengine/vertexprog.cpp:253
-msgid "Initializing ARB vertex programs . . .\n"
-msgstr "初始化 ARB 頂點程式中...\n"
-
-#: ../src/celengine/vertexprog.cpp:313
-msgid "All ARB vertex programs loaded successfully.\n"
-msgstr "所有的 ARB 頂點程式均已成功載入。\n"
-
-#: ../src/celephem/samporbit.cpp:832
+#: ../src/celephem/samporbit.cpp:833
 #, fuzzy, c-format
 msgid "Error openning %s.\n"
 msgstr "發生錯誤於開啟 "
 
-#: ../src/celephem/samporbit.cpp:839 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
+#: ../src/celephem/samporbit.cpp:840 ../src/tools/xyzv2bin/bin2xyzv.cpp:25
 #, fuzzy, c-format
 msgid "Error reading header of %s.\n"
 msgstr "讀取PNG影像檔發生錯誤"
 
-#: ../src/celephem/samporbit.cpp:845 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
+#: ../src/celephem/samporbit.cpp:846 ../src/tools/xyzv2bin/bin2xyzv.cpp:31
 #, c-format
 msgid "Bad binary xyzv file %s.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:851 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
+#: ../src/celephem/samporbit.cpp:852 ../src/tools/xyzv2bin/bin2xyzv.cpp:37
 #, c-format
 msgid "Unsupported byte order %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celephem/samporbit.cpp:859 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
+#: ../src/celephem/samporbit.cpp:860 ../src/tools/xyzv2bin/bin2xyzv.cpp:44
 #, c-format
 msgid "Unsupported digits number %i, expected %i.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:333
+#: ../src/celestia/celestiacore.cpp:186
 msgid "Error reading favorites file."
 msgstr "讀取我的最愛檔案時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:422
-#, c-format
-msgid ""
-"%s\n"
-"Orientation: [%f, %f, %f], %.1f\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:469
-msgid "Error opening script file."
-msgstr "開啟腳本檔案時發生錯誤。"
-
-#: ../src/celestia/celestiacore.cpp:497
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "開啟腳本 '%s' 時發生錯誤"
-
-#: ../src/celestia/celestiacore.cpp:512
-msgid "Unknown error opening script"
-msgstr "開啟腳本時發生未知的錯誤"
-
-#: ../src/celestia/celestiacore.cpp:521 ../src/celestia/celestiacore.cpp:4988
-msgid "Script coroutine initialization failed"
-msgstr "腳本的子函式初始化失敗"
-
-#: ../src/celestia/celestiacore.cpp:532
+#: ../src/celestia/celestiacore.cpp:312
 msgid "Invalid filetype"
 msgstr "無效的檔案型態"
 
-#: ../src/celestia/celestiacore.cpp:874 ../src/celestia/celestiacore.cpp:1651
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:644 ../src/celestia/celestiacore.cpp:1374
+#: ../src/celestia/celestiacore.cpp:1391
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "極限星等:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1296
+#: ../src/celestia/celestiacore.cpp:1021
 msgid "Markers enabled"
 msgstr "標記已開啟"
 
-#: ../src/celestia/celestiacore.cpp:1299
+#: ../src/celestia/celestiacore.cpp:1024
 msgid "Markers disabled"
 msgstr "標記已關閉"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1309
+#: ../src/celestia/celestiacore.cpp:1034
 msgid "Goto surface"
 msgstr "前往表面"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1045
 msgid "Alt-azimuth mode enabled"
 msgstr "經緯儀模式啟動"
 
-#: ../src/celestia/celestiacore.cpp:1323
+#: ../src/celestia/celestiacore.cpp:1048
 msgid "Alt-azimuth mode disabled"
 msgstr "經緯儀模式關閉"
 
-#: ../src/celestia/celestiacore.cpp:1379
+#: ../src/celestia/celestiacore.cpp:1104
 msgid "Star style: fuzzy points"
 msgstr "恆星樣式:模糊的點"
 
-#: ../src/celestia/celestiacore.cpp:1382
+#: ../src/celestia/celestiacore.cpp:1107
 msgid "Star style: points"
 msgstr "恆星樣式:點"
 
-#: ../src/celestia/celestiacore.cpp:1385
+#: ../src/celestia/celestiacore.cpp:1110
 msgid "Star style: scaled discs"
 msgstr "恆星樣式:按比例的盤面"
 
-#: ../src/celestia/celestiacore.cpp:1398
+#: ../src/celestia/celestiacore.cpp:1123
 msgid "Comet tails enabled"
 msgstr "彗尾已開啟動"
 
-#: ../src/celestia/celestiacore.cpp:1401
+#: ../src/celestia/celestiacore.cpp:1126
 msgid "Comet tails disabled"
 msgstr "彗尾已關閉"
 
-#: ../src/celestia/celestiacore.cpp:1416
+#: ../src/celestia/celestiacore.cpp:1142
 msgid "Render path: OpenGL 2.0"
 msgstr "成像路徑:OpenGL 2.0"
 
-#: ../src/celestia/celestiacore.cpp:1434
+#: ../src/celestia/celestiacore.cpp:1161
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "經緯儀模式啟動"
 
-#: ../src/celestia/celestiacore.cpp:1439
+#: ../src/celestia/celestiacore.cpp:1166
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "經緯儀模式關閉"
 
-#: ../src/celestia/celestiacore.cpp:1448
+#: ../src/celestia/celestiacore.cpp:1175
 msgid "Auto-magnitude enabled"
 msgstr "自動調整星等已開啟"
 
-#: ../src/celestia/celestiacore.cpp:1453
+#: ../src/celestia/celestiacore.cpp:1180
 msgid "Auto-magnitude disabled"
 msgstr "自動調整星等已關閉"
 
-#: ../src/celestia/celestiacore.cpp:1475
+#: ../src/celestia/celestiacore.cpp:1202
 #: ../src/celestia/macosx/CelestiaController.m:470
-#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/res/resource_strings.cpp:93
+#: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
-#: ../src/celestia/win32/res/resource_strings.cpp:109
-#: ../src/celestia/win32/res/resource_strings.cpp:137
-#: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:190
-#: ../src/celestia/win32/res/resource_strings.cpp:204
-#: ../src/celestia/win32/res/resource_strings.cpp:210
-#: ../src/celestia/win32/res/resource_strings.cpp:214
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:116
+#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:131
+#: ../src/celestia/win32/res/resource_strings.cpp:139
+#: ../src/celestia/win32/res/resource_strings.cpp:145
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/celestia/celestiacore.cpp:1511
+#: ../src/celestia/celestiacore.cpp:1234
 msgid "Time and script are paused"
 msgstr "時間與腳本已暫停"
 
-#: ../src/celestia/celestiacore.cpp:1513
+#: ../src/celestia/celestiacore.cpp:1236
 msgid "Time is paused"
 msgstr "時間已暫停"
 
-#: ../src/celestia/celestiacore.cpp:1517
+#: ../src/celestia/celestiacore.cpp:1240
 msgid "Resume"
 msgstr "回復"
 
-#: ../src/celestia/celestiacore.cpp:1551
+#: ../src/celestia/celestiacore.cpp:1274
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "全部恆星數: "
 
-#: ../src/celestia/celestiacore.cpp:1557
+#: ../src/celestia/celestiacore.cpp:1280
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "全部恆星數: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1594
+#: ../src/celestia/celestiacore.cpp:1317
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "光旅行時間:%.4f 年 "
 
-#: ../src/celestia/celestiacore.cpp:1603
+#: ../src/celestia/celestiacore.cpp:1326
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "光旅行時間:%d 分 %.1f 秒 "
 
-#: ../src/celestia/celestiacore.cpp:1608
+#: ../src/celestia/celestiacore.cpp:1331
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "光旅行時間:%d 小時 %d 分 %.1f 秒 "
 
-#: ../src/celestia/celestiacore.cpp:1626
+#: ../src/celestia/celestiacore.cpp:1349
 msgid "Light travel delay included"
 msgstr "包括光旅行延遲"
 
-#: ../src/celestia/celestiacore.cpp:1631
+#: ../src/celestia/celestiacore.cpp:1354
 msgid "Light travel delay switched off"
 msgstr "關閉光旅行延遲"
 
-#: ../src/celestia/celestiacore.cpp:1637
+#: ../src/celestia/celestiacore.cpp:1360
 msgid "Light travel delay ignored"
 msgstr "忽略光旅行延遲"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1403
 msgid "Using normal surface textures."
 msgstr "使用一般表面紋理"
 
-#: ../src/celestia/celestiacore.cpp:1685
+#: ../src/celestia/celestiacore.cpp:1408
 msgid "Using limit of knowledge surface textures."
 msgstr "使用知識的界限表面紋理。"
 
-#: ../src/celestia/celestiacore.cpp:1752
+#: ../src/celestia/celestiacore.cpp:1475
 msgid "Follow"
 msgstr "跟隨天體"
 
-#: ../src/celestia/celestiacore.cpp:1777
+#: ../src/celestia/celestiacore.cpp:1500
 msgid "Time: Forward"
 msgstr "時間:前進"
 
-#: ../src/celestia/celestiacore.cpp:1779
+#: ../src/celestia/celestiacore.cpp:1502
 msgid "Time: Backward"
 msgstr "時間:後退"
 
-#: ../src/celestia/celestiacore.cpp:1791 ../src/celestia/celestiacore.cpp:1806
+#: ../src/celestia/celestiacore.cpp:1514 ../src/celestia/celestiacore.cpp:1529
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "時間速率"
 
-#: ../src/celestia/celestiacore.cpp:1846
+#: ../src/celestia/celestiacore.cpp:1569
 #, fuzzy
 msgid "Low res textures"
 msgstr "紋理"
 
-#: ../src/celestia/celestiacore.cpp:1849
+#: ../src/celestia/celestiacore.cpp:1572
 #, fuzzy
 msgid "Medium res textures"
 msgstr "紋理"
 
-#: ../src/celestia/celestiacore.cpp:1852
+#: ../src/celestia/celestiacore.cpp:1575
 #, fuzzy
 msgid "High res textures"
 msgstr "紋理"
 
-#: ../src/celestia/celestiacore.cpp:1899
+#: ../src/celestia/celestiacore.cpp:1622
 msgid "Sync Orbit"
 msgstr "同步軌道"
 
-#: ../src/celestia/celestiacore.cpp:1905
+#: ../src/celestia/celestiacore.cpp:1628
 msgid "Lock"
 msgstr "鎖定"
 
-#: ../src/celestia/celestiacore.cpp:1911
+#: ../src/celestia/celestiacore.cpp:1634
 msgid "Chase"
 msgstr "追逐"
 
-#: ../src/celestia/celestiacore.cpp:1924 ../src/celestia/celestiacore.cpp:1955
+#: ../src/celestia/celestiacore.cpp:1647 ../src/celestia/celestiacore.cpp:1678
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "極限星等:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1935 ../src/celestia/celestiacore.cpp:1966
+#: ../src/celestia/celestiacore.cpp:1658 ../src/celestia/celestiacore.cpp:1689
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "45 度時自動調整星等限制:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1985 ../src/celestia/celestiacore.cpp:2000
+#: ../src/celestia/celestiacore.cpp:1708 ../src/celestia/celestiacore.cpp:1723
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "環境光線等級:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:2011 ../src/celestia/celestiacore.cpp:2022
+#: ../src/celestia/celestiacore.cpp:1734 ../src/celestia/celestiacore.cpp:1745
 #, c-format
 msgid "Light gain"
 msgstr "增光"
 
-#: ../src/celestia/celestiacore.cpp:2043
+#: ../src/celestia/celestiacore.cpp:1766
 msgid "Bloom enabled"
 msgstr "彗尾已啟動"
 
-#: ../src/celestia/celestiacore.cpp:2045
+#: ../src/celestia/celestiacore.cpp:1768
 msgid "Bloom disabled"
 msgstr "彗尾已關閉"
 
-#: ../src/celestia/celestiacore.cpp:2051 ../src/celestia/celestiacore.cpp:2059
+#: ../src/celestia/celestiacore.cpp:1774 ../src/celestia/celestiacore.cpp:1782
 #, c-format
 msgid "Exposure"
 msgstr "曝光"
 
-#: ../src/celestia/celestiacore.cpp:2412
+#: ../src/celestia/celestiacore.cpp:2119
 msgid "GL error: "
 msgstr "GL 錯誤:"
 
-#: ../src/celestia/celestiacore.cpp:2511
+#: ../src/celestia/celestiacore.cpp:2208
 msgid "View too small to be split"
 msgstr "檢視過小無法分離"
 
-#: ../src/celestia/celestiacore.cpp:2514
+#: ../src/celestia/celestiacore.cpp:2228
 msgid "Added view"
 msgstr "已新增檢視"
 
-#: ../src/celestia/celestiacore.cpp:2760
+#: ../src/celestia/celestiacore.cpp:2384
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2765
+#: ../src/celestia/celestiacore.cpp:2389
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2770
+#: ../src/celestia/celestiacore.cpp:2394
 #: ../src/celestia/qt/qtselectionpopup.cpp:108
 msgid "ly"
 msgstr "光年"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2774
+#: ../src/celestia/celestiacore.cpp:2398
 #: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
-#: ../src/celestia/win32/res/resource_strings.cpp:135
 msgid "au"
 msgstr "天文單位"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2779 ../src/celestia/qt/qtinfopanel.cpp:118
-#: ../src/celestia/qt/qtinfopanel.cpp:212 ../src/celestia/qt/rc.cpp:30
-#: ../src/celestia/win32/res/resource_strings.cpp:133
+#: ../src/celestia/celestiacore.cpp:2403 ../src/celestia/qt/qtinfopanel.cpp:120
+#: ../src/celestia/qt/qtinfopanel.cpp:234 ../src/celestia/qt/rc.cpp:30
 msgid "km"
 msgstr "公里"
 
-#: ../src/celestia/celestiacore.cpp:2784 ../src/celestia/qt/qtinfopanel.cpp:122
+#: ../src/celestia/celestiacore.cpp:2409 ../src/celestia/qt/qtinfopanel.cpp:124
 #, fuzzy
 msgid "m"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2804 ../src/celestia/qt/qtinfopanel.cpp:166
-#: ../src/celestia/qt/qtinfopanel.cpp:190
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/celestiacore.cpp:2432 ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:196
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy
 msgid "days"
 msgstr " 日"
 
-#: ../src/celestia/celestiacore.cpp:2806 ../src/celestia/qt/qtinfopanel.cpp:162
+#: ../src/celestia/celestiacore.cpp:2437 ../src/celestia/qt/qtinfopanel.cpp:164
+#: ../src/celestia/qt/qtinfopanel.cpp:192
 #, fuzzy
 msgid "hours"
 msgstr " 時"
 
-#: ../src/celestia/celestiacore.cpp:2808
+#: ../src/celestia/celestiacore.cpp:2442
 #, fuzzy
 msgid "minutes"
 msgstr " 分"
 
-#: ../src/celestia/celestiacore.cpp:2810
+#: ../src/celestia/celestiacore.cpp:2447
 #, fuzzy
 msgid "seconds"
 msgstr " 秒"
 
-#: ../src/celestia/celestiacore.cpp:2812
+#: ../src/celestia/celestiacore.cpp:2450
 #, fuzzy, c-format
 msgid "Rotation period: %s %s\n"
 msgstr "自轉週期:"
 
-#: ../src/celestia/celestiacore.cpp:2821
+#: ../src/celestia/celestiacore.cpp:2456
+#, c-format
+msgid "Mass: %.6g kg\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2458
+#, c-format
+msgid "Mass: %.2f Mj\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2460
+#, c-format
+msgid "Mass: %.2f Me\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:2471
 #, fuzzy
 msgid "m/s"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2823
+#: ../src/celestia/celestiacore.cpp:2476
 #, fuzzy
 msgid "km/s"
 msgstr "km/s"
 
-#: ../src/celestia/celestiacore.cpp:2827
+#: ../src/celestia/celestiacore.cpp:2486
 #, fuzzy
 msgid "AU/s"
 msgstr "天文單位"
 
-#: ../src/celestia/celestiacore.cpp:2829
+#: ../src/celestia/celestiacore.cpp:2491
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2831
+#: ../src/celestia/celestiacore.cpp:2494
 #, fuzzy, c-format
 msgid "Speed: %s %s\n"
 msgstr ""
 "\n"
 "速度:"
 
-#: ../src/celestia/celestiacore.cpp:2895
+#: ../src/celestia/celestiacore.cpp:2558
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "視直徑:"
 
-#: ../src/celestia/celestiacore.cpp:2908
+#: ../src/celestia/celestiacore.cpp:2571
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "視星等:"
 
-#: ../src/celestia/celestiacore.cpp:2912
+#: ../src/celestia/celestiacore.cpp:2575
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "絕對星等:"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:2655
 #, c-format
 msgid "%.6f%c %.6f%c %f km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3018 ../src/celestia/celestiacore.cpp:3091
-#: ../src/celestia/celestiacore.cpp:3120 ../src/celestia/celestiacore.cpp:3201
+#: ../src/celestia/celestiacore.cpp:2681 ../src/celestia/celestiacore.cpp:2754
+#: ../src/celestia/celestiacore.cpp:2783 ../src/celestia/celestiacore.cpp:2858
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "距離:"
 
-#: ../src/celestia/celestiacore.cpp:3022
+#: ../src/celestia/celestiacore.cpp:2685
 msgid "Star system barycenter\n"
 msgstr "恆星系統質心\n"
 
-#: ../src/celestia/celestiacore.cpp:3026
+#: ../src/celestia/celestiacore.cpp:2689
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "絕對星等(視星等):%.2f(%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:3032
+#: ../src/celestia/celestiacore.cpp:2695
 #, fuzzy, c-format
 msgid "Luminosity: %sx Sun\n"
 msgstr "光度:"
 
-#: ../src/celestia/celestiacore.cpp:3038
+#: ../src/celestia/celestiacore.cpp:2701
 msgid "Neutron star"
 msgstr "中子星"
 
-#: ../src/celestia/celestiacore.cpp:3041
+#: ../src/celestia/celestiacore.cpp:2704
 msgid "Black hole"
 msgstr "黑洞"
 
-#: ../src/celestia/celestiacore.cpp:3046
+#: ../src/celestia/celestiacore.cpp:2709
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "類別:"
 
-#: ../src/celestia/celestiacore.cpp:3053
+#: ../src/celestia/celestiacore.cpp:2716
 #, fuzzy, c-format
 msgid "Surface temp: %s K\n"
 msgstr "表面溫度:"
 
-#: ../src/celestia/celestiacore.cpp:3058
+#: ../src/celestia/celestiacore.cpp:2721
 #, fuzzy, c-format
 msgid "Radius: %s Rsun  (%s km)\n"
 msgstr "半徑:"
 
-#: ../src/celestia/celestiacore.cpp:3064
+#: ../src/celestia/celestiacore.cpp:2727
 #, fuzzy, c-format
 msgid "Radius: %s km\n"
 msgstr "半徑:"
 
-#: ../src/celestia/celestiacore.cpp:3080
+#: ../src/celestia/celestiacore.cpp:2743
 msgid "Planetary companions present\n"
 msgstr "呈現行星的伴星\n"
 
-#: ../src/celestia/celestiacore.cpp:3096
+#: ../src/celestia/celestiacore.cpp:2759
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "與中心距離:"
 
-#: ../src/celestia/celestiacore.cpp:3099 ../src/celestia/celestiacore.cpp:3127
+#: ../src/celestia/celestiacore.cpp:2762 ../src/celestia/celestiacore.cpp:2790
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "半徑:"
 
-#: ../src/celestia/celestiacore.cpp:3168
+#: ../src/celestia/celestiacore.cpp:2831
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "相位角: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3180
-#, c-format
-msgid "Mass: %.2f Me\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:3186
+#: ../src/celestia/celestiacore.cpp:2845
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3192
+#: ../src/celestia/celestiacore.cpp:2849
 #, fuzzy, c-format
 msgid "Temperature: %.0f K\n"
 msgstr "溫度:"
 
-#: ../src/celestia/celestiacore.cpp:3432
+#: ../src/celestia/celestiacore.cpp:3000
 msgid "  LT"
 msgstr "  本地時間"
 
-#: ../src/celestia/celestiacore.cpp:3441
-#: ../src/celestia/qt/qttimetoolbar.cpp:38
-#: ../src/celestia/qt/qttimetoolbar.cpp:53
+#: ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/qt/qttimetoolbar.cpp:39
+#: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "即時"
 
-#: ../src/celestia/celestiacore.cpp:3443
+#: ../src/celestia/celestiacore.cpp:3011
 msgid "-Real time"
 msgstr "-即時"
 
-#: ../src/celestia/celestiacore.cpp:3447
+#: ../src/celestia/celestiacore.cpp:3015
 msgid "Time stopped"
 msgstr "時間已停止"
 
-#: ../src/celestia/celestiacore.cpp:3451
+#: ../src/celestia/celestiacore.cpp:3019
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " 增快"
 
-#: ../src/celestia/celestiacore.cpp:3455
+#: ../src/celestia/celestiacore.cpp:3023
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " 減慢"
 
-#: ../src/celestia/celestiacore.cpp:3461
+#: ../src/celestia/celestiacore.cpp:3029
 msgid " (Paused)"
 msgstr " (已暫停)"
 
-#: ../src/celestia/celestiacore.cpp:3479
+#: ../src/celestia/celestiacore.cpp:3048
+#, c-format
+msgid ""
+"FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
+"%zu : %zu ]\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3057
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "每秒影格速率:"
 
-#: ../src/celestia/celestiacore.cpp:3504
+#: ../src/celestia/celestiacore.cpp:3082
 #, fuzzy, c-format
 msgid "Travelling (%s)\n"
 msgstr "旅行中 "
 
-#: ../src/celestia/celestiacore.cpp:3507
+#: ../src/celestia/celestiacore.cpp:3085
 #, fuzzy, c-format
 msgid "Travelling\n"
 msgstr "旅行中 "
 
-#: ../src/celestia/celestiacore.cpp:3516
+#: ../src/celestia/celestiacore.cpp:3094
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "追蹤 "
 
-#: ../src/celestia/celestiacore.cpp:3532
+#: ../src/celestia/celestiacore.cpp:3110
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "跟隨 "
 
-#: ../src/celestia/celestiacore.cpp:3536
+#: ../src/celestia/celestiacore.cpp:3114
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "同步軌道"
 
-#: ../src/celestia/celestiacore.cpp:3540
+#: ../src/celestia/celestiacore.cpp:3118
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3546
+#: ../src/celestia/celestiacore.cpp:3124
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "追逐"
 
-#: ../src/celestia/celestiacore.cpp:3560
+#: ../src/celestia/celestiacore.cpp:3138
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3588 ../src/celestia/celestiacore.cpp:3591
+#: ../src/celestia/celestiacore.cpp:3166 ../src/celestia/celestiacore.cpp:3169
 msgid "Sun"
 msgstr "太陽"
 
-#: ../src/celestia/celestiacore.cpp:3766
-msgid "Target name: "
+#: ../src/celestia/celestiacore.cpp:3342
+#, fuzzy, c-format
+msgid "Target name: %s"
 msgstr "目標名稱:"
 
-#: ../src/celestia/celestiacore.cpp:3849
+#: ../src/celestia/celestiacore.cpp:3429
 #, c-format
 msgid "%dx%d at %f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Paused"
 msgstr " 已暫停"
 
-#: ../src/celestia/celestiacore.cpp:3852
+#: ../src/celestia/celestiacore.cpp:3432
 #, fuzzy
 msgid "Recording"
 msgstr "  錄影中"
 
-#: ../src/celestia/celestiacore.cpp:3875
+#: ../src/celestia/celestiacore.cpp:3453
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 開始/暫停   F12 停止"
 
-#: ../src/celestia/celestiacore.cpp:3885 ../src/celestia/celestiacore.cpp:3888
+#: ../src/celestia/celestiacore.cpp:3464 ../src/celestia/celestiacore.cpp:3467
 msgid "Edit Mode"
 msgstr "編輯模式"
 
-#: ../src/celestia/celestiacore.cpp:3954
+#: ../src/celestia/celestiacore.cpp:3490
 #, fuzzy, c-format
 msgid "Loading solar system catalog: %s\n"
 msgstr "載入太陽系目錄:"
 
-#: ../src/celestia/celestiacore.cpp:3995
+#: ../src/celestia/celestiacore.cpp:3528
 #, fuzzy, c-format
 msgid "Loading %s catalog: %s\n"
 msgstr "載入太陽系目錄:"
 
-#: ../src/celestia/celestiacore.cpp:4037
+#: ../src/celestia/celestiacore.cpp:3564
 msgid "Error reading configuration file."
 msgstr "讀取設定檔時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:4048
+#: ../src/celestia/celestiacore.cpp:3575
 msgid "Initialization of SPICE library failed."
 msgstr "初始化 SPICE 函式庫時失敗。"
 
-#: ../src/celestia/celestiacore.cpp:4094
+#: ../src/celestia/celestiacore.cpp:3618
 msgid "Cannot read star database."
 msgstr "無法讀取星體資料庫。"
 
-#: ../src/celestia/celestiacore.cpp:4115
+#: ../src/celestia/celestiacore.cpp:3639
 #, fuzzy, c-format
 msgid "Error opening deepsky catalog file %s.\n"
 msgstr "開啟深空目錄時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:4119
+#: ../src/celestia/celestiacore.cpp:3643
 #, fuzzy, c-format
 msgid "Cannot read Deep Sky Objects database %s.\n"
 msgstr "無法讀取星體資料庫。"
 
-#: ../src/celestia/celestiacore.cpp:4160
+#: ../src/celestia/celestiacore.cpp:3686
 #, fuzzy, c-format
 msgid "Error opening solar system catalog %s.\n"
 msgstr "開啟太陽系目錄時發生錯誤。\n"
 
-#: ../src/celestia/celestiacore.cpp:4192
+#: ../src/celestia/celestiacore.cpp:3722
 #, fuzzy, c-format
 msgid "Error opening asterisms file %s.\n"
 msgstr "開啟星群檔時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:4208
+#: ../src/celestia/celestiacore.cpp:3738
 #, fuzzy, c-format
 msgid "Error opening constellation boundaries file %s.\n"
 msgstr "開啟星座邊界檔時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:4282
+#: ../src/celestia/celestiacore.cpp:3827
 msgid "Failed to initialize renderer"
 msgstr "初始化成像器失敗。"
 
-#: ../src/celestia/celestiacore.cpp:4298
+#: ../src/celestia/celestiacore.cpp:3843
 msgid "Error loading font; text will not be visible.\n"
 msgstr "載入字型時發生錯誤；將無法看到文字。\n"
 
-#: ../src/celestia/celestiacore.cpp:4352
+#: ../src/celestia/celestiacore.cpp:3891
 #, fuzzy, c-format
 msgid "Error reading cross index %s\n"
 msgstr "讀取跨索引時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:4354
+#: ../src/celestia/celestiacore.cpp:3893
 #, fuzzy, c-format
 msgid "Loaded cross index %s\n"
 msgstr "已載入跨索引"
 
-#: ../src/celestia/celestiacore.cpp:4368 ../src/celestia/celestiacore.cpp:4390
+#: ../src/celestia/celestiacore.cpp:3910
+msgid "Error reading star names file\n"
+msgstr "讀取星體名稱檔時發生錯誤\n"
+
+#: ../src/celestia/celestiacore.cpp:3914 ../src/celestia/celestiacore.cpp:3928
 #, fuzzy, c-format
 msgid "Error opening %s\n"
 msgstr "發生錯誤於開啟 "
 
-#: ../src/celestia/celestiacore.cpp:4375
-msgid "Error reading star names file\n"
-msgstr "讀取星體名稱檔時發生錯誤\n"
-
-#: ../src/celestia/celestiacore.cpp:4398
+#: ../src/celestia/celestiacore.cpp:3936
 msgid "Error reading stars file\n"
 msgstr "讀取星體檔時發生錯誤\n"
 
-#: ../src/celestia/celestiacore.cpp:4426
+#: ../src/celestia/celestiacore.cpp:3962
 #, fuzzy, c-format
 msgid "Error opening star catalog %s\n"
 msgstr "開啟星體目錄時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:4957
+#: ../src/celestia/celestiacore.cpp:4283
+msgid "Invalid URL"
+msgstr ""
+
+#: ../src/celestia/glut/glutmain.cpp:521
+msgid "Celestia was unable to initialize OpenGL 2.1.\n"
+msgstr ""
+
+#: ../src/celestia/gtk/actions.cpp:1023 ../src/celestia/win32/winmain.cpp:2621
+msgid "Please use a name ending in '.jpg' or '.png'."
+msgstr ""
+
+#: ../src/celestia/helper.cpp:105 ../src/celestia/helper.cpp:114
 #, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "開啟腳本 '%s' 時發生錯誤"
+msgid "%s Version: %s\n"
+msgstr "版本:"
 
-#: ../src/celestia/celestiacore.cpp:4976
-#, fuzzy
-msgid "Unknown error loading hook script"
-msgstr "開啟腳本時發生未知的錯誤"
+#: ../src/celestia/helper.cpp:108
+#, fuzzy, c-format
+msgid "Vendor: %s\n"
+msgstr "製造商:"
 
-#: ../src/celestia/celx.cpp:1066
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?\n"
-"\n"
-"y = yes, ESC = cancel script, any other key = no"
-msgstr ""
+#: ../src/celestia/helper.cpp:111
+#, fuzzy, c-format
+msgid "Renderer: %s\n"
+msgstr "成像器:"
 
-#: ../src/celestia/celx.cpp:1077
-msgid ""
-"WARNING:\n"
-"\n"
-"This script requests permission to read/write files\n"
-"and execute external programs. Allowing this can be\n"
-"dangerous.\n"
-"Do you trust the script and want to allow this?"
-msgstr ""
+#: ../src/celestia/helper.cpp:117
+#, fuzzy, c-format
+msgid "Max simultaneous textures: %s\n"
+msgstr "最大同時紋理:"
 
-#: ../src/celestia/glutmain.cpp:520
+#: ../src/celestia/helper.cpp:120
+#, fuzzy, c-format
+msgid "Max texture size: %s\n"
+msgstr "最大紋理尺寸:"
+
+#: ../src/celestia/helper.cpp:123
+#, fuzzy, c-format
+msgid "Point size range: %s - %s\n"
+msgstr "點尺寸範圍:"
+
+#: ../src/celestia/helper.cpp:126
+#, fuzzy, c-format
+msgid "Point size granularity: %s\n"
+msgstr "點尺寸範圍:"
+
+#: ../src/celestia/helper.cpp:129
+#, fuzzy, c-format
+msgid "Max cube map size: %s\n"
+msgstr "最大立方體地圖尺寸:"
+
+#: ../src/celestia/helper.cpp:132
 #, c-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-"quality will be reduced."
+msgid "Number of interpolators: %s\n"
+msgstr ""
+
+#: ../src/celestia/helper.cpp:135
+#, c-format
+msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
 #. if (glGetError())
@@ -2364,14 +2565,14 @@ msgstr ""
 msgid "Please enter the date as \"mm/dd/yyyy\" and the time as \"hh:mm:ss\"."
 msgstr ""
 
-#: ../src/celestia/oggtheoracapture.cpp:162
+#: ../src/celestia/oggtheoracapture.cpp:161
 #, c-format
 msgid "Error in creating ogg file %s for capture.\n"
 msgstr "錄製影像, 在建立 ogg 檔 %s 時發生錯誤。\n"
 
 #. can't get here
-#: ../src/celestia/oggtheoracapture.cpp:256
-#: ../src/celestia/oggtheoracapture.cpp:276
+#: ../src/celestia/oggtheoracapture.cpp:255
+#: ../src/celestia/oggtheoracapture.cpp:275
 #, fuzzy
 msgid "Internal Ogg library error.\n"
 msgstr "內部 Ogg 函式庫發生錯誤。"
@@ -2390,46 +2591,37 @@ msgstr ""
 msgid "OggTheoraCapture::cleanup() - wrote %d frames\n"
 msgstr "OggTheoraCapture::cleanup() - 已寫入 %d 張影像\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:162
+#: ../src/celestia/qt/qtappwin.cpp:157
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:168
+#: ../src/celestia/qt/qtappwin.cpp:163
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:212
+#: ../src/celestia/qt/qtappwin.cpp:214
 msgid ""
-"Celestia is unable to run because the data directroy was not found, probably "
+"Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:249
-msgid ""
-"Celestia is unable to run because the CelestiaResources folder was not "
-"found, probably due to improper installation."
+#: ../src/celestia/qt/qtappwin.cpp:263
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:291
-#, qt-format
-msgid ""
-"Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-"quality will be reduced."
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:309
+#: ../src/celestia/qt/qtappwin.cpp:281
 msgid "Celestial Browser"
 msgstr "天球瀏覽"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:315
+#: ../src/celestia/qt/qtappwin.cpp:287
 #, fuzzy
 msgid "Info Browser"
 msgstr "天球瀏覽"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:344
-#: ../src/celestia/win32/res/resource_strings.cpp:114
+#: ../src/celestia/qt/qtappwin.cpp:316
+#: ../src/celestia/win32/res/resource_strings.cpp:156
 msgid "Solar System"
 msgstr "太陽系"
 
@@ -2439,21 +2631,20 @@ msgstr "太陽系"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:345
-#: ../src/celestia/qt/qtcelestiaactions.cpp:82
-#: ../src/celestia/qt/qtcelestiaactions.cpp:109 ../src/celestia/qt/rc.cpp:72
+#: ../src/celestia/qt/qtappwin.cpp:317
+#: ../src/celestia/qt/qtcelestiaactions.cpp:83
+#: ../src/celestia/qt/qtcelestiaactions.cpp:110 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:153 ../src/celestia/qt/rc.cpp:219
-#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Stars"
 msgstr "星體"
 
-#: ../src/celestia/qt/qtappwin.cpp:346
+#: ../src/celestia/qt/qtappwin.cpp:318
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "深太空天體"
 
-#: ../src/celestia/qt/qtappwin.cpp:353 ../src/celestia/qt/qteventfinder.cpp:662
-#: ../src/celestia/qt/qteventfinder.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:325 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
 msgstr "食相尋找器"
@@ -2462,463 +2653,514 @@ msgstr "食相尋找器"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:362 ../src/celestia/qt/rc.cpp:348
+#: ../src/celestia/qt/qtappwin.cpp:334 ../src/celestia/qt/rc.cpp:348
 msgid "Time"
 msgstr "時間"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:369 ../src/celestia/qt/rc.cpp:138
+#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/rc.cpp:138
 #, fuzzy
 msgid "Guides"
 msgstr "遊歷指導"
 
-#: ../src/celestia/qt/qtappwin.cpp:419
+#: ../src/celestia/qt/qtappwin.cpp:391
 #, fuzzy
 msgid "Full screen"
 msgstr "全螢幕"
 
-#: ../src/celestia/qt/qtappwin.cpp:421
+#: ../src/celestia/qt/qtappwin.cpp:393
 #, fuzzy
 msgid "Shift+F11"
 msgstr "抓取影片(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:612
+#: ../src/celestia/qt/qtappwin.cpp:549
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "開啟星群檔時發生錯誤。"
 
-#: ../src/celestia/qt/qtappwin.cpp:631
+#: ../src/celestia/qt/qtappwin.cpp:568
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "新增書籤(&A)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:610
 #, fuzzy
 msgid "Save Image"
 msgstr "另存新檔"
 
-#: ../src/celestia/qt/qtappwin.cpp:675
+#: ../src/celestia/qt/qtappwin.cpp:612
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " 並不是一個PNG檔案。\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:723 ../src/celestia/qt/qtappwin.cpp:728
+#: ../src/celestia/qt/qtappwin.cpp:660 ../src/celestia/qt/qtappwin.cpp:665
 msgid "Capture Video"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:725
+#: ../src/celestia/qt/qtappwin.cpp:662
 #, fuzzy
 msgid "Video (*.avi)"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:730
+#: ../src/celestia/qt/qtappwin.cpp:667
 #, fuzzy
 msgid "Video (*.ogv)"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:740
+#: ../src/celestia/qt/qtappwin.cpp:677
 #, fuzzy
 msgid "Resolution:"
 msgstr "解析度: "
 
-#: ../src/celestia/qt/qtappwin.cpp:744
+#: ../src/celestia/qt/qtappwin.cpp:681
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:748
-#: ../src/celestia/win32/res/resource_strings.cpp:143
+#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/win32/res/resource_strings.cpp:136
 msgid "Frame rate:"
 msgstr "影像速率:"
 
-#: ../src/celestia/qt/qtappwin.cpp:795
+#: ../src/celestia/qt/qtappwin.cpp:732
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:806 ../src/celestia/win32/winmain.cpp:3896
+#: ../src/celestia/qt/qtappwin.cpp:743 ../src/celestia/win32/winmain.cpp:3740
 msgid "Copied URL"
 msgstr "已複製網址"
 
-#: ../src/celestia/qt/qtappwin.cpp:816
+#: ../src/celestia/qt/qtappwin.cpp:753
 #, fuzzy
 msgid "Pasting URL"
 msgstr "載入網址中"
 
-#: ../src/celestia/qt/qtappwin.cpp:940
+#: ../src/celestia/qt/qtappwin.cpp:877
 #, fuzzy
 msgid "Open Script"
 msgstr "開啟腳本(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:942
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1012
+#: ../src/celestia/qt/qtappwin.cpp:949
 #, fuzzy
 msgid "New bookmark"
 msgstr "在本選單中建立新的書籤資料夾"
 
-#: ../src/celestia/qt/qtappwin.cpp:1068
+#: ../src/celestia/qt/qtappwin.cpp:1004
 #, qt-format
 msgid ""
-"<html><p><b>Celestia 1.7.0 (Qt5 beta version, git commit %1)</b></"
-"p><p>Copyright (C) 2001-2018 by the Celestia Development Team. Celestia is "
-"free software. You can redistribute it and/or modify it under the terms of "
-"the GNU General Public License version&nbsp;2.</p><b>Celestia on the web</"
-"b><br>Main site: <a href=\"https://celestia.space/\">https://celestia.space/"
-"</a><br>Forum: <a href=\"https://celestia.space/forum/\">https://celestia."
-"space/forum/</a><br>GitHub project: <a href=\"https://github.com/"
-"CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
-"a><br></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kerners are %7<br>Runtime Qt version: %6</p><p>Copyright (C) "
+"2001-2020 by the Celestia Development Team.<br>Celestia is free software. "
+"You can redistribute it and/or modify it under the terms of the GNU General "
+"Public License as published by the Free Software Foundation; either version "
+"2 of the License, or (at your option) any later version.</p><p>Main site: <a "
+"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
+"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 msgstr ""
 
-#. Get the version string
-#. QTextStream::operator<<(const char *string) assumes that the string has
-#. ISO-8859-1 encoding, so we need to convert in to QString
-#: ../src/celestia/qt/qtappwin.cpp:1097
+#: ../src/celestia/qt/qtappwin.cpp:1039
 #, fuzzy
-msgid "<b>OpenGL version: </b>"
+msgid "Unknown compiler"
+msgstr "開啟腳本時發生未知的錯誤"
+
+#: ../src/celestia/qt/qtappwin.cpp:1043
+#, fuzzy
+msgid "supported"
+msgstr "支援的延伸功能:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1045
+#, fuzzy
+msgid "not supported"
+msgstr "支援的延伸功能:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1048 ../src/celestia/qt/qtappwin.cpp:1443
+#: ../src/celestia/win32/res/resource_strings.cpp:70
+msgid "About Celestia"
+msgstr "關於 Celestia"
+
+#: ../src/celestia/qt/qtappwin.cpp:1067
+#, fuzzy, qt-format
+msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading 語言</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1105
-#, fuzzy
-msgid "<b>Renderer: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1073
+#, fuzzy, qt-format
+msgid "<b>Vendor</b>: %1"
+msgstr "製造商:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1079
+#, fuzzy, qt-format
+msgid "<b>Renderer:</b> %1"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1115
-#, fuzzy
-msgid "<b>GLSL Version: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1086
+#, fuzzy, qt-format
+msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL 版本:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1121
-#, fuzzy
-msgid "<b>Maximum texture size: </b>"
+#: ../src/celestia/qt/qtappwin.cpp:1093
+#, fuzzy, qt-format
+msgid "<b>Max simultaneous textures:</b> %1"
+msgstr "最大同時紋理:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1099
+#, fuzzy, qt-format
+msgid "<b>Maximum texture size:</b> %1"
 msgstr "最大紋理尺寸:"
 
-#. Show all supported extensions
-#: ../src/celestia/qt/qtappwin.cpp:1126
+#: ../src/celestia/qt/qtappwin.cpp:1105
+#, fuzzy, qt-format
+msgid "<b>Point size range</b>: %1 - %2"
+msgstr "點尺寸範圍:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1111
+#, fuzzy, qt-format
+msgid "<b>Point size granularity</b>: %1"
+msgstr "點尺寸範圍:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1117
+#, fuzzy, qt-format
+msgid "<b>Max cube map size</b>: %1"
+msgstr "最大立方體地圖尺寸:"
+
+#: ../src/celestia/qt/qtappwin.cpp:1123
+#, fuzzy, qt-format
+msgid "<b>Number of interpolators</b>: %1"
+msgstr "赤道"
+
+#: ../src/celestia/qt/qtappwin.cpp:1129
+#, qt-format
+msgid "<b>Max anisotropy filtering</b>: %1"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1139
 #, fuzzy
-msgid "<b>Extensions:</b><br>\n"
+msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1471
+#: ../src/celestia/qt/qtappwin.cpp:1153
 #, fuzzy
-msgid "OpenGL Info"
-msgstr "OpenGL 資訊"
+msgid "Renderer Info"
+msgstr "成像器:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1166
+#: ../src/celestia/qt/qtappwin.cpp:1180
 #, fuzzy
 msgid "&Grab image"
 msgstr "抓取圖像"
 
-#: ../src/celestia/qt/qtappwin.cpp:1167
+#: ../src/celestia/qt/qtappwin.cpp:1181
 #, fuzzy
 msgid "F10"
 msgstr "抓取圖像(&I)...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1172
+#: ../src/celestia/qt/qtappwin.cpp:1186
 #, fuzzy
 msgid "Capture &video"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1191
 #, fuzzy
 msgid "Shift+F10"
 msgstr "抓取影片(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1181
+#: ../src/celestia/qt/qtappwin.cpp:1195
 #, fuzzy
 msgid "&Copy image"
 msgstr "複製網址"
 
-#: ../src/celestia/qt/qtappwin.cpp:1182
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1186
-#, fuzzy
-msgid "Copy &URL"
-msgstr "複製網址"
-
-#: ../src/celestia/qt/qtappwin.cpp:1191
-#, fuzzy
-msgid "&Paste URL"
-msgstr "已複製網址"
-
-#: ../src/celestia/qt/qtappwin.cpp:1198
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "開啟腳本(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1209
+#: ../src/celestia/qt/qtappwin.cpp:1213
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia 偏好設定"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1217
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "離開(&X)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1214
+#: ../src/celestia/qt/qtappwin.cpp:1218
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "反鋸齒\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1219
+#: ../src/celestia/qt/qtappwin.cpp:1223
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "導覽(&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1221
+#: ../src/celestia/qt/qtappwin.cpp:1225
 #, fuzzy
 msgid "Select Sun"
 msgstr "選取(&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1225
+#: ../src/celestia/qt/qtappwin.cpp:1229
 #, fuzzy
 msgid "Center Selection"
 msgstr "選取星體置中(&C)\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1229
+#: ../src/celestia/qt/qtappwin.cpp:1233
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "選擇區:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1233
+#: ../src/celestia/qt/qtappwin.cpp:1237
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "前往星體..."
 
+#: ../src/celestia/qt/qtappwin.cpp:1241
+msgid "Copy URL / console text"
+msgstr ""
+
+#: ../src/celestia/qt/qtappwin.cpp:1246
+msgid "Paste URL / console text"
+msgstr ""
+
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1238
+#: ../src/celestia/qt/qtappwin.cpp:1252
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "時間(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1240
+#: ../src/celestia/qt/qtappwin.cpp:1254
 #, fuzzy
 msgid "Set &time"
 msgstr "設定時間..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1248
+#: ../src/celestia/qt/qtappwin.cpp:1262
 #, fuzzy
 msgid "&Display"
 msgstr "顯示"
 
-#: ../src/celestia/qt/qtappwin.cpp:1254
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "已標記星體"
 
-#: ../src/celestia/qt/qtappwin.cpp:1260
+#: ../src/celestia/qt/qtappwin.cpp:1274
 #, fuzzy
 msgid "&Shadows"
 msgstr "顯示雲影"
 
-#: ../src/celestia/qt/qtappwin.cpp:1271
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "恆星樣式(&Y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "紋理解析度"
 
-#: ../src/celestia/qt/qtappwin.cpp:1283
+#: ../src/celestia/qt/qtappwin.cpp:1297
 #, fuzzy
 msgid "&FPS control"
 msgstr "控制(&C)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1314
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "書籤(&B)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1303
+#: ../src/celestia/qt/qtappwin.cpp:1317
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "檢視(&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1320
 #, fuzzy
 msgid "&MultiView"
 msgstr "多重檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1309
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Split view vertically"
 msgstr "垂直分割檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1310
+#: ../src/celestia/qt/qtappwin.cpp:1324
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "水平分離(&H)\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1315
+#: ../src/celestia/qt/qtappwin.cpp:1329
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "水平分割檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1330
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "垂直分離(&V)\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1321
+#: ../src/celestia/qt/qtappwin.cpp:1335
 #, fuzzy
 msgid "Cycle views"
 msgstr "循環檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1322
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1327
+#: ../src/celestia/qt/qtappwin.cpp:1341
 #, fuzzy
 msgid "Single view"
 msgstr "單一檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1328
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "單一檢視(&S)\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1333
+#: ../src/celestia/qt/qtappwin.cpp:1347
 #, fuzzy
 msgid "Delete view"
 msgstr "刪除檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1334
-#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/qt/qtappwin.cpp:1348
+#: ../src/celestia/win32/res/resource_strings.cpp:142
 msgid "Delete"
 msgstr "刪除"
 
-#: ../src/celestia/qt/qtappwin.cpp:1340
+#: ../src/celestia/qt/qtappwin.cpp:1354
 #, fuzzy
 msgid "Frames visible"
 msgstr "影格檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1373
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #, fuzzy
 msgid "Active frame visible"
 msgstr "作用中影格檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1389
+#: ../src/celestia/qt/qtappwin.cpp:1391
 #, fuzzy
 msgid "Synchronize time"
 msgstr "同步時間"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1464
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "說明(&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1466
+#: ../src/celestia/qt/qtappwin.cpp:1434
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia 偏好設定"
 
-#: ../src/celestia/qt/qtappwin.cpp:1475
-#: ../src/celestia/win32/res/resource_strings.cpp:70
-msgid "About Celestia"
-msgstr "關於 Celestia"
+#: ../src/celestia/qt/qtappwin.cpp:1439
+#, fuzzy
+msgid "OpenGL Info"
+msgstr "OpenGL 資訊"
 
-#: ../src/celestia/qt/qtappwin.cpp:1491
+#: ../src/celestia/qt/qtappwin.cpp:1459
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "加入書籤(&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1495
+#: ../src/celestia/qt/qtappwin.cpp:1463
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "組織書籤(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1533
+#: ../src/celestia/qt/qtappwin.cpp:1501
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1534
+#: ../src/celestia/qt/qtappwin.cpp:1502
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1554
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "載入中 "
 
-#: ../src/celestia/qt/qtappwin.cpp:1565
+#: ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "腳本"
 
-#: ../src/celestia/qt/qtbookmark.cpp:394
+#: ../src/celestia/qt/qtbookmark.cpp:395
 msgid "Title"
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:396
+#: ../src/celestia/qt/qtbookmark.cpp:397
 #, fuzzy
 msgid "Description"
 msgstr "歷時"
 
-#: ../src/celestia/qt/qtbookmark.cpp:581
+#: ../src/celestia/qt/qtbookmark.cpp:582
 #, fuzzy
 msgid "Bookmarks Menu"
 msgstr "書籤(&B)"
 
-#: ../src/celestia/qt/qtbookmark.cpp:582
+#: ../src/celestia/qt/qtbookmark.cpp:583
 msgid "Add bookmarks to this folder to see them in the bookmarks menu."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:587
+#: ../src/celestia/qt/qtbookmark.cpp:588
 #, fuzzy
 msgid "Bookmarks Toolbar"
 msgstr "主工具列"
 
-#: ../src/celestia/qt/qtbookmark.cpp:588
+#: ../src/celestia/qt/qtbookmark.cpp:589
 msgid "Add bookmarks to this folder to see them in the bookmarks toolbar."
 msgstr ""
 
-#: ../src/celestia/qt/qtbookmark.cpp:602
+#: ../src/celestia/qt/qtbookmark.cpp:603
 #, fuzzy
 msgid "Error reading bookmarks file"
 msgstr "讀取我的最愛檔案時發生錯誤。"
 
-#: ../src/celestia/qt/qtbookmark.cpp:719
+#: ../src/celestia/qt/qtbookmark.cpp:720
 msgid "Bookmarks"
 msgstr "書籤"
 
-#: ../src/celestia/qt/qtbookmark.cpp:832
+#: ../src/celestia/qt/qtbookmark.cpp:833
 #, fuzzy
 msgid "Current simulation time"
 msgstr "設定模擬時間"
 
-#: ../src/celestia/qt/qtbookmark.cpp:833
+#: ../src/celestia/qt/qtbookmark.cpp:834
 #, fuzzy
 msgid "Simulation time at activation"
 msgstr "設定模擬時間"
 
-#: ../src/celestia/qt/qtbookmark.cpp:834
+#: ../src/celestia/qt/qtbookmark.cpp:835
 #, fuzzy
 msgid "System time at activation"
 msgstr "時間"
@@ -2927,79 +3169,77 @@ msgstr "時間"
 #. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
-#: ../src/celestia/qt/qtbookmark.cpp:879 ../src/celestia/qt/rc.cpp:39
+#: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
 #: ../src/celestia/qt/rc.cpp:54
 #, fuzzy
 msgid "New Folder"
 msgstr "新資料夾..."
 
 #. Create the render flags actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:25
+#: ../src/celestia/qt/qtcelestiaactions.cpp:26
 msgid "Eq"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:26
+#: ../src/celestia/qt/qtcelestiaactions.cpp:27
 #, fuzzy
 msgid "Equatorial coordinate grid"
 msgstr "顯示赤道格線"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:30
+#: ../src/celestia/qt/qtcelestiaactions.cpp:31
 msgid "Ga"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:31
+#: ../src/celestia/qt/qtcelestiaactions.cpp:32
 #, fuzzy
 msgid "Galactic coordinate grid"
 msgstr "銀河"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:35
+#: ../src/celestia/qt/qtcelestiaactions.cpp:36
 msgid "Ec"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:36
+#: ../src/celestia/qt/qtcelestiaactions.cpp:37
 #, fuzzy
 msgid "Ecliptic coordinate grid"
 msgstr "赤道標線"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:40
+#: ../src/celestia/qt/qtcelestiaactions.cpp:41
 msgid "Hz"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:41
+#: ../src/celestia/qt/qtcelestiaactions.cpp:42
 #, fuzzy
 msgid "Horizontal coordinate grid"
 msgstr "水平分割檢視"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:45
+#: ../src/celestia/qt/qtcelestiaactions.cpp:46
 msgid "Ecl"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:461
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticLineCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:46 ../src/celestia/qt/rc.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:47 ../src/celestia/qt/rc.cpp:210
 #, fuzzy
 msgid "Ecliptic line"
 msgstr "黃道"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:50
+#: ../src/celestia/qt/qtcelestiaactions.cpp:51
 #, fuzzy
 msgid "M"
 msgstr "m/s"
 
-#. Controls for marking selected objects
 #. i18n: file: ../src/celestia/qt/preferences.ui:454
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
-#: ../src/celestia/qt/qtcelestiaactions.cpp:51
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:473
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:707
+#: ../src/celestia/qt/qtcelestiaactions.cpp:52
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
 #: ../src/celestia/qt/rc.cpp:207
-#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Markers"
 msgstr "標記"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:55
+#: ../src/celestia/qt/qtcelestiaactions.cpp:56
 #, fuzzy
 msgid "C"
 msgstr "選取星體置中(&C)\tC"
@@ -3008,57 +3248,54 @@ msgstr "選取星體置中(&C)\tC"
 #. i18n: ectx: property (title), widget (QGroupBox, constellationsGroupBox)
 #. i18n: file: ../src/celestia/qt/preferences.ui:583
 #. i18n: ectx: property (text), widget (QCheckBox, constellationLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:56
-#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:57
+#: ../src/celestia/qt/qtcelestiaactions.cpp:123 ../src/celestia/qt/rc.cpp:192
 #: ../src/celestia/qt/rc.cpp:255
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:176
 msgid "Constellations"
 msgstr "星座"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:60
+#: ../src/celestia/qt/qtcelestiaactions.cpp:61
 #, fuzzy
 msgid "B"
 msgstr "<b>NVIDIA combiners，不用頂點程式</b>"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:61
+#: ../src/celestia/qt/qtcelestiaactions.cpp:62
 #, fuzzy
 msgid "Constellation boundaries"
 msgstr "星座邊界"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:65
+#: ../src/celestia/qt/qtcelestiaactions.cpp:66
 #, fuzzy
 msgid "O"
 msgstr "確定"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:66 ../src/celestia/qt/rc.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtcelestiaactions.cpp:67 ../src/celestia/qt/rc.cpp:141
 msgid "Orbits"
 msgstr "軌道"
 
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
-#. Skip sorting if we are dealing with the planets in our own Solar System.
-#: ../src/celestia/qt/qtcelestiaactions.cpp:83
-#: ../src/celestia/qt/qtcelestiaactions.cpp:110
-#: ../src/celestia/qt/qtselectionpopup.cpp:383
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:545 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtcelestiaactions.cpp:84
+#: ../src/celestia/qt/qtcelestiaactions.cpp:111
+#: ../src/celestia/qt/qtselectionpopup.cpp:387
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:156 ../src/celestia/qt/rc.cpp:222
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/winmain.cpp:1531
-#: ../src/celestia/win32/winmain.cpp:1566
-#: ../src/celestia/win32/winmain.cpp:1683
+#: ../src/celestia/win32/winmain.cpp:1449
+#: ../src/celestia/win32/winmain.cpp:1484
+#: ../src/celestia/win32/winmain.cpp:1601
 msgid "Planets"
 msgstr "行星"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:84
-#: ../src/celestia/qt/qtcelestiaactions.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:169
+#: ../src/celestia/qt/qtcelestiaactions.cpp:85
+#: ../src/celestia/qt/qtcelestiaactions.cpp:112
 msgid "Dwarf Planets"
 msgstr "矮行星"
 
@@ -3068,19 +3305,17 @@ msgstr "矮行星"
 #. i18n: ectx: property (text), widget (QCheckBox, moonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:520
 #. i18n: ectx: property (text), widget (QCheckBox, moonLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:85
-#: ../src/celestia/qt/qtcelestiaactions.cpp:112
-#: ../src/celestia/qt/qtselectionpopup.cpp:386
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:547 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtcelestiaactions.cpp:86
+#: ../src/celestia/qt/qtcelestiaactions.cpp:113
+#: ../src/celestia/qt/qtselectionpopup.cpp:393
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:162 ../src/celestia/qt/rc.cpp:228
-#: ../src/celestia/win32/res/resource_strings.cpp:170
-#: ../src/celestia/win32/winmain.cpp:1529
+#: ../src/celestia/win32/winmain.cpp:1447
 msgid "Moons"
 msgstr "衛星"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:86
-#: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/qt/qtcelestiaactions.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:114
 msgid "Minor Moons"
 msgstr "小行星衛星 (二重小行星)"
 
@@ -3090,12 +3325,12 @@ msgstr "小行星衛星 (二重小行星)"
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:534
 #. i18n: ectx: property (text), widget (QCheckBox, asteroidLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:87
-#: ../src/celestia/qt/qtcelestiaactions.cpp:114
-#: ../src/celestia/qt/qtselectionpopup.cpp:389 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtcelestiaactions.cpp:88
+#: ../src/celestia/qt/qtcelestiaactions.cpp:115
+#: ../src/celestia/qt/qtselectionpopup.cpp:399
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:168 ../src/celestia/qt/rc.cpp:234
-#: ../src/celestia/win32/res/resource_strings.cpp:172
-#: ../src/celestia/win32/winmain.cpp:1523
+#: ../src/celestia/win32/winmain.cpp:1441
 msgid "Asteroids"
 msgstr "小行星"
 
@@ -3105,12 +3340,12 @@ msgstr "小行星"
 #. i18n: ectx: property (text), widget (QCheckBox, cometOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:541
 #. i18n: ectx: property (text), widget (QCheckBox, cometLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:88
-#: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/qt/qtselectionpopup.cpp:392 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:89
+#: ../src/celestia/qt/qtcelestiaactions.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:402
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:171 ../src/celestia/qt/rc.cpp:237
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/winmain.cpp:1525
+#: ../src/celestia/win32/winmain.cpp:1443
 msgid "Comets"
 msgstr "彗星"
 
@@ -3120,14 +3355,15 @@ msgstr "彗星"
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:89
-#: ../src/celestia/qt/qtcelestiaactions.cpp:116 ../src/celestia/qt/rc.cpp:93
+#: ../src/celestia/qt/qtcelestiaactions.cpp:90
+#: ../src/celestia/qt/qtcelestiaactions.cpp:117
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:93
 #: ../src/celestia/qt/rc.cpp:174 ../src/celestia/qt/rc.cpp:240
 msgid "Spacecrafts"
 msgstr "太空船"
 
 #. Label actions
-#: ../src/celestia/qt/qtcelestiaactions.cpp:105
+#: ../src/celestia/qt/qtcelestiaactions.cpp:106
 #, fuzzy
 msgid "L"
 msgstr "10x 快轉(&F)\tL"
@@ -3136,9 +3372,8 @@ msgstr "10x 快轉(&F)\tL"
 #. i18n: ectx: attribute (title), widget (QWidget, labelsTab)
 #. i18n: file: ../src/celestia/qt/preferences.ui:493
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:106 ../src/celestia/qt/rc.cpp:213
+#: ../src/celestia/qt/qtcelestiaactions.cpp:107 ../src/celestia/qt/rc.cpp:213
 #: ../src/celestia/qt/rc.cpp:216
-#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Labels"
 msgstr "標籤"
 
@@ -3146,20 +3381,18 @@ msgstr "標籤"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:117
-#: ../src/celestia/qt/qtcelestiaactions.cpp:141
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:438 ../src/celestia/qt/rc.cpp:96
+#: ../src/celestia/qt/qtcelestiaactions.cpp:118
+#: ../src/celestia/qt/qtcelestiaactions.cpp:142
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:96
 #: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:175
 msgid "Galaxies"
 msgstr "星系"
 
-#. Buttons to select filtering criterion for dsos
 #. galaxiesAction->setShortcut(QString("U"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:118
-#: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:434
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#. Buttons to select filtering criterion for dsos
+#: ../src/celestia/qt/qtcelestiaactions.cpp:119
+#: ../src/celestia/qt/qtcelestiaactions.cpp:144
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
 msgid "Globulars"
 msgstr "球狀星團"
 
@@ -3167,7 +3400,7 @@ msgstr "球狀星團"
 #. i18n: ectx: property (text), widget (QCheckBox, openClustersCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:569
 #. i18n: ectx: property (text), widget (QCheckBox, openClusterLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:119 ../src/celestia/qt/rc.cpp:102
+#: ../src/celestia/qt/qtcelestiaactions.cpp:120 ../src/celestia/qt/rc.cpp:102
 #: ../src/celestia/qt/rc.cpp:249
 #, fuzzy
 msgid "Open clusters"
@@ -3177,615 +3410,632 @@ msgstr "疏散星團"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaeCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:562
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:120
-#: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:442 ../src/celestia/qt/rc.cpp:99
+#: ../src/celestia/qt/qtcelestiaactions.cpp:121
+#: ../src/celestia/qt/qtcelestiaactions.cpp:146
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:99
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Nebulae"
 msgstr "星雲"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:606
 #. i18n: ectx: property (title), widget (QGroupBox, locationsGroupBox)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:121 ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/qt/qtcelestiaactions.cpp:122 ../src/celestia/qt/rc.cpp:258
+#: ../src/celestia/win32/res/resource_strings.cpp:129
 msgid "Locations"
 msgstr "位置"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:144
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:446
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/qt/qtcelestiaactions.cpp:145
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
 msgid "Open Clusters"
 msgstr "疏散星團"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:152 ../src/celestia/qt/rc.cpp:114
-#: ../src/celestia/win32/res/resource_strings.cpp:151
+#: ../src/celestia/qt/qtcelestiaactions.cpp:153 ../src/celestia/qt/rc.cpp:114
 msgid "Clouds"
 msgstr "雲層"
 
 #. cloudsAction->setShortcut(QString("I"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/qt/qtcelestiaactions.cpp:155
 msgid "Night Side Lights"
 msgstr "夜視光"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/qt/qtcelestiaactions.cpp:157
 msgid "Comet Tails"
 msgstr "彗尾"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:157 ../src/celestia/qt/rc.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:150
+#: ../src/celestia/qt/qtcelestiaactions.cpp:158 ../src/celestia/qt/rc.cpp:111
 msgid "Atmospheres"
 msgstr "大氣壓"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:164
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/qt/qtcelestiaactions.cpp:165
 msgid "Ring Shadows"
 msgstr "環狀陰影"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:165
-#: ../src/celestia/win32/res/resource_strings.cpp:154
+#: ../src/celestia/qt/qtcelestiaactions.cpp:166
 msgid "Eclipse Shadows"
 msgstr "日月食陰影"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/qt/qtcelestiaactions.cpp:168
 msgid "Cloud Shadows"
 msgstr "雲層陰影"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:815
 #. i18n: ectx: property (text), widget (QRadioButton, lowResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:172 ../src/celestia/qt/rc.cpp:309
+#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:309
 msgid "Low"
 msgstr "低"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:822
 #. i18n: ectx: property (text), widget (QRadioButton, mediumResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:173 ../src/celestia/qt/rc.cpp:312
+#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:312
 msgid "Medium"
 msgstr "中"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:829
 #. i18n: ectx: property (text), widget (QRadioButton, highResolutionButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:174 ../src/celestia/qt/rc.cpp:315
+#: ../src/celestia/qt/qtcelestiaactions.cpp:175 ../src/celestia/qt/rc.cpp:315
 msgid "High"
 msgstr "高"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:184
+#: ../src/celestia/qt/qtcelestiaactions.cpp:185
 #, fuzzy
 msgid "Auto Magnitude"
 msgstr "自動調整星等\tCtrl+Y"
 
-#. toggleVSyncAction->setShortcut(QKeySequence("Ctrl+Y"));
-#: ../src/celestia/qt/qtcelestiaactions.cpp:186
-#: ../src/celestia/qt/qtcelestiaactions.cpp:217
+#: ../src/celestia/qt/qtcelestiaactions.cpp:187
 msgid "Faintest visible magnitude based on field of view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:189
+#: ../src/celestia/qt/qtcelestiaactions.cpp:190
 #, fuzzy
 msgid "More Stars Visible"
 msgstr "讓更多星體可見\t]"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:192
+#: ../src/celestia/qt/qtcelestiaactions.cpp:193
 #, fuzzy
 msgid "Fewer Stars Visible"
 msgstr "讓較少星體可見\t]"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:946
 #. i18n: ectx: property (text), widget (QRadioButton, pointStarsButton)
-#: ../src/celestia/qt/qtcelestiaactions.cpp:198 ../src/celestia/qt/rc.cpp:333
+#: ../src/celestia/qt/qtcelestiaactions.cpp:199 ../src/celestia/qt/rc.cpp:333
 #, fuzzy
 msgid "Points"
 msgstr "點(&P)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:199
+#: ../src/celestia/qt/qtcelestiaactions.cpp:200
 #, fuzzy
 msgid "Fuzzy Points"
 msgstr "模糊點(&U)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:200
+#: ../src/celestia/qt/qtcelestiaactions.cpp:201
 #, fuzzy
 msgid "Scaled Discs"
 msgstr "按比例的盤面(&D)"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:210
+#: ../src/celestia/qt/qtcelestiaactions.cpp:211
 #, fuzzy
 msgid "Light Time Delay"
 msgstr "關閉光旅行延遲"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:215
-#, fuzzy
-msgid "Enable Vsync"
-msgstr "經緯儀模式啟動"
-
-#: ../src/celestia/qt/qtcelestiaactions.cpp:389
+#: ../src/celestia/qt/qtcelestiaactions.cpp:393
 #, fuzzy, qt-format
 msgid "Auto magnitude limit at 45 degrees: %L1"
 msgstr "45 度時自動調整星等限制:%.2f"
 
-#: ../src/celestia/qt/qtcelestiaactions.cpp:396
+#: ../src/celestia/qt/qtcelestiaactions.cpp:400
 #, fuzzy, qt-format
 msgid "Magnitude limit: %L1"
 msgstr "極限星等:%.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:218
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:189
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:618
-#: ../src/celestia/win32/res/resource_strings.cpp:107
-#: ../src/celestia/win32/winstarbrowser.cpp:61
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/win32/res/resource_strings.cpp:91
+#: ../src/celestia/win32/winstarbrowser.cpp:60
 msgid "Name"
 msgstr "名稱"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:220
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:191
-#: ../src/celestia/win32/winstarbrowser.cpp:63
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Distance (ly)"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
-#: ../src/celestia/win32/winstarbrowser.cpp:66
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "App. mag"
 msgstr "視星等"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
-#: ../src/celestia/win32/winstarbrowser.cpp:69
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "Abs. mag"
 msgstr "絕對星等"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:459
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:620
-#: ../src/celestia/win32/winstarbrowser.cpp:72
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Type"
 msgstr "類型"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
 #, fuzzy
 msgid "Closest Stars"
 msgstr "顯示恆星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:516
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "星體"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:526
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:456
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
 #, fuzzy
 msgid "Filter"
 msgstr "過濾恆星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:529
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
 msgid "With Planets"
 msgstr "包含行星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:533
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "顯示恆星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:536
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
 #, fuzzy
 msgid "Barycenters"
 msgstr "質心"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
 #, fuzzy
 msgid "Spectral Type"
 msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:551
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:697
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
 msgid "Refresh"
 msgstr "重新整理"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:559
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:710
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
 #, fuzzy
 msgid "Mark Selected"
 msgstr "標示(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "列表中顯示的最多恆星數"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:715
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "標示(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:716
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:720
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
 #, fuzzy
 msgid "Clear Markers"
 msgstr "標記"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:488
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:722
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:493
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:727
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:794
 msgid "None"
 msgstr "無"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtselectionpopup.cpp:239
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:728
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
+#: ../src/celestia/qt/qtselectionpopup.cpp:243
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:795
 msgid "Diamond"
 msgstr "鑽石"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:578
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
-#: ../src/celestia/qt/qtselectionpopup.cpp:240
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:729
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
 msgid "Triangle"
 msgstr "三角形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:579
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtselectionpopup.cpp:241
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:730
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
 msgid "Square"
 msgstr "方形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:580
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
-#: ../src/celestia/qt/qtselectionpopup.cpp:243
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:731
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtselectionpopup.cpp:247
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Plus"
 msgstr "加號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:581
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:498
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:732
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:582
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:499
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:733
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Circle"
 msgstr "圓形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:500
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:734
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Left Arrow"
 msgstr "左箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:501
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:735
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "Right Arrow"
 msgstr "右箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:502
-#: ../src/celestia/qt/qtselectionpopup.cpp:247
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:736
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Up Arrow"
 msgstr "上箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:737
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Down Arrow"
 msgstr "下箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "選取星體(&O)..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:601
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:518
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:752
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:606
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:526
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:819
 #, fuzzy
 msgid "Select marker size"
 msgstr "大小:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:605
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:522
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:756
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:610
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:530
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:823
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "選取星體(&O)..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:525
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Label"
 msgstr "標記特徵"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:672
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:577
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:677
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:585
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "天體"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "標示(&M)"
 
-#: ../src/celestia/qt/qteventfinder.cpp:473
+#: ../src/celestia/qt/qteventfinder.cpp:142
 #, fuzzy
 msgid "Eclipsed body"
 msgstr "母體 '"
 
-#: ../src/celestia/qt/qteventfinder.cpp:475
+#: ../src/celestia/qt/qteventfinder.cpp:144
 msgid "Occulter"
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:477
+#: ../src/celestia/qt/qteventfinder.cpp:146
 #, fuzzy
 msgid "Start time"
 msgstr "以全螢幕模式啟動"
 
-#: ../src/celestia/qt/qteventfinder.cpp:479
-#: ../src/celestia/win32/wineclipses.cpp:67
+#: ../src/celestia/qt/qteventfinder.cpp:148
+#: ../src/celestia/win32/wineclipses.cpp:61
 msgid "Duration"
 msgstr "歷時"
 
-#: ../src/celestia/qt/qteventfinder.cpp:566
+#: ../src/celestia/qt/qteventfinder.cpp:239
 #, fuzzy
 msgid "Solar eclipses"
 msgstr "日食"
 
-#: ../src/celestia/qt/qteventfinder.cpp:567
+#: ../src/celestia/qt/qteventfinder.cpp:240
 #, fuzzy
 msgid "Lunar eclipses"
 msgstr "月食"
 
-#: ../src/celestia/qt/qteventfinder.cpp:568
+#: ../src/celestia/qt/qteventfinder.cpp:241
 #, fuzzy
 msgid "All eclipses"
 msgstr "全部取消標記(&A)"
 
 #. Search the search range box
-#: ../src/celestia/qt/qteventfinder.cpp:576
+#: ../src/celestia/qt/qteventfinder.cpp:249
 #, fuzzy
 msgid "Search range"
 msgstr "點尺寸範圍:"
 
-#: ../src/celestia/qt/qteventfinder.cpp:606
+#: ../src/celestia/qt/qteventfinder.cpp:279
 #, fuzzy
 msgid "Find eclipses"
 msgstr "月食"
 
-#: ../src/celestia/qt/qteventfinder.cpp:663
+#: ../src/celestia/qt/qteventfinder.cpp:334
 #, fuzzy, qt-format
 msgid "%1 is not a valid object"
 msgstr "選取星體(&O)..."
 
-#: ../src/celestia/qt/qteventfinder.cpp:674
+#: ../src/celestia/qt/qteventfinder.cpp:346
 msgid "End date is earlier than start date."
 msgstr ""
 
-#: ../src/celestia/qt/qteventfinder.cpp:688
+#: ../src/celestia/qt/qteventfinder.cpp:360
 #, fuzzy
 msgid "Finding eclipses..."
 msgstr "日食"
 
-#: ../src/celestia/qt/qteventfinder.cpp:720
+#: ../src/celestia/qt/qteventfinder.cpp:392
 #, fuzzy
 msgid "Set time to mid-eclipse"
 msgstr "設定為現在"
 
-#: ../src/celestia/qt/qteventfinder.cpp:724
+#: ../src/celestia/qt/qteventfinder.cpp:396
 #, fuzzy, qt-format
 msgid "Near %1"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qteventfinder.cpp:728
-#: ../src/celestia/qt/qteventfinder.cpp:732
+#: ../src/celestia/qt/qteventfinder.cpp:400
+#: ../src/celestia/qt/qteventfinder.cpp:404
 #, fuzzy, qt-format
 msgid "From surface of %1"
 msgstr "從檔案讀取影像"
 
-#: ../src/celestia/qt/qteventfinder.cpp:736
+#: ../src/celestia/qt/qteventfinder.cpp:408
 #, fuzzy, qt-format
 msgid "Behind %1"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:75
+#: ../src/celestia/qt/qtinfopanel.cpp:77
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:86
+#: ../src/celestia/qt/qtinfopanel.cpp:88
 #: ../src/celestia/qt/qtselectionpopup.cpp:159
 #, fuzzy
 msgid "Info"
 msgstr "資訊(&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:111
+#: ../src/celestia/qt/qtinfopanel.cpp:113
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL 資訊"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:127
+#: ../src/celestia/qt/qtinfopanel.cpp:129
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:129
+#: ../src/celestia/qt/qtinfopanel.cpp:131
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:134
+#: ../src/celestia/qt/qtinfopanel.cpp:136
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:169
+#: ../src/celestia/qt/qtinfopanel.cpp:171
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:172
+#: ../src/celestia/qt/qtinfopanel.cpp:174
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:200
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:198
+#: ../src/celestia/qt/qtinfopanel.cpp:205
+msgid "<b>Has rings</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:207
+msgid "<b>Has atmosphere</b>"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:215
+#, fuzzy, qt-format
+msgid "<b>Start:</b> %1"
+msgstr "距離(光年)"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:218
+#, fuzzy, qt-format
+msgid "<b>End:</b> %1"
+msgstr "大小:%1 MB"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:220
 #, fuzzy
 msgid "Orbit information"
 msgstr "資訊文字"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/qt/qtinfopanel.cpp:221
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
 #. stream << "<i>[ Orbit reference plane info goes here ]</i><br>\n";
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:224
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:207
+#: ../src/celestia/qt/qtinfopanel.cpp:229
 #, fuzzy
 msgid "AU"
 msgstr "天文單位"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:215
+#: ../src/celestia/qt/qtinfopanel.cpp:237
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:216
+#: ../src/celestia/qt/qtinfopanel.cpp:238
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:217
+#: ../src/celestia/qt/qtinfopanel.cpp:239
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:218
+#: ../src/celestia/qt/qtinfopanel.cpp:240
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:219
+#: ../src/celestia/qt/qtinfopanel.cpp:241
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:221
+#: ../src/celestia/qt/qtinfopanel.cpp:243
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:222
+#: ../src/celestia/qt/qtinfopanel.cpp:244
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:223
+#: ../src/celestia/qt/qtinfopanel.cpp:245
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:224
+#: ../src/celestia/qt/qtinfopanel.cpp:246
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:264
-#: ../src/celestia/qt/qtinfopanel.cpp:287
+#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:309
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:268
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/qt/qtinfopanel.cpp:290
+#: ../src/celestia/qt/qtinfopanel.cpp:313
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:298
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:301
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:168
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
 msgid "OpenGL 2.0"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:208
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#, fuzzy
+msgid "OpenGL 2.1"
+msgstr "OpenGL 2.0"
+
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:209
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
 #, fuzzy
 msgid "Classic colors"
 msgstr "恆星樣式(&Y)"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:215
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
 #, fuzzy
 msgid "Local format"
 msgstr "本地格式"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
 #, fuzzy
 msgid "Time zone name"
 msgstr "時區名稱"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
 #, fuzzy
 msgid "UTC offset"
 msgstr "與世界協調時間的差異"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#, fuzzy, qt-format
+msgid "Start: %1"
+msgstr "開始"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#, qt-format
+msgid "End: %1"
+msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:116
 msgid "Distance: "
@@ -3804,21 +4054,21 @@ msgid "&Select"
 msgstr "選取(&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:140
-#: ../src/celestia/win32/res/resource_strings.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:122
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "&Center"
 msgstr "置中(&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:144
-#: ../src/celestia/win32/winmain.cpp:1623
-#: ../src/celestia/win32/winmain.cpp:1671
-#: ../src/celestia/win32/winmain.cpp:1694
+#: ../src/celestia/win32/winmain.cpp:1541
+#: ../src/celestia/win32/winmain.cpp:1589
+#: ../src/celestia/win32/winmain.cpp:1612
 msgid "&Goto"
 msgstr "前往(&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:148
-#: ../src/celestia/win32/winmain.cpp:1624
-#: ../src/celestia/win32/winmain.cpp:1695
+#: ../src/celestia/win32/winmain.cpp:1542
+#: ../src/celestia/win32/winmain.cpp:1613
 msgid "&Follow"
 msgstr "跟隨(&F)"
 
@@ -3832,49 +4082,54 @@ msgid "Visible"
 msgstr "作用中影格檢視"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
-#: ../src/celestia/win32/winmain.cpp:1708
+#: ../src/celestia/win32/winmain.cpp:1626
 msgid "&Unmark"
 msgstr "取消標示(&U)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:242
+#: ../src/celestia/qt/qtselectionpopup.cpp:196
+#, fuzzy
+msgid "Select Primary Body"
+msgstr "選擇顯示模式"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 msgid "Filled Square"
 msgstr "填滿的方形"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 msgid "Disk"
 msgstr "碟形"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/win32/winmain.cpp:1710
+#: ../src/celestia/qt/qtselectionpopup.cpp:257
+#: ../src/celestia/win32/winmain.cpp:1628
 msgid "&Mark"
 msgstr "標示(&M)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:270
-#: ../src/celestia/win32/winmain.cpp:1628
+#: ../src/celestia/qt/qtselectionpopup.cpp:274
+#: ../src/celestia/win32/winmain.cpp:1546
 msgid "&Reference Marks"
 msgstr "參考標記(&R)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:272
+#: ../src/celestia/qt/qtselectionpopup.cpp:276
 #, fuzzy
 msgid "Show &Body Axes"
 msgstr "顯示天體轉軸"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:278
+#: ../src/celestia/qt/qtselectionpopup.cpp:282
 #, fuzzy
 msgid "Show &Frame Axes"
 msgstr "顯示系統轉軸"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:284
+#: ../src/celestia/qt/qtselectionpopup.cpp:288
 #, fuzzy
 msgid "Show &Sun Direction"
 msgstr "顯示太陽方向"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:290
+#: ../src/celestia/qt/qtselectionpopup.cpp:294
 #, fuzzy
 msgid "Show &Velocity Vector"
 msgstr "顯示速度向量"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:296
+#: ../src/celestia/qt/qtselectionpopup.cpp:300
 #, fuzzy
 msgid "Show S&pin Vector"
 msgstr "顯示速度向量"
@@ -3882,190 +4137,41 @@ msgstr "顯示速度向量"
 #. Only show the frame center menu item if the selection orbits another
 #. a non-stellar object. If it orbits a star, this is generally identical
 #. to the sun direction entry.
-#: ../src/celestia/qt/qtselectionpopup.cpp:308
+#: ../src/celestia/qt/qtselectionpopup.cpp:312
 #, fuzzy, qt-format
 msgid "Show &Direction to %1"
 msgstr "顯示太陽方向"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:315
+#: ../src/celestia/qt/qtselectionpopup.cpp:319
 #, fuzzy
 msgid "Show Planetographic &Grid"
 msgstr "顯示行星格線"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:321
+#: ../src/celestia/qt/qtselectionpopup.cpp:325
 #, fuzzy
 msgid "Show &Terminator"
 msgstr "顯示晝夜界線"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:339
-#: ../src/celestia/win32/winmain.cpp:1658
+#: ../src/celestia/qt/qtselectionpopup.cpp:343
+#: ../src/celestia/win32/winmain.cpp:1576
 msgid "&Alternate Surfaces"
 msgstr "替代表面(&A)"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:340
+#: ../src/celestia/qt/qtselectionpopup.cpp:344
 msgid "Normal"
 msgstr "一般"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:395
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:526
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:549
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/winmain.cpp:1533
-msgid "Spacecraft"
-msgstr "太空船"
-
-#: ../src/celestia/qt/qtselectionpopup.cpp:398
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
+#. i18n: file: ../src/celestia/qt/preferences.ui:56
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:293
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
+#. i18n: file: ../src/celestia/qt/preferences.ui:513
+#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
+#: ../src/celestia/qt/qtselectionpopup.cpp:390 ../src/celestia/qt/rc.cpp:78
+#: ../src/celestia/qt/rc.cpp:159 ../src/celestia/qt/rc.cpp:225
 #, fuzzy
-msgid "Other objects"
-msgstr "天體"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:48
-#, fuzzy
-msgid "Set Time"
-msgstr "設定時間..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:54
-#: ../src/celestia/win32/res/resource_strings.cpp:100
-msgid "Time Zone: "
-msgstr "時區: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:59
-#: ../src/celestia/win32/wintime.cpp:95
-msgid "Universal Time"
-msgstr "世界時間"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:60
-#: ../src/celestia/win32/wintime.cpp:96
-msgid "Local Time"
-msgstr "本地時間"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:65
-#, fuzzy
-msgid "Select Time Zone"
-msgstr "時區名稱"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:69
-#, fuzzy
-msgid "Date: "
-msgstr "日期"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:87
-#, fuzzy
-msgid "Set Year"
-msgstr "設定時間..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:90
-#, fuzzy
-msgid "Set Month"
-msgstr "設定時間..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:93
-#, fuzzy
-msgid "Set Day"
-msgstr "設定時間..."
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:97
-#, fuzzy
-msgid "Time: "
-msgstr "時間(&T)"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:116
-#, fuzzy
-msgid "Set Hours"
-msgstr " 時"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:119
-#: ../src/celestia/qt/qtsettimedialog.cpp:123
-msgid ":"
-msgstr ""
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:120
-#, fuzzy
-msgid "Set Minutes"
-msgstr " 分"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:124
-#, fuzzy
-msgid "Set Seconds"
-msgstr " 秒"
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:102
-msgid "Julian Date: "
-msgstr "儒略日: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:140
-#, fuzzy
-msgid "Set Julian Date"
-msgstr "儒略日: "
-
-#: ../src/celestia/qt/qtsettimedialog.cpp:149
-#, fuzzy
-msgid "Set time"
-msgstr "設定時間..."
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:504
-msgid "Barycenter"
-msgstr "質心"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:506
-#, fuzzy
-msgid "Star"
-msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:514
-#: ../src/celestia/win32/wineclipses.cpp:59
-msgid "Planet"
-msgstr "行星"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:516
-#, fuzzy
-msgid "Dwarf planet"
+msgid "Dwarf planets"
 msgstr "矮行星"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:520
-#, fuzzy
-msgid "Minor moon"
-msgstr "小行星衛星 (二重小行星)"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:522
-msgid "Asteroid"
-msgstr "小行星"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:524
-msgid "Comet"
-msgstr "彗星"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:528
-#, fuzzy
-msgid "Reference point"
-msgstr "參考標記(&R)"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:530
-#, fuzzy
-msgid "Component"
-msgstr "計算"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:532
-#, fuzzy
-msgid "Surface feature"
-msgstr "前往表面"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:536
-#, fuzzy
-msgid "Unknown"
-msgstr "開啟腳本時發生未知的錯誤"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
-#, fuzzy
-msgid "Asteroids & comets"
-msgstr "小行星"
-
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
-#, fuzzy
-msgid "Reference points"
-msgstr "參考標記(&R)"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:70
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonsCheck)
@@ -4073,67 +4179,234 @@ msgstr "參考標記(&R)"
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtselectionpopup.cpp:396
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:165 ../src/celestia/qt/rc.cpp:231
 #, fuzzy
 msgid "Minor moons"
 msgstr "小行星衛星 (二重小行星)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
+#: ../src/celestia/qt/qtselectionpopup.cpp:405
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
+#: ../src/celestia/win32/winmain.cpp:1451
+msgid "Spacecraft"
+msgstr "太空船"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:408
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#, fuzzy
+msgid "Other objects"
+msgstr "天體"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:49
+#, fuzzy
+msgid "Set Time"
+msgstr "設定時間..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:55
+#: ../src/celestia/win32/res/resource_strings.cpp:148
+msgid "Time Zone: "
+msgstr "時區: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:60
+#: ../src/celestia/win32/wintime.cpp:94
+msgid "Universal Time"
+msgstr "世界時間"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:61
+#: ../src/celestia/win32/wintime.cpp:95
+msgid "Local Time"
+msgstr "本地時間"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:66
+#, fuzzy
+msgid "Select Time Zone"
+msgstr "時區名稱"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:70
+#, fuzzy
+msgid "Date: "
+msgstr "日期"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:88
+#, fuzzy
+msgid "Set Year"
+msgstr "設定時間..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:91
+#, fuzzy
+msgid "Set Month"
+msgstr "設定時間..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:94
+#, fuzzy
+msgid "Set Day"
+msgstr "設定時間..."
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:98
+#, fuzzy
+msgid "Time: "
+msgstr "時間(&T)"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:117
+#, fuzzy
+msgid "Set Hours"
+msgstr " 時"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:120
+#: ../src/celestia/qt/qtsettimedialog.cpp:124
+msgid ":"
+msgstr ""
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:121
+#, fuzzy
+msgid "Set Minutes"
+msgstr " 分"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:125
+#, fuzzy
+msgid "Set Seconds"
+msgstr " 秒"
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:129
+#: ../src/celestia/win32/res/resource_strings.cpp:150
+msgid "Julian Date: "
+msgstr "儒略日: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:141
+#, fuzzy
+msgid "Set Julian Date"
+msgstr "儒略日: "
+
+#: ../src/celestia/qt/qtsettimedialog.cpp:150
+#, fuzzy
+msgid "Set time"
+msgstr "設定時間..."
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+msgid "Barycenter"
+msgstr "質心"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#, fuzzy
+msgid "Star"
+msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/win32/wineclipses.cpp:57
+msgid "Planet"
+msgstr "行星"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#, fuzzy
+msgid "Dwarf planet"
+msgstr "矮行星"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#, fuzzy
+msgid "Minor moon"
+msgstr "小行星衛星 (二重小行星)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+msgid "Asteroid"
+msgstr "小行星"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+msgid "Comet"
+msgstr "彗星"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#, fuzzy
+msgid "Reference point"
+msgstr "參考標記(&R)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#, fuzzy
+msgid "Component"
+msgstr "計算"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#, fuzzy
+msgid "Surface feature"
+msgstr "前往表面"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#, fuzzy
+msgid "Unknown"
+msgstr "開啟腳本時發生未知的錯誤"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#, fuzzy
+msgid "Asteroids & comets"
+msgstr "小行星"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#, fuzzy
+msgid "Reference points"
+msgstr "參考標記(&R)"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
 #, fuzzy
 msgid "Surface features"
 msgstr "其他特徵"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:701
+#. Buttons to select filtering criterion for objects
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#, fuzzy
+msgid "Planets and moons"
+msgstr "行星"
+
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
 #, fuzzy
 msgid "Group objects by class"
 msgstr "天體"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:712
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
 msgid "Mark bodies selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:30
-#: ../src/celestia/qt/qttimetoolbar.cpp:45
+#: ../src/celestia/qt/qttimetoolbar.cpp:31
+#: ../src/celestia/qt/qttimetoolbar.cpp:46
 #, fuzzy
 msgid "Reverse time"
 msgstr "時間倒轉"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:32
-#: ../src/celestia/qt/qttimetoolbar.cpp:47
+#: ../src/celestia/qt/qttimetoolbar.cpp:33
+#: ../src/celestia/qt/qttimetoolbar.cpp:48
 #, fuzzy
 msgid "10x slower"
 msgstr "10x 慢轉(&S)\tK"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:34
-#: ../src/celestia/qt/qttimetoolbar.cpp:49
+#: ../src/celestia/qt/qttimetoolbar.cpp:35
+#: ../src/celestia/qt/qttimetoolbar.cpp:50
 #, fuzzy
 msgid "2x slower"
 msgstr " 減慢"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:36
-#: ../src/celestia/qt/qttimetoolbar.cpp:51
+#: ../src/celestia/qt/qttimetoolbar.cpp:37
+#: ../src/celestia/qt/qttimetoolbar.cpp:52
 #, fuzzy
 msgid "Pause time"
 msgstr "時間暫停"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:40
-#: ../src/celestia/qt/qttimetoolbar.cpp:55
+#: ../src/celestia/qt/qttimetoolbar.cpp:41
+#: ../src/celestia/qt/qttimetoolbar.cpp:56
 #, fuzzy
 msgid "2x faster"
 msgstr " 增快"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:42
-#: ../src/celestia/qt/qttimetoolbar.cpp:57
+#: ../src/celestia/qt/qttimetoolbar.cpp:43
+#: ../src/celestia/qt/qttimetoolbar.cpp:58
 #, fuzzy
 msgid "10x faster"
 msgstr "10x 快轉(&F)\tL"
 
-#: ../src/celestia/qt/qttimetoolbar.cpp:59
+#: ../src/celestia/qt/qttimetoolbar.cpp:60
 #, fuzzy
 msgid "Set to current time"
 msgstr "設為目前的時間"
@@ -4205,7 +4478,6 @@ msgstr "緯度:"
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:187
 #. i18n: ectx: property (text), widget (QRadioButton, radiiButton)
 #: ../src/celestia/qt/rc.cpp:33
-#: ../src/celestia/win32/res/resource_strings.cpp:134
 msgid "radii"
 msgstr "半徑"
 
@@ -4226,7 +4498,7 @@ msgstr "解析度: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:137
 msgid "Organize Bookmarks"
 msgstr "組織書籤"
 
@@ -4257,18 +4529,6 @@ msgstr "Celestia 偏好設定"
 #: ../src/celestia/qt/rc.cpp:66 ../src/celestia/qt/rc.cpp:69
 msgid "Objects"
 msgstr "天體"
-
-#. i18n: file: ../src/celestia/qt/preferences.ui:56
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:293
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetOrbitsCheck)
-#. i18n: file: ../src/celestia/qt/preferences.ui:513
-#. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
-#: ../src/celestia/qt/rc.cpp:78 ../src/celestia/qt/rc.cpp:159
-#: ../src/celestia/qt/rc.cpp:225
-#, fuzzy
-msgid "Dwarf planets"
-msgstr "矮行星"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:119
 #. i18n: ectx: property (text), widget (QCheckBox, globularClustersCheck)
@@ -4359,49 +4619,43 @@ msgstr "部份軌道"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:177
-#: ../src/celestia/win32/res/resource_strings.cpp:161
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Grids"
 msgstr "格子"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:180
-#: ../src/celestia/win32/res/resource_strings.cpp:162
 msgid "Equatorial"
 msgstr "赤道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Ecliptic"
 msgstr "黃道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:186
-#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "Galactic"
 msgstr "銀河"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:163
 msgid "Horizontal"
 msgstr "水平分割檢視"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:195
-#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Diagrams"
 msgstr "圖形"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:198
-#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "Boundaries"
 msgstr "邊界"
 
@@ -4435,7 +4689,6 @@ msgstr "顯示地點標籤"
 #. i18n: file: ../src/celestia/qt/preferences.ui:647
 #. i18n: ectx: property (text), widget (QCheckBox, citiesCheck)
 #: ../src/celestia/qt/rc.cpp:267
-#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "Cities"
 msgstr "城市"
 
@@ -4449,21 +4702,18 @@ msgstr "著陸點(Landing Sites)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:661
 #. i18n: ectx: property (text), widget (QCheckBox, volcanoesCheck)
 #: ../src/celestia/qt/rc.cpp:273
-#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Volcanoes"
 msgstr "火山"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:668
 #. i18n: ectx: property (text), widget (QCheckBox, observatoriesCheck)
 #: ../src/celestia/qt/rc.cpp:276
-#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Observatories"
 msgstr "天文臺"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:675
 #. i18n: ectx: property (text), widget (QCheckBox, cratersCheck)
 #: ../src/celestia/qt/rc.cpp:279
-#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Craters"
 msgstr "隕坑(Craters)"
 
@@ -4498,7 +4748,6 @@ msgstr "海(Maria)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:710
 #. i18n: ectx: property (text), widget (QCheckBox, otherLocationsCheck)
 #: ../src/celestia/qt/rc.cpp:294
-#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Other features"
 msgstr "其他特徵"
 
@@ -4603,7 +4852,7 @@ msgstr "顯示"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:655
+#: ../src/celestia/url.cpp:659
 msgid "Settings"
 msgstr "設定"
 
@@ -4845,21 +5094,21 @@ msgid "&About Celestia"
 msgstr "關於 Celestia(&A)"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:71
-#: ../src/celestia/win32/res/resource_strings.cpp:90
-#: ../src/celestia/win32/res/resource_strings.cpp:94
-#: ../src/celestia/win32/res/resource_strings.cpp:96
-#: ../src/celestia/win32/res/resource_strings.cpp:98
+#: ../src/celestia/win32/res/resource_strings.cpp:92
+#: ../src/celestia/win32/res/resource_strings.cpp:97
+#: ../src/celestia/win32/res/resource_strings.cpp:101
 #: ../src/celestia/win32/res/resource_strings.cpp:104
-#: ../src/celestia/win32/res/resource_strings.cpp:108
-#: ../src/celestia/win32/res/resource_strings.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:189
-#: ../src/celestia/win32/res/resource_strings.cpp:203
-#: ../src/celestia/win32/res/resource_strings.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/res/resource_strings.cpp:115
+#: ../src/celestia/win32/res/resource_strings.cpp:119
+#: ../src/celestia/win32/res/resource_strings.cpp:128
+#: ../src/celestia/win32/res/resource_strings.cpp:130
+#: ../src/celestia/win32/res/resource_strings.cpp:138
+#: ../src/celestia/win32/res/resource_strings.cpp:144
+#: ../src/celestia/win32/res/resource_strings.cpp:152
+#: ../src/celestia/win32/res/resource_strings.cpp:155
+#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:168
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 #, fuzzy
 msgid "OK"
 msgstr "確定"
@@ -4869,531 +5118,621 @@ msgid "Celestia"
 msgstr "Celestia"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:73
+msgid "1.7.0"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:74
 #, fuzzy
 msgid "Copyright (C) 2001-2019, Celestia Development Team"
 msgstr "Copyright (C) 2001-2009, Celestia 開發團隊"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:74
+#: ../src/celestia/win32/res/resource_strings.cpp:75
 msgid "https://celestia.space/"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:75
+#: ../src/celestia/win32/res/resource_strings.cpp:76
 msgid "Celestia is free software and comes with absolutely no warranty."
 msgstr "Celestia 是一套自由軟體，不做任何保證。"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:76
+#: ../src/celestia/win32/res/resource_strings.cpp:77
 msgid "Authors"
 msgstr "作者群"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:77
+#: ../src/celestia/win32/res/resource_strings.cpp:78
 msgid "Chris Laurel"
 msgstr "Chris Laurel"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:78
+#: ../src/celestia/win32/res/resource_strings.cpp:79
 msgid "Clint Weisbrod"
 msgstr "Clint Weisbrod"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:79
+#: ../src/celestia/win32/res/resource_strings.cpp:80
 msgid "Fridger Schrempp"
 msgstr "Fridger Schrempp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:80
+#: ../src/celestia/win32/res/resource_strings.cpp:81
 msgid "Christophe Teyssier"
 msgstr "Christophe Teyssier"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:81
+#: ../src/celestia/win32/res/resource_strings.cpp:82
 msgid "Grant Hutchison"
 msgstr "Grant Hutchison"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:82
+#: ../src/celestia/win32/res/resource_strings.cpp:83
 msgid "Pat Suwalski"
 msgstr "Pat Suwalski"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:83
+#: ../src/celestia/win32/res/resource_strings.cpp:84
 msgid "Toti"
 msgstr "Toti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:84
+#: ../src/celestia/win32/res/resource_strings.cpp:85
 msgid "Da Woon Jung"
 msgstr "Da Woon Jung"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:85
+#: ../src/celestia/win32/res/resource_strings.cpp:86
 msgid "Hank Ramsey"
 msgstr "Hank Ramsey"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:86
+#: ../src/celestia/win32/res/resource_strings.cpp:87
 msgid "Bob Ippolito"
 msgstr "Bob Ippolito"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:87
+#: ../src/celestia/win32/res/resource_strings.cpp:88
 msgid "Vincent Giangiulio"
 msgstr "Vincent Giangiulio"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:88
+#: ../src/celestia/win32/res/resource_strings.cpp:89
 msgid "Andrew Tribick"
 msgstr "Andrew Tribick"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:89
-msgid "Select Object"
-msgstr "選擇星體"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:92
-msgid "Object Name"
-msgstr "星體名稱"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:93
-msgid "License"
-msgstr "授權"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:95
-msgid "Celestia Controls"
-msgstr "Celestia 控制"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:97
-msgid "OpenGL Driver Info"
-msgstr "OpenGL 驅動程式資訊"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:99
-msgid "Set Simulation Time"
-msgstr "設定模擬時間"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:101
-msgid "Format: "
-msgstr "格式: "
-
-#: ../src/celestia/win32/res/resource_strings.cpp:103
-msgid "Set To Current Time"
-msgstr "設為目前的時間"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:106
+#: ../src/celestia/win32/res/resource_strings.cpp:90
 msgid "Add Bookmark"
 msgstr "新增書籤"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:110
+#: ../src/celestia/win32/res/resource_strings.cpp:94
 msgid "Create in >>"
 msgstr "建立於 >>"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:111
-#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/res/resource_strings.cpp:95
+#: ../src/celestia/win32/res/resource_strings.cpp:140
 msgid "New Folder..."
 msgstr "新資料夾..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:112
-msgid "Solar System Browser"
-msgstr "太陽系瀏覽器"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:116
-#: ../src/celestia/win32/res/resource_strings.cpp:123
-msgid "&Go To"
-msgstr "前往(&G)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:117
-msgid "Solar System Objects"
-msgstr "太陽系星體"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:118
-msgid "Star Browser"
-msgstr "恆星瀏覽器"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:119
-msgid "Nearest"
-msgstr "最接近"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:120
-msgid "Brightest"
-msgstr "最亮"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:121
-#, fuzzy
-msgid "With planets"
-msgstr "包含行星"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:124
-msgid "&Refresh"
-msgstr "刷新(&R)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:126
-msgid "Star Search Criteria"
-msgstr "恆星搜尋條件"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:127
-msgid "Maximum Stars Displayed in List"
-msgstr "列表中顯示的最多恆星數"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:128
-msgid "Tour Guide"
-msgstr "遊歷指導"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:130
-#: ../src/celestia/win32/res/resource_strings.cpp:136
-msgid "Go To"
-msgstr "前往"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:131
-msgid "Select your destination:"
-msgstr "選擇您的目標:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:132
-msgid "Go to Object"
-msgstr "前往星體"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:138
-msgid "Object"
-msgstr "星體"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:139
-msgid "Long."
-msgstr "經度"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:140
-msgid "Lat."
-msgstr "緯度"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:141
-#: ../src/celestia/win32/res/resource_strings.cpp:188
-msgid "Distance"
-msgstr "距離"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:142
-msgid "Size:"
-msgstr "大小:"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:144
-msgid "Select Display Mode"
-msgstr "選擇顯示模式"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:145
-msgid "Resolution"
-msgstr "解析度"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:148
-msgid "View Options"
-msgstr "檢視選項"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:149
-#, fuzzy
-msgid "Show:"
-msgstr "顯示"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-#, fuzzy
-msgid "Display:"
-msgstr "顯示"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-msgid "Ecliptic Line"
-msgstr "黃道"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:166
-#, fuzzy
-msgid "Body / Orbit / Label display"
-msgstr "軌道 / 標籤"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-msgid "Latin Names"
-msgstr "拉丁文名"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:184
-msgid "Information Text"
-msgstr "資訊文字"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:186
-msgid "Terse"
-msgstr "精簡"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-msgid "Verbose"
-msgstr "詳細"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:194
-msgid "Landing Sites"
-msgstr "著陸點(Landing Sites)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:195
-msgid "Montes (Mountains)"
-msgstr "山(Montes)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:196
-msgid "Maria (Seas)"
-msgstr "海(Maria)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:198
-msgid "Valles (Valleys)"
-msgstr "峽谷(Valles)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:199
-msgid "Terrae (Land masses)"
-msgstr "高地(Terrae)"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:202
-msgid "Label Features"
-msgstr "標記特徵"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:205
-msgid "Show Features"
-msgstr "顯示特徵"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:206
-#, fuzzy
-msgid "Show Label"
-msgstr "標記特徵"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:207
-msgid "Minimum Labeled Feature Size"
-msgstr "最小已標記特徵的尺寸"
-
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:96
 msgid "Add New Bookmark Folder"
 msgstr "新增書籤資料夾"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:99
 msgid "Folder Name"
 msgstr "資料夾名稱"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:216
-msgid "Rename..."
-msgstr "重新命名..."
+#: ../src/celestia/win32/res/resource_strings.cpp:100
+msgid "Celestia Controls"
+msgstr "Celestia 控制"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-msgid "Rename Bookmark or Folder"
-msgstr "重新命名書籤或資料夾"
+#: ../src/celestia/win32/res/resource_strings.cpp:102
+msgid "Select Display Mode"
+msgstr "選擇顯示模式"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:221
-msgid "New Name"
-msgstr "新名稱"
+#: ../src/celestia/win32/res/resource_strings.cpp:103
+msgid "Resolution"
+msgstr "解析度"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/win32/res/resource_strings.cpp:106
 msgid "Eclipse Finder"
 msgstr "食相尋找器"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:107
 msgid "Compute"
 msgstr "計算"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:108
 msgid "Set Date and Go to Planet"
 msgstr "設定日期並前往行星"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:109
 #, fuzzy
 msgid "Close"
 msgstr "關閉"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:110
 msgid "From:"
 msgstr "從:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:111
 msgid "To:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:112
 msgid "On:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:113
 msgid "Search parameters"
 msgstr "搜尋參數"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "Solar Eclipses"
-msgstr "日食"
+#: ../src/celestia/win32/res/resource_strings.cpp:114
+msgid "Select Object"
+msgstr "選擇星體"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
-msgid "Lunar Eclipses"
-msgstr "月食"
+#: ../src/celestia/win32/res/resource_strings.cpp:117
+msgid "Object Name"
+msgstr "星體名稱"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
-#: ../src/celestia/win32/winmain.cpp:3366
+#: ../src/celestia/win32/res/resource_strings.cpp:118
+msgid "OpenGL Driver Info"
+msgstr "OpenGL 驅動程式資訊"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:120
+msgid "Go to Object"
+msgstr "前往星體"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:121
+#: ../src/celestia/win32/res/resource_strings.cpp:169
+msgid "Go To"
+msgstr "前往"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:123
+msgid "Object"
+msgstr "星體"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:124
+msgid "Long."
+msgstr "經度"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:125
+msgid "Lat."
+msgstr "緯度"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:126
+#: ../src/celestia/win32/res/resource_strings.cpp:178
+msgid "Distance"
+msgstr "距離"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:127
+msgid "License"
+msgstr "授權"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:132
+msgid "Show Features"
+msgstr "顯示特徵"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:133
+#, fuzzy
+msgid "Show Label"
+msgstr "標記特徵"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:134
+msgid "Minimum Labeled Feature Size"
+msgstr "最小已標記特徵的尺寸"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:135
+msgid "Size:"
+msgstr "大小:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:141
+msgid "Rename..."
+msgstr "重新命名..."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:143
+msgid "Rename Bookmark or Folder"
+msgstr "重新命名書籤或資料夾"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:146
+msgid "New Name"
+msgstr "新名稱"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:147
+msgid "Set Simulation Time"
+msgstr "設定模擬時間"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:149
+msgid "Format: "
+msgstr "格式: "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:151
+msgid "Set To Current Time"
+msgstr "設為目前的時間"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:154
+msgid "Solar System Browser"
+msgstr "太陽系瀏覽器"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+msgid "&Go To"
+msgstr "前往(&G)"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Solar System Objects"
+msgstr "太陽系星體"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:160
+msgid "Star Browser"
+msgstr "恆星瀏覽器"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+msgid "&Refresh"
+msgstr "刷新(&R)"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:165
+msgid "Star Search Criteria"
+msgstr "恆星搜尋條件"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:166
+msgid "Maximum Stars Displayed in List"
+msgstr "列表中顯示的最多恆星數"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:167
+msgid "Tour Guide"
+msgstr "遊歷指導"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+msgid "Select your destination:"
+msgstr "選擇您的目標:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+msgid "View Options"
+msgstr "檢視選項"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:172
+#, fuzzy
+msgid "Show:"
+msgstr "顯示"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#, fuzzy
+msgid "Display:"
+msgstr "顯示"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#, fuzzy
+msgid "Body / Orbit / Label display"
+msgstr "軌道 / 標籤"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:177
+msgid "Information Text"
+msgstr "資訊文字"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/winmain.cpp:3221
 msgid "WinLangID"
 msgstr "WinLangID"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Apr"
 msgstr "4"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Feb"
 msgstr "2"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jan"
 msgstr "1"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Jun"
 msgstr "6"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "Mar"
 msgstr "3"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "May"
 msgstr "5"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Aug"
 msgstr "8"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Dec"
 msgstr "12"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Jul"
 msgstr "7"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Nov"
 msgstr "11"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Oct"
 msgstr "10"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "Sep"
 msgstr "9"
 
-#: ../src/celestia/win32/wineclipses.cpp:61
+#: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Satellite"
 msgstr "衛星"
 
-#: ../src/celestia/win32/wineclipses.cpp:63
+#: ../src/celestia/win32/wineclipses.cpp:59
 msgid "Date"
 msgstr "日期"
 
-#: ../src/celestia/win32/wineclipses.cpp:65
+#: ../src/celestia/win32/wineclipses.cpp:60
 msgid "Start"
 msgstr "開始"
 
-#: ../src/celestia/win32/winmain.cpp:640
-msgid "Vendor: "
-msgstr "製造商:"
+#. Add windowed mode as the first item on the menu
+#: ../src/celestia/win32/winmain.cpp:1318
+msgid "Windowed Mode"
+msgstr "視窗模式"
 
-#: ../src/celestia/win32/winmain.cpp:645
-msgid "Renderer: "
-msgstr "成像器:"
+#: ../src/celestia/win32/winmain.cpp:1445
+msgid "Invisibles"
+msgstr "不可見"
+
+#: ../src/celestia/win32/winmain.cpp:1543
+msgid "S&ync Orbit"
+msgstr "同步軌道(&Y)"
+
+#: ../src/celestia/win32/winmain.cpp:1544
+#: ../src/celestia/win32/winmain.cpp:1590
+#: ../src/celestia/win32/winmain.cpp:1614
+msgid "&Info"
+msgstr "資訊(&I)"
+
+#: ../src/celestia/win32/winmain.cpp:1547
+msgid "Show Body Axes"
+msgstr "顯示天體轉軸"
+
+#: ../src/celestia/win32/winmain.cpp:1548
+msgid "Show Frame Axes"
+msgstr "顯示系統轉軸"
+
+#: ../src/celestia/win32/winmain.cpp:1549
+msgid "Show Sun Direction"
+msgstr "顯示太陽方向"
+
+#: ../src/celestia/win32/winmain.cpp:1550
+msgid "Show Velocity Vector"
+msgstr "顯示速度向量"
+
+#: ../src/celestia/win32/winmain.cpp:1551
+msgid "Show Planetographic Grid"
+msgstr "顯示行星格線"
+
+#: ../src/celestia/win32/winmain.cpp:1552
+msgid "Show Terminator"
+msgstr "顯示晝夜界線"
+
+#: ../src/celestia/win32/winmain.cpp:1566
+msgid "&Satellites"
+msgstr "衛星(&S)"
+
+#: ../src/celestia/win32/winmain.cpp:1599
+msgid "Orbiting Bodies"
+msgstr "繞行天體"
+
+#: ../src/celestia/win32/winmain.cpp:1955
+msgid "You system doesn't support OpenGL 2.1!"
+msgstr ""
+
+#: ../src/celestia/win32/winmain.cpp:3048
+msgid "Loading: "
+msgstr "載入:"
+
+#: ../src/celestia/win32/winmain.cpp:3219 ../src/celutil/util.cpp:77
+#: ../src/celutil/util.cpp:80
+msgid "LANGUAGE"
+msgstr "zh_TW"
+
+#: ../src/celestia/win32/winmain.cpp:3838
+msgid "Loading URL"
+msgstr "載入網址中"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winmain.cpp:650
 #: ../src/celestia/win32/winsplash.cpp:138
 msgid "Version: "
 msgstr "版本:"
 
-#: ../src/celestia/win32/winmain.cpp:660
-msgid "GLSL version: "
-msgstr "GLSL 版本:"
-
-#: ../src/celestia/win32/winmain.cpp:671
-msgid "Max simultaneous textures: "
-msgstr "最大同時紋理:"
-
-#: ../src/celestia/win32/winmain.cpp:678
-msgid "Max texture size: "
-msgstr "最大紋理尺寸:"
-
-#: ../src/celestia/win32/winmain.cpp:687
-msgid "Max cube map size: "
-msgstr "最大立方體地圖尺寸:"
-
-#: ../src/celestia/win32/winmain.cpp:695
-msgid "Point size range: "
-msgstr "點尺寸範圍:"
-
-#: ../src/celestia/win32/winmain.cpp:700
-msgid "Supported Extensions:"
-msgstr "支援的延伸功能:"
-
-#: ../src/celestia/win32/winmain.cpp:1401
-msgid "Windowed Mode"
-msgstr "視窗模式"
-
-#: ../src/celestia/win32/winmain.cpp:1527
-msgid "Invisibles"
-msgstr "不可見"
-
-#: ../src/celestia/win32/winmain.cpp:1625
-msgid "S&ync Orbit"
-msgstr "同步軌道(&Y)"
-
-#: ../src/celestia/win32/winmain.cpp:1626
-#: ../src/celestia/win32/winmain.cpp:1672
-#: ../src/celestia/win32/winmain.cpp:1696
-msgid "&Info"
-msgstr "資訊(&I)"
-
-#: ../src/celestia/win32/winmain.cpp:1629
-msgid "Show Body Axes"
-msgstr "顯示天體轉軸"
-
-#: ../src/celestia/win32/winmain.cpp:1630
-msgid "Show Frame Axes"
-msgstr "顯示系統轉軸"
-
-#: ../src/celestia/win32/winmain.cpp:1631
-msgid "Show Sun Direction"
-msgstr "顯示太陽方向"
-
-#: ../src/celestia/win32/winmain.cpp:1632
-msgid "Show Velocity Vector"
-msgstr "顯示速度向量"
-
-#: ../src/celestia/win32/winmain.cpp:1633
-msgid "Show Planetographic Grid"
-msgstr "顯示行星格線"
-
-#: ../src/celestia/win32/winmain.cpp:1634
-msgid "Show Terminator"
-msgstr "顯示晝夜界線"
-
-#: ../src/celestia/win32/winmain.cpp:1648
-msgid "&Satellites"
-msgstr "衛星(&S)"
-
-#: ../src/celestia/win32/winmain.cpp:1681
-msgid "Orbiting Bodies"
-msgstr "繞行天體"
-
-#: ../src/celestia/win32/winmain.cpp:3194
-msgid "Loading: "
-msgstr "載入:"
-
-#: ../src/celestia/win32/winmain.cpp:3364 ../src/celutil/util.cpp:69
-#: ../src/celutil/util.cpp:73
-msgid "LANGUAGE"
-msgstr "zh_TW"
-
-#: ../src/celestia/win32/winmain.cpp:3994
-msgid "Loading URL"
-msgstr "載入網址中"
-
-#: ../src/celestia/win32/winmain.cpp:4006
-msgid "Error opening script"
-msgstr "開啟腳本錯誤"
-
-#: ../src/celestia/win32/winmain.cpp:4025
-msgid "Error loading script"
-msgstr "載入腳本錯誤"
-
-#: ../src/celestia/win32/winmain.cpp:4030
-msgid "Running script"
-msgstr "執行腳本中"
-
-#: ../src/celestia/win32/wintime.cpp:97
+#: ../src/celestia/win32/wintime.cpp:96
 msgid "Time Zone Name"
 msgstr "時區名稱"
 
-#: ../src/celestia/win32/wintime.cpp:98
+#: ../src/celestia/win32/wintime.cpp:97
 msgid "UTC Offset"
 msgstr "與世界協調時間的差異"
+
+#: ../src/celscript/legacy/legacyscript.cpp:96
+msgid "Error opening script file."
+msgstr "開啟腳本檔案時發生錯誤。"
+
+#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/lua/luascript.cpp:96
+#, fuzzy
+msgid "Unknown error loading script"
+msgstr "開啟腳本時發生未知的錯誤"
+
+#: ../src/celscript/lua/celx.cpp:761
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?\n"
+"\n"
+"y = yes, ESC = cancel script, any other key = no"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:772
+msgid ""
+"WARNING:\n"
+"\n"
+"This script requests permission to read/write files\n"
+"and execute external programs. Allowing this can be\n"
+"dangerous.\n"
+"Do you trust the script and want to allow this?"
+msgstr ""
+
+#: ../src/celscript/lua/luascript.cpp:87
+#, c-format
+msgid "Error opening script '%s'"
+msgstr "開啟腳本 '%s' 時發生錯誤"
+
+#: ../src/celscript/lua/luascript.cpp:104
+#: ../src/celscript/lua/luascript.cpp:234
+msgid "Script coroutine initialization failed"
+msgstr "腳本的子函式初始化失敗"
+
+#: ../src/celscript/lua/luascript.cpp:206
+#, fuzzy, c-format
+msgid "Error opening LuaHook '%s'"
+msgstr "開啟腳本 '%s' 時發生錯誤"
+
+#: ../src/celscript/lua/luascript.cpp:223
+#, fuzzy
+msgid "Unknown error loading hook script"
+msgstr "開啟腳本時發生未知的錯誤"
+
+#: ../src/celutil/util.cpp:197
+msgid "Unknown value returned by GetTimeZoneInformation()\n"
+msgstr ""
 
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 #, fuzzy, c-format
 msgid "Error openning %s or .\n"
 msgstr "發生錯誤於開啟 "
+
+#~ msgid "Loading NV fragment program: "
+#~ msgstr "載入 NV 片段程式中:"
+
+#~ msgid "Error loading NV fragment program: "
+#~ msgstr "讀取 NV 片段程式時發生錯誤:"
+
+#~ msgid "Error in fragment program "
+#~ msgstr "片段程式發生錯誤"
+
+#~ msgid "Initializing NV fragment programs . . .\n"
+#~ msgstr "初始化 NV 片段程式中...\n"
+
+#~ msgid "All NV fragment programs loaded successfully.\n"
+#~ msgstr "所有 NV 片段程式已成功載入。\n"
+
+#~ msgid "Initializing ARB fragment programs . . .\n"
+#~ msgstr "初始化 ARB 片段程式中...\n"
+
+#, fuzzy, c-format
+#~ msgid "%s: unrecognized or unsupported image file type.\n"
+#~ msgstr ":無法辨識或未支援的影像格式。\n"
+
+#~ msgid "Loading NV vertex program: "
+#~ msgstr "載入 NV 頂點程式:"
+
+#~ msgid "Error loading NV vertex program: "
+#~ msgstr "載入 NV 頂點程式時發生錯誤:"
+
+#~ msgid "Error in vertex program "
+#~ msgstr "頂點程式發生錯誤 "
+
+#~ msgid "Loading ARB vertex program: "
+#~ msgstr "載入 ARB 頂點程式:"
+
+#~ msgid "Error loading ARB vertex program: "
+#~ msgstr "載入 ARB 頂點程式時發生錯誤:"
+
+#~ msgid ", line "
+#~ msgstr "，行號:"
+
+#~ msgid "Initializing NV vertex programs . . .\n"
+#~ msgstr "初始化 NV 頂點程式中...\n"
+
+#~ msgid "All NV vertex programs loaded successfully.\n"
+#~ msgstr "所有的 NV 頂點程式均已成功載入。\n"
+
+#~ msgid "Initializing ARB vertex programs . . .\n"
+#~ msgstr "初始化 ARB 頂點程式中...\n"
+
+#~ msgid "All ARB vertex programs loaded successfully.\n"
+#~ msgstr "所有的 ARB 頂點程式均已成功載入。\n"
+
+#~ msgid "Unknown error opening script"
+#~ msgstr "開啟腳本時發生未知的錯誤"
+
+#, fuzzy
+#~ msgid "Copy &URL"
+#~ msgstr "複製網址"
+
+#, fuzzy
+#~ msgid "&Paste URL"
+#~ msgstr "已複製網址"
+
+#, fuzzy
+#~ msgid "Enable Vsync"
+#~ msgstr "經緯儀模式啟動"
+
+#~ msgid "Nearest"
+#~ msgstr "最接近"
+
+#~ msgid "Brightest"
+#~ msgstr "最亮"
+
+#, fuzzy
+#~ msgid "With planets"
+#~ msgstr "包含行星"
+
+#~ msgid "Ecliptic Line"
+#~ msgstr "黃道"
+
+#~ msgid "Latin Names"
+#~ msgstr "拉丁文名"
+
+#~ msgid "Terse"
+#~ msgstr "精簡"
+
+#~ msgid "Verbose"
+#~ msgstr "詳細"
+
+#~ msgid "Landing Sites"
+#~ msgstr "著陸點(Landing Sites)"
+
+#~ msgid "Montes (Mountains)"
+#~ msgstr "山(Montes)"
+
+#~ msgid "Maria (Seas)"
+#~ msgstr "海(Maria)"
+
+#~ msgid "Valles (Valleys)"
+#~ msgstr "峽谷(Valles)"
+
+#~ msgid "Terrae (Land masses)"
+#~ msgstr "高地(Terrae)"
+
+#~ msgid "Label Features"
+#~ msgstr "標記特徵"
+
+#~ msgid "Solar Eclipses"
+#~ msgstr "日食"
+
+#~ msgid "Lunar Eclipses"
+#~ msgstr "月食"
+
+#~ msgid "Vendor: "
+#~ msgstr "製造商:"
+
+#~ msgid "GLSL version: "
+#~ msgstr "GLSL 版本:"
+
+#~ msgid "Supported Extensions:"
+#~ msgstr "支援的延伸功能:"
+
+#~ msgid "Error opening script"
+#~ msgstr "開啟腳本錯誤"
+
+#~ msgid "Error loading script"
+#~ msgstr "載入腳本錯誤"
+
+#~ msgid "Running script"
+#~ msgstr "執行腳本中"
 
 #~ msgid "Invisible"
 #~ msgstr "不可見的"

--- a/po3/ar.po
+++ b/po3/ar.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "عن Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "القيمة المطلقة"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "اضافة مفضلة"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "الكويكبات"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "الغلاف الجوي"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "وحدة قياس فضائية"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "المؤلفون"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "المفضلة"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "السطوع"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "إلغاء الامر"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "التقاط &صورة…\tF10"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&الاختيار المركزي\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "ملاحقة"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "مدن"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "ظلال الحلقة"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "سحب"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "أذيال المذنبات"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "المذنبات"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "برج فلكي"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "الأبراج الفلكية باللاتينية"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "تاريخ"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "العناصر المعلّمة"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "حذف"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr ""
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "جوهرة"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr ""
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "عرض"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "المسافة: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr ""
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "مع الكواكب"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "كاشف الكسوف أو الخسوف"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "ظلال الكسوف أو الخسوف"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr ", السطر"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "إظهار النجوم"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "مميزات العرض"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "مربع"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "يتبع"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "معدل الإطار"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&نقاط غير واضحة"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "المجرّات"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "المجرّات"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "إظهار النجوم"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr ""
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "مرشد الجولة"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr ""
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "تقسيم العرض أفقياً"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&معلومات"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "كيلومتر"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "مميزات الأسماء"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "مواقع الهبوط"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "الوقت المحلي"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "المواقع"
+
+# Android/iOS
+msgid "Lock"
+msgstr "قفل"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "&ضئيل"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "البحر المقصور استخدامه لدولة واحدة"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "المعلّم"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "&متوسط"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "الأقمار"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "جبال"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "الأقمار"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "الاسم"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "السديم"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "مجلد جديد…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "لا شيء"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "عناصر"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "مراصد"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "موافق"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "المجموعات المفتوحة"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "معلومات عن OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "المسارات"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "الكواب"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "زائد"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&نقاط"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "انصاف الاقطار"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "الدقة"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "ظلال الحلقة"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "الأقراص الممدة"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "&فتح مستند…"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "بحث"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "ضبط الوقت…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "إضافة أوضاع المفضلة للمستند الحالي"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "بدن الأصل '"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "إظهار الحدود الفاصلة"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "الإطارات الفعّالة مرئية"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "إظهار النجوم"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "إظهار النجوم"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "إظهار النجوم"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "إظهار النجوم"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "نظام الخلية الشمسية"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "المركبات الفضائية"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "مربع"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "النجوم"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "مدار مصاحب"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "تيرا"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "مصقول"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "وقت"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "مثلث"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "النوع"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "خطأ غير معروف في فتح المستند"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr ""
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "مضجر"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr ""
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/ar.po
+++ b/po3/ar.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/ar.po
+++ b/po3/ar.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/ar.po
+++ b/po3/ar.po
@@ -80,6 +80,14 @@ msgstr "اضافة مفضلة"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "التقاط &صورة…\tF10"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "المسافة: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -392,6 +412,14 @@ msgstr ""
 
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
 msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "لا شيء"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "النوع"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/be.po
+++ b/po3/be.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: be\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Пра Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Абс. вел."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Дадаць закладку"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Астэроіды"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Атмасфэры"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "аа"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Стваральнікі"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Закладкі"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Найярчэйшая зоркі"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Адмяніць"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Захапіць відэа"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Цэтраваць вылучэньне"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Даганяць"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Акружына"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Гарады"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Цені аблокаў"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Воблакі"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Хвасты камэт"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Камэты"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Сузор'і"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Сузор'і лацінай"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr "Свая"
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Дата"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Аб'екты глыбокага космасу"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Выдаліць"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Апісаньне"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Ромб"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Дыск"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr ""
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Адлегласьць: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Стрэлка ўніз"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Працягласьць"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Карлікавыя плянэты"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Пошук зацьменьняў"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Цені зацьменьняў"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Экліптычная"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Экватарыяльная"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Дэталі"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Запоўнены квадрат"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Ісьці ўсьлед"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Часьціня кадраў:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Размытыя кропкі"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Ґаляктычная"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Ґаляктыкі"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Шаравыя"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Сеткі"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Накіроўныя"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Высокае"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Гарызантальная"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "Зьвесткі"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "км"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Метка"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Месцы пасадкі"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Стрэлка ўлева"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Мясцовы час"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Месцы"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Захапіць"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Нізкае"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Моры й акіяны"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Пазнакі"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Сярэдняе"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Малыя месяцы"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Горы"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Месяцы"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Назва"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Туманнасьці"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Новы каталёґ"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Нічога"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Аб'екты"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Абсэрваторыі"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr "Зацямняльнік"
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "Так"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Адкрытыя скопішчы"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Зьвесткі OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Арбіты"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Плянэты"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Плюс"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Кропкі"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "радыюсаў"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Разрозьненьне:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Стрэлка ўправа"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Цені ад колцаў"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Маштабаваныя дыскі"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Сцэнары"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr ""
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Задаць час"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Настаўленьні"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Паказаць восі цела"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Паказваць межы"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Паказаць восі сыстэмы каардынат"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Паказваць плянэтаґрафічную сетку"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Паказваць напрамак Сонца"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Паказаць тэрмінатар"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Паказваць вэктар хуткасьці"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Сонечная сыстэма"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Караблі"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Квадрат"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Зоркі"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Сынхранізаваць арбіту"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Кантынэнты"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Сьцісла"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Час"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Трохкутнік"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Тып"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Невядомая"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Стрэлка ўверх"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Зрух ад UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Даліны"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Падрабязна"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Вульканы"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/be.po
+++ b/po3/be.po
@@ -80,6 +80,14 @@ msgstr "Дадаць закладку"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Захапіць відэа"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Адлегласьць: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Стрэлка ўніз"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Нічога"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Тып"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/be.po
+++ b/po3/be.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/be.po
+++ b/po3/be.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -1,16 +1,17 @@
-#
 # Copyright (C) 2001-2020 Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 #
-#, fuzzy
+# Translators:
+# Georgi Georgiev <georgiev_1994@abv.bg>, 2020
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
 "POT-Creation-Date: 2020-04-15 20:22+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2020-08-29 22:36+0200\n"
+"Last-Translator: Georgi Georgiev <georgiev_1994@abv.bg>\n"
+"Language-Team: Bulgarian <georgiev_1994@abv.bg>\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,94 +20,94 @@ msgstr ""
 # Android/iOS/Mac
 #, c-format
 msgid "%.2f days"
-msgstr ""
+msgstr "%.2f дни"
 
 # Android/iOS/Mac
 #, c-format
 msgid "%.2f hours"
-msgstr ""
+msgstr "%.2f часа"
 
 # Android/iOS/Mac, Unit kilometer
 #, c-format
 msgid "%d km"
-msgstr ""
+msgstr "%d км"
 
 # Android/iOS/Mac, Unit meter
 #, c-format
 msgid "%d m"
-msgstr ""
+msgstr "%d м"
 
 # Mac, Speed unit
 msgid "1 AU/s"
-msgstr ""
+msgstr "1 АЕ"
 
 # Mac, Speed unit
 msgid "1 km/s"
-msgstr ""
+msgstr "1 км/с"
 
 # Mac, Speed unit
 msgid "1 ly/s"
-msgstr ""
+msgstr "1 сг/с"
 
 # Mac, Speed unit
 msgid "1000 km/s"
-msgstr ""
+msgstr "1 000 км/с"
 
 # Mac, Speed unit
 msgid "10c"
-msgstr ""
+msgstr "10c"
 
 # Android/iOS, About Celstia...
 msgid "About"
-msgstr ""
+msgstr "Относно"
 
 # Mac, System menu item
 msgid "About Celestia"
-msgstr "За Селестия"
+msgstr "За Celestia"
 
 # Mac, Absolute magnitude
 msgid "Abs. mag"
-msgstr "Абс. зв.вел."
+msgstr "Абс. зв.в."
 
 # Android, Add a new item (bookmark)
 msgid "Add"
-msgstr ""
+msgstr "Добави"
 
 # Mac, Add a new bookmark
 msgid "Add Bookmark"
-msgstr "Добави фаворит"
+msgstr "Добави отметка"
 
 # iOS, Add a new item (bookmark)
 msgid "Add new…"
-msgstr ""
+msgstr "Добави нова..."
 
 # Mac
 msgid "Add/Subtract Light Travel Delay"
-msgstr ""
+msgstr "Добави/Извади забавянето на светлината"
 
 # Android/iOS, Advanced setting items
 msgid "Advanced"
-msgstr ""
+msgstr "Разширено"
 
 # Mac, Traveling forward
 msgid "Ahead"
-msgstr ""
+msgstr "Напред"
 
 # Android/iOS/Mac, Alternative textures to display
 msgid "Alternate Surfaces"
-msgstr ""
+msgstr "Алтернативни повърхности"
 
 # Android/iOS/Mac, In setting
 msgid "Ambient Light"
-msgstr ""
+msgstr "Фонова светлина"
 
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
-msgstr ""
+msgstr "и:"
 
 # Android/iOS/Mac
 msgid "Anti-aliasing"
-msgstr ""
+msgstr "Изглаждане"
 
 # Android/iOS/Mac
 msgid "Asteroids"
@@ -118,7 +119,7 @@ msgstr "Атмосфери"
 
 # Mac, Astronomical unit
 msgid "au"
-msgstr "АЕ"
+msgstr "ае"
 
 # Android/iOS, Authors for Celestia
 msgid "Authors"
@@ -126,64 +127,64 @@ msgstr "Автори"
 
 # Mac, Auto mag for star display
 msgid "Auto Mag"
-msgstr ""
+msgstr "Автоматична зв.в."
 
 # Android/iOS/Mac, Galactic coordinates
 #, c-format
 msgid "B: %d° %d′ %.2f″"
-msgstr ""
+msgstr "B: %d° %d′ %.2f″"
 
 # Mac, Undo an operation
 msgid "Back"
-msgstr ""
+msgstr "Назад"
 
 # Mac, Beginning time (for eclipse)
 msgid "Beginning"
-msgstr ""
+msgstr "Начало"
 
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "Between:"
-msgstr ""
+msgstr "Между:"
 
 # Mac
 msgid "Bookmark Organizer"
-msgstr ""
+msgstr "Организатор на отметки"
 
 # Android/iOS/Mac, URL bookmarks
 msgid "Bookmarks"
-msgstr "Фаворити"
+msgstr "Отметки"
 
 # Android/iOS/Mac
 msgid "Brightest Stars"
-msgstr "Звезди"
+msgstr "Най-ярки звезди"
 
 # Mac, System menu item, bring all windows to front
 msgid "Bring All to Front"
-msgstr ""
+msgstr "Всички отпред"
 
 # Android/iOS/Mac, Object browser
 msgid "Browser"
-msgstr ""
+msgstr "Браузър"
 
 # Mac
 msgid "c (lightspeed)"
-msgstr ""
+msgstr "c (светлинна скорост)"
 
 # Android/iOS, Calculating for eclipses
 msgid "Calculating…"
-msgstr ""
+msgstr "Изчисляване..."
 
 # Android/iOS, Observer control
 msgid "Camera Control"
-msgstr ""
+msgstr "Контрол на камерата"
 
 # Android/iOS/Mac
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Отказ"
 
 # Android/iOS, Failed to add a favorite item (currently a bookmark)
 msgid "Cannot add object"
-msgstr ""
+msgstr "Обектът не може да се добави"
 
 # Mac, Record a video in Celestia
 msgid "Capture Video"
@@ -191,35 +192,35 @@ msgstr "Прихвани видео"
 
 # Mac
 msgid "Celestia"
-msgstr "Селестия"
+msgstr "Celestia"
 
 # Mac, Object browser
 msgid "Celestia Browser"
-msgstr ""
+msgstr "Браузър на Celestia"
 
 # Mac
 msgid "Celestia Help"
-msgstr ""
+msgstr "Помощ за Celestia"
 
 # Android/iOS/Mac, Center an object
 msgid "Center"
-msgstr ""
+msgstr "Центрирай"
 
 # Mac, Center selected object
 msgid "Center Selection"
-msgstr "&Центрирай селекция\tC"
+msgstr "Центрирай селекция"
 
 # Mac, Choose another location for celestia.cfg and data to load
 msgid "Change Config File"
-msgstr ""
+msgstr "Смени конфигурационен файл"
 
 # Android/iOS/Mac
 msgid "Chase"
-msgstr "Гони"
+msgstr "Преследвай"
 
 # Mac, Choose location for celestia.cfg
 msgid "Choose Config File"
-msgstr ""
+msgstr "Избери конфигурационен файл"
 
 # Android/iOS/Mac, Marker
 msgid "Circle"
@@ -231,7 +232,7 @@ msgstr "Градове"
 
 # Android/iOS/Mac
 msgid "Cloud Shadows"
-msgstr "Сенки на облаци"
+msgstr "Сенки от облаци"
 
 # Android/iOS/Mac
 msgid "Clouds"
@@ -247,19 +248,19 @@ msgstr "Комети"
 
 # Android/iOS/Mac, celestia.cfg
 msgid "Config File"
-msgstr ""
+msgstr "Конфигурационен файл"
 
 # Android/iOS, Change requires a restart
 msgid "Configuration will take effect after a restart."
-msgstr ""
+msgstr "Промените ще бъдат приложени след рестартиране."
 
 # Mac, Confirm and relaunch Celestia
 msgid "Confirm and Relaunch"
-msgstr ""
+msgstr "Потвърди и рестартирай"
 
 # Android/iOS
 msgid "Constellation Labels"
-msgstr ""
+msgstr "Наименования на съзвездията"
 
 # Android/iOS/Mac
 msgid "Constellations"
@@ -271,43 +272,43 @@ msgstr "Съзвездия на латински"
 
 # Mac, Longitude and latitude (in Go to)
 msgid "Coordinate:"
-msgstr ""
+msgstr "Координати:"
 
 # Mac, Copy current URL to pasteboard
 msgid "Copy URL"
-msgstr ""
+msgstr "Копирай URL"
 
 # Android, Copying default data from APK
 msgid "Copying data…"
-msgstr ""
+msgstr "Копиране на данни..."
 
 # Android/iOS/Mac, Location labels
 msgid "Crater"
-msgstr ""
+msgstr "Кратер"
 
 # Android/iOS/Mac, Marker
 msgid "Crosshair"
-msgstr ""
+msgstr "Прицел"
 
 # Android, Current display language
 msgid "Current Language"
-msgstr ""
+msgstr "Текущ език"
 
 # Android/iOS/Mac
 msgid "Current Time"
-msgstr ""
+msgstr "Текущо време"
 
 # Android/iOS
 msgid "Custom"
-msgstr ""
+msgstr "Персонализирано"
 
 # Android/iOS/Mac, Directory to load data from
 msgid "Data Directory"
-msgstr ""
+msgstr "Директория на данните"
 
 # Android/iOS, Title for celestia.cfg, data location setting
 msgid "Data Location"
-msgstr ""
+msgstr "Местоположение на данните"
 
 # Mac, The date that a specifc eclipse takes place
 msgid "Date"
@@ -315,24 +316,24 @@ msgstr "Дата"
 
 # Android/iOS
 msgid "Date Format"
-msgstr ""
+msgstr "Формат на датата"
 
 # Android/iOS, Debug menu
 msgid "Debug"
-msgstr ""
+msgstr "Отстраняване на грешки"
 
 # Android/iOS/Mac, Equatorial coordinate
 #, c-format
 msgid "DEC: %d° %d′ %.2f″"
-msgstr ""
+msgstr "DEC: %d° %d′ %.2f″"
 
 # Android/iOS/Mac
 msgid "Deep Sky Objects"
-msgstr "Маркирани обекти"
+msgstr "Обекти от дълбокия космос"
 
 # Androd/iOS/Mac
 msgid "Default"
-msgstr ""
+msgstr "По подразбиране"
 
 # Android/iOS
 msgid "Delete"
@@ -340,15 +341,15 @@ msgstr "Изтрий"
 
 # Mac, Delete current view (in split view mode)
 msgid "Delete Active View"
-msgstr ""
+msgstr "Изтрий активния изглед"
 
 # Mac, Delete views other than current view (in split view mode)
 msgid "Delete Other Views"
-msgstr ""
+msgstr "Изтрий другите изгледи"
 
 # iOS, Title for share link
 msgid "Description"
-msgstr "Продължителност"
+msgstr "Описание"
 
 # Android/iOS, URL for Development wiki
 msgid "Development"
@@ -360,7 +361,7 @@ msgstr "Диамант"
 
 # Mac, Camera direction
 msgid "Direction"
-msgstr ""
+msgstr "Посока"
 
 # Android/iOS/Mac, Marker
 msgid "Disk"
@@ -372,23 +373,23 @@ msgstr "Екран"
 
 # Mac
 msgid "Display Light Travel Delay"
-msgstr ""
+msgstr "Покажи забавянето на светлината"
 
 # Mac, Distance to the object (in Go to)
 msgid "Distance:"
-msgstr "Разстояние: "
+msgstr "Разстояние:"
 
 # Mac, In eclipse finder
 msgid "Double click on item to go"
-msgstr ""
+msgstr "Кликни два пъти за да отидеш до елемента"
 
 # Mac, In bookmark organizer
 msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
-msgstr ""
+msgstr "Кликни два пъти върху елемент за да го отвориш или кликни с Ctrl за контекстното меню. Премествай елементите чрез влачене."
 
 # Mac, Pitch angle down
 msgid "Down"
-msgstr ""
+msgstr "Надолу"
 
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
@@ -396,7 +397,7 @@ msgstr "Стрелка надолу"
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
-msgstr ""
+msgstr "ОДК"
 
 # Mac, Duration for an eclipse
 msgid "Duration"
@@ -404,7 +405,7 @@ msgstr "Продължителност"
 
 # Android/iOS/Mac
 msgid "Dwarf Planets"
-msgstr "С планети"
+msgstr "Планети джуджета"
 
 # Android/iOS/Mac
 msgid "Eclipse Finder"
@@ -412,80 +413,80 @@ msgstr "Търсач на затъмнения"
 
 # Android/iOS/Mac
 msgid "Eclipse Shadows"
-msgstr "Санки на затъмнеия"
+msgstr "Сенки от затъмнеия"
 
 # Android/iOS/Mac, Grids
 msgid "Ecliptic"
-msgstr ", ред "
+msgstr "Еклиптична"
 
 # iOS, Enter edit mode for favorite items
 msgid "Edit"
-msgstr ""
+msgstr "Редактиране"
 
 # Android/iOS, In eclipse finder, range of time to find eclipse in
 msgid "End Time"
-msgstr ""
+msgstr "Крайно време"
 
 # Mac, In eclipse finder
 msgid "Enter name of planet or moon"
-msgstr ""
+msgstr "Въведи име на планета или спътник"
 
 # Android/iOS/Mac, Grids
 msgid "Equatorial"
-msgstr "Покажи звезди"
+msgstr "Екваториална"
 
 # Android/iOS/Mac
 #, c-format
 msgid "Equatorial radius: %s"
-msgstr ""
+msgstr "Екваториален радиус: %s"
 
 # Android/iOS
 msgid "Error loading data, fallback to original configuration."
-msgstr ""
+msgstr "Грешка при зареждане на данните, връщане към началната конфигурация."
 
 # Mac
 msgid "Failed to start OpenGL."
-msgstr ""
+msgstr "Неуспешно стартиране на OpenGL."
 
 # Mac
 msgid "Failed to start renderer."
-msgstr ""
+msgstr "Неуспешно стартиране на рендъра."
 
 # Android/iOS/Mac, Control the faintest star that Celestia should display
 msgid "Faintest Stars"
-msgstr ""
+msgstr "Най-бледи звезди"
 
 # Mac, Make time go faster
 msgid "Faster"
-msgstr ""
+msgstr "По-бързо"
 
 # Mac
 msgid "Fatal Error"
-msgstr ""
+msgstr "Фатална грешка"
 
 # Android/iOS, Favorites (currently bookmarks and scripts)
 msgid "Favorites"
-msgstr ""
+msgstr "Фаворити"
 
 # Android/iOS/Mac
 msgid "Features"
-msgstr "Покажи детайли"
+msgstr "Характеристики"
 
 # Mac, File menu
 msgid "File"
-msgstr ""
+msgstr "Файл"
 
 # Android/iOS/Mac, Marker
 msgid "Filled Square"
-msgstr "Изпълнен квадрат"
+msgstr "Запълнен квадрат"
 
 # Android/iOS/Mac, Find (eclipses)
 msgid "Find"
-msgstr ""
+msgstr "Търси"
 
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "Find Eclipses cast on:"
-msgstr ""
+msgstr "Търси затъмнения на:"
 
 # Android/iOS/Mac
 msgid "Follow"
@@ -493,23 +494,23 @@ msgstr "Следвай"
 
 # Mac, Format for time
 msgid "Format:"
-msgstr ""
+msgstr "Формат:"
 
 # Mac, Redo an operation
 msgid "Forward"
-msgstr ""
+msgstr "Напред"
 
 # Mac, Frame rate for capturing video
 msgid "Frame rate:"
-msgstr "Скорост на кадрите:"
+msgstr "Честота на кадрите:"
 
 # Android/iOS/Mac, Star style
 msgid "Fuzzy Points"
-msgstr "Мъгливи точки"
+msgstr "Неясни точки"
 
 # Android/iOS/Mac, Grids
 msgid "Galactic"
-msgstr "Галактики"
+msgstr "Галактическа"
 
 # Android/iOS/Mac
 msgid "Galaxies"
@@ -517,99 +518,99 @@ msgstr "Галактики"
 
 # Android/iOS/Mac
 msgid "Galaxies (Barred Spiral)"
-msgstr ""
+msgstr "Галактики (Пресечени спирални)"
 
 # Android/iOS/Mac
 msgid "Galaxies (Elliptical)"
-msgstr ""
+msgstr "Галактики (Елиптични)"
 
 # Android/iOS/Mac
 msgid "Galaxies (Irregular)"
-msgstr ""
+msgstr "Галактики (Неправилни)"
 
 # Android/iOS/Mac
 msgid "Galaxies (Spiral)"
-msgstr ""
+msgstr "Галактики (Спирални)"
 
 # Android/iOS, Render parameter
 msgid "Galaxy Brightness"
-msgstr ""
+msgstr "Галактическа яркост"
 
 # Mac, In settings
 msgid "General"
-msgstr ""
+msgstr "Общи"
 
 # Android/iOS
 msgid "Generating sharing link…"
-msgstr ""
+msgstr "Генериране на споделяща връзка..."
 
 # Android/iOS/Mac
 msgid "Globulars"
-msgstr "Покажи звезди"
+msgstr "Кълбовидни звездни купове"
 
 # Android/iOS/Mac, Go to an object
 msgid "Go"
-msgstr ""
+msgstr "Отиди"
 
 # Mac
 msgid "Go to Object"
-msgstr ""
+msgstr "Отиди до обект"
 
 # Mac
 msgid "Go to Object…"
-msgstr ""
+msgstr "Отиди до обект..."
 
 # Mac, Go to selected object
 msgid "Go to Selection"
-msgstr ""
+msgstr "Отиди до селекция"
 
 # Android/iOS/Mac
 msgid "Grids"
-msgstr ""
+msgstr "Мрежи"
 
 # Mac, Grids, labels, orbits, markers
 msgid "Guides"
-msgstr "Тур"
+msgstr "Водачи"
 
 # Android/iOS/Mac, Indicate that an object has atmosphere
 msgid "Has atmosphere"
-msgstr ""
+msgstr "Има атмосфера"
 
 # Android/iOS/Mac, Indicate that an object has rings
 msgid "Has rings"
-msgstr ""
+msgstr "Има пръстени"
 
 # Android/iOS/Mac
 msgid "Help"
-msgstr ""
+msgstr "Помощ"
 
 # Mac, System menu item, hide Celestia window
 msgid "Hide Celestia"
-msgstr ""
+msgstr "Скрий Celestia"
 
 # Mac, System menu item, hide windows other than Celestia
 msgid "Hide Others"
-msgstr ""
+msgstr "Скрий другите"
 
 # Android/iOS/Mac, HiDPI support in display
 msgid "HiDPI"
-msgstr ""
+msgstr "HiDPI"
 
 # Android/iOS/Mac, High resolution
 msgid "High"
-msgstr ""
+msgstr "Висока"
 
 # Mac, Operation history menu
 msgid "History"
-msgstr ""
+msgstr "История"
 
 # Android/iOS/Mac, Home object, sun.
 msgid "Home (Sol)"
-msgstr ""
+msgstr "Начало (Слънце)"
 
 # Android/iOS/Mac, Grids
 msgid "Horizontal"
-msgstr "Раздели изгледа хоризонтално"
+msgstr "Хоризонтална"
 
 # Android/iOS
 msgid ""
@@ -617,6 +618,9 @@ msgid ""
 "\n"
 "Pinch to zoom in/out field of view."
 msgstr ""
+"В режим наблюдение, влачи за преместване на зрителното поле.\n"
+"\n"
+"Влачи с два пръста за увеличение или намаление на зрителното поле."
 
 # Android/iOS
 msgid ""
@@ -624,26 +628,29 @@ msgid ""
 "\n"
 "Pinch to zoom in/out on an object."
 msgstr ""
+"В режим обекти, влачи за завъртане около обекта.\n"
+"\n"
+"Влачи с два пръста за увеличение или намаление върху обекта."
 
 # Mac, HUD display
 msgid "Info"
-msgstr "&Инфо"
+msgstr "Инфо"
 
 # Android/iOS, HUD display
 msgid "Info Display"
-msgstr ""
+msgstr "Информационен екран"
 
 # Mac, HUD display
 msgid "Info Display:"
-msgstr ""
+msgstr "Информационен екран:"
 
 # Android/iOS, Information of an object
 msgid "Information"
-msgstr ""
+msgstr "Информация"
 
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
-msgstr ""
+msgstr "Юлианова дата:"
 
 # Mac, Unit
 msgid "km"
@@ -652,55 +659,55 @@ msgstr "км"
 # Android/iOS/Mac, Galactic coordinates
 #, c-format
 msgid "L: %d° %d′ %.2f″"
-msgstr ""
+msgstr "L: %d° %d′ %.2f″"
 
 # Mac, Density of labels to display
 msgid "Label Density"
-msgstr ""
+msgstr "Наситеност на надписите"
 
 # Mac, Labels to display
 msgid "Labels"
-msgstr "Етикет детайли"
+msgstr "Надписи"
 
 # Android/iOS/Mac, Location labels
 msgid "Landing Sites"
-msgstr "Места на кацане"
+msgstr "Места на приземяване"
 
 # Android, Display language setting
 msgid "Language"
-msgstr ""
+msgstr "Език"
 
 # Mac, Coordinates
 msgid "Latitude"
-msgstr ""
+msgstr "Географска ширина"
 
 # Mac, Yaw angle left
 msgid "Left"
-msgstr ""
+msgstr "Наляво"
 
 # Android/iOS/Mac, Marker
 msgid "Left Arrow"
-msgstr "Лява стрелка"
+msgstr "Стрелка наляво"
 
 # Android/iOS/Mac
 #, c-format
 msgid "Length of day: %s"
-msgstr ""
+msgstr "Продължителност на деня: %s"
 
 # Android/iOS, Celestia loading failed
 #, c-format
 msgid "Loading Celestia failed…"
-msgstr ""
+msgstr "Зареждането на Celestia е неуспешно…"
 
 # Android, Loading Celestia configuration
 #, c-format
 msgid "Loading configuration…"
-msgstr ""
+msgstr "Зареждане на конфигурация..."
 
 # Android/iOS, Celestia initialization, loading file
 #, c-format
 msgid "Loading: %s"
-msgstr ""
+msgstr "Зареждане: %s"
 
 # Android/iOS/Mac
 msgid "Local Time"
@@ -708,11 +715,11 @@ msgstr "Местно време"
 
 # Mac, Menu, location for observation
 msgid "Location"
-msgstr ""
+msgstr "Местоположение"
 
 # Mac, Type of locations to display
 msgid "Location Types"
-msgstr ""
+msgstr "Видове местоположения"
 
 # Android/iOS/Mac, Location labels to display
 msgid "Locations"
@@ -724,23 +731,23 @@ msgstr "Заключи"
 
 # Mac
 msgid "Lock Phase"
-msgstr ""
+msgstr "Заключи фазата"
 
 # Android/iOS
 msgid "Long press on stepper to change orientation."
-msgstr ""
+msgstr "Натисни продължително степъра за промяна на ориентацията."
 
 # Mac, Coordinates
 msgid "Longitude"
-msgstr ""
+msgstr "Географска дължина"
 
 # Mac, Reverse camera direction
 msgid "Look Back"
-msgstr ""
+msgstr "Погледни назад"
 
 # Android/iOS/Mac, Low resolution
 msgid "Low"
-msgstr "Ниско"
+msgstr "Ниска"
 
 # Android/iOS/Mac, Location labels
 msgid "Mare"
@@ -748,7 +755,7 @@ msgstr "Морета"
 
 # Android/iOS/Mac, Mark an object
 msgid "Mark"
-msgstr ""
+msgstr "Маркирай"
 
 # Mac
 msgid "Markers"
@@ -756,27 +763,27 @@ msgstr "Маркери"
 
 # Mac, Mass of an object
 msgid "Mass"
-msgstr ""
+msgstr "Маса"
 
 # Android/iOS/Mac, Medium resolution
 msgid "Medium"
-msgstr "Средно"
+msgstr "Средна"
 
 # Mac, System menu item, minimize window
 msgid "Minimize"
-msgstr ""
+msgstr "Минимизирай"
 
 # Android/iOS, Minimum feature size that we should display a label for
 msgid "Minimum Labelled Feature Size"
-msgstr ""
+msgstr "Минимален размер на характеристиките с надписи"
 
 # Android/iOS/Mac
 msgid "Minor Moons"
-msgstr "Луни"
+msgstr "Астероидни спътници"
 
 # Android/iOS/Mac, Location labels
 msgid "Mons"
-msgstr "Луни"
+msgstr "Планини"
 
 # Android/iOS/Mac
 msgid "Moons"
@@ -784,11 +791,11 @@ msgstr "Луни"
 
 # Mac, Move closer to the object
 msgid "Move Closer"
-msgstr ""
+msgstr "Приближи"
 
 # Mac, Move farther away from the object
 msgid "Move Farther"
-msgstr ""
+msgstr "Отдалечи"
 
 # Mac, Name of an object
 msgid "Name"
@@ -796,7 +803,7 @@ msgstr "Име"
 
 # Android/iOS/Mac
 msgid "Nearest Stars"
-msgstr ""
+msgstr "Най-близки звезди"
 
 # Android/iOS/Mac
 msgid "Nebulae"
@@ -804,27 +811,27 @@ msgstr "Мъглявини"
 
 # Mac, Create a folder in bookmark organizer
 msgid "New Folder"
-msgstr "Нова папка…"
+msgstr "Нова папка"
 
 # Android/iOS/Mac
 msgid "Night Lights"
-msgstr ""
+msgstr "Нощни светлини"
 
 # iOS, No data received for a request
 msgid "No data"
-msgstr ""
+msgstr "Липсват данни"
 
 # Mac, In Go to
 msgid "No object name entered"
-msgstr ""
+msgstr "Не е въведено име на обект"
 
 # Android/iOS/Mac, No overview for an object
 msgid "No overview available."
-msgstr ""
+msgstr "Не е наличен общ преглед."
 
 # iOS, No response received for a request
 msgid "No response"
-msgstr ""
+msgstr "Няма отговор"
 
 # Android/iOS/Mac, Empty HUD display
 msgid "None"
@@ -835,22 +842,24 @@ msgid ""
 "Note:\n"
 "Specifying a large time interval may cause long search times and a very large number of results."
 msgstr ""
+"Забележка:\n"
+"При задаване на голям времеви интервал, времето за търсене и броят на резултатите се увеличават."
 
 # Android/iOS, In eclipse finder, object to find eclipse with
 msgid "Object"
-msgstr ""
+msgstr "Обект"
 
 # Android/iOS, Labels
 msgid "Object Labels"
-msgstr ""
+msgstr "Надписи на обектите"
 
 # Android/iOS/Mac
 msgid "Object not found"
-msgstr ""
+msgstr "Обектът не е намерен"
 
 # Mac, In Go to
 msgid "Object:"
-msgstr ""
+msgstr "Обект:"
 
 # Android/iOS
 msgid "Objects"
@@ -862,11 +871,11 @@ msgstr "Обсерватории"
 
 # Mac, In eclipse finder
 msgid "Occulter"
-msgstr ""
+msgstr "Затъмняващ обект"
 
 # Android/iOS
 msgid "Official Website"
-msgstr ""
+msgstr "Официален уебсайт"
 
 # Android/iOS/Mac
 msgid "OK"
@@ -874,31 +883,31 @@ msgstr "ОК"
 
 # Android/iOS/Mac
 msgid "Open Clusters"
-msgstr "Отворени купове"
+msgstr "Разсеяни звездни купове"
 
 # Android/iOS/Mac, Request user consent to open a URL
 msgid "Open URL?"
-msgstr ""
+msgstr "Отвори URL?"
 
 # Mac, Open web URL for an object
 msgid "Open Web URL"
-msgstr ""
+msgstr "Отвори уеб URL"
 
 # Mac
 msgid "OpenGL Info"
-msgstr "OpenGL Инфо"
+msgstr "Информация за OpenGL"
 
 # Android
 msgid "Opening external file or URL…"
-msgstr ""
+msgstr "Отваряне на външен файл или URL..."
 
 # iOS
 msgid "Operation not permitted."
-msgstr ""
+msgstr "Операцията не е позволена."
 
 # Mac
 msgid "Orbit Synchronously"
-msgstr ""
+msgstr "Орбитирай синхронизирано"
 
 # Android/iOS/Mac
 msgid "Orbits"
@@ -906,31 +915,31 @@ msgstr "Орбити"
 
 # Mac
 msgid "Organize Bookmarks…"
-msgstr ""
+msgstr "Организирай отметки..."
 
 # Mac, Other location labels
 msgid "Other"
-msgstr ""
+msgstr "Други"
 
 # Android/iOS, Other settings
 msgid "Others"
-msgstr ""
+msgstr "Други"
 
 # Mac, Paste URL from pasteboard
 msgid "Paste URL"
-msgstr ""
+msgstr "Постави URL"
 
 # Mac, Pause time
 msgid "Pause"
-msgstr ""
+msgstr "Паузирай"
 
 # Android/iOS/Mac, Camera control
 msgid "Pitch"
-msgstr ""
+msgstr "Наклон"
 
 # Android/iOS/Mac
 msgid "Planet Rings"
-msgstr ""
+msgstr "Пръстени на планетите"
 
 # Android/iOS/Mac
 msgid "Planets"
@@ -938,32 +947,32 @@ msgstr "Планети"
 
 # Mac, In Go to/Eclipse Finder
 msgid "Please check that the object name is correct."
-msgstr ""
+msgstr "Моля, проверете името на обекта за грешки."
 
 # Android/iOS, In eclipse finder, choose an object to find eclipse wth
 msgid "Please choose an object."
-msgstr ""
+msgstr "Моля, изберете обект."
 
 # iOS, Message for sharing a URL
 msgid "Please enter a description of the content."
-msgstr ""
+msgstr "Моля, въведете описание на съдържанието."
 
 # iOS, Message for renaming a favorite item (currently bookmark)
 msgid "Please enter a new name."
-msgstr ""
+msgstr "Моля, въведете ново име."
 
 # Mac, In Go to
 msgid "Please enter an object name."
-msgstr ""
+msgstr "Моля, въведете име на обекта."
 
 # Android/iOS
 #, c-format
 msgid "Please enter the time in \"%s\" format."
-msgstr ""
+msgstr "Моля, въведете времето във формат \"%s\"."
 
 # Android, Possibly due to memory issue, Celestia needs to be restarted
 msgid "Please restart Celestia"
-msgstr ""
+msgstr "Моля, рестартирайте Celestia"
 
 # Android/iOS/Mac, Marker
 msgid "Plus"
@@ -975,128 +984,128 @@ msgstr "Точки"
 
 # Mac, Settings window title
 msgid "Preferences"
-msgstr ""
+msgstr "Предпочитания"
 
 # Mac, Settings
 msgid "Preferences…"
-msgstr ""
+msgstr "Предпочитания..."
 
 # Mac, Quit Celestia
 msgid "Quit"
-msgstr ""
+msgstr "Изход"
 
 # Mac, System menu item
 msgid "Quit Celestia"
-msgstr ""
+msgstr "Изход от Celestia"
 
 # Android/iOS/Mac, Equatorial coordinate
 #, c-format
 msgid "RA: %dh %dm %.2fs"
-msgstr ""
+msgstr "RA: %dh %dm %.2fs"
 
 # Mac, In Go to, specify the distance based on the object radius
 msgid "radii"
-msgstr "радиус"
+msgstr "радиуси"
 
 # Mac, Radius of an object
 msgid "Radius"
-msgstr ""
+msgstr "Радиус"
 
 # Mac, Reset time speed to 1x
 msgid "Real Time"
-msgstr ""
+msgstr "Реално време"
 
 # Mac, In Eclipse Finder
 msgid "Receiver"
-msgstr ""
+msgstr "Получател"
 
 # Android/iOS/Mac, Reference vectors for an object
 msgid "Reference Vectors"
-msgstr ""
+msgstr "Референтни вектори"
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
-msgstr ""
+msgstr "Референтните вектори са видими само за текущия обект от слънчевата система."
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
-msgstr ""
+msgstr "Преименувай"
 
 # Android/iOS, Information about renderer
 msgid "Render Info"
-msgstr ""
+msgstr "Информация за рендъра"
 
 # Android/iOS, Render parameters in setting
 msgid "Render Parameters"
-msgstr ""
+msgstr "Параметри на рендъра"
 
 # Mac, In settings
 msgid "Renderer"
-msgstr ""
+msgstr "Рендър"
 
 # Android, Finished requesting permission needed for Celestia
 msgid "Requesting permission finished"
-msgstr ""
+msgstr "Заявката за разрешение завърши"
 
 # Mac, Run the previous script again
 msgid "Rerun Script"
-msgstr ""
+msgstr "Повторно изпълнение на скрипта"
 
 # Mac, Reset celestia.cfg, data directory location
 msgid "Reset"
-msgstr ""
+msgstr "Нулирай"
 
 # Android/iOS, Reset celestia.cfg, data directory location
 msgid "Reset to Default"
-msgstr ""
+msgstr "Връщане към начални настройки"
 
 # Mac, Resolution for capturing video
 msgid "Resolution:"
-msgstr "Резолюция"
+msgstr "Резолюция:"
 
 # Mac, Traveling backward
 msgid "Reverse"
-msgstr ""
+msgstr "Обърни"
 
 # Android/iOS, Reverse camera direction
 msgid "Reverse Direction"
-msgstr ""
+msgstr "Обърни посоката"
 
 # Mac, Yaw angle right
 msgid "Right"
-msgstr ""
+msgstr "Надясно"
 
 # Android/iOS/Mac, Marker
 msgid "Right Arrow"
-msgstr "Дясна стрелка"
+msgstr "Стрелка надясно"
 
 # Android/iOS/Mac
 msgid "Ring Shadows"
-msgstr "Сенки на пръстени"
+msgstr "Сенки от пръстени"
 
 # Android/iOS/Mac, Camera control
 msgid "Roll"
-msgstr ""
+msgstr "Завъртане"
 
 # Android/iOS/Mac
 msgid "Run Demo"
-msgstr ""
+msgstr "Стартирай демонстрация"
 
 # Android/iOS/Mac, Request user consent to run a script
 msgid "Run script?"
-msgstr ""
+msgstr "Изпълни скрипта?"
 
 # Mac
 msgid "Run Script…"
-msgstr ""
+msgstr "Изпълни скрипта..."
 
 # Android/iOS/Mac, Star style
 msgid "Scaled Discs"
-msgstr "Оразмерени дискове"
+msgstr "Мащабирани дискове"
 
 # Android/iOS
 msgid "Script Control"
-msgstr ""
+msgstr "Контрол на скриптовете"
 
 # Android/iOS/Mac
 msgid "Scripts"
@@ -1112,31 +1121,31 @@ msgstr "Търси"
 
 # Android/iOS/Mac, Select an object
 msgid "Select"
-msgstr ""
+msgstr "Избери"
 
 # Mac, Select next view (in split view)
 msgid "Select Next View"
-msgstr ""
+msgstr "Избери другия изглед"
 
 # Android, Select simulation time
 msgid "Select Time"
-msgstr ""
+msgstr "Избери време"
 
 # Mac, System menu
 msgid "Services"
-msgstr ""
+msgstr "Услуги"
 
 # Mac, Button to confirm selected simulation time
 msgid "Set Time"
-msgstr "Задай време…"
+msgstr "Задай време"
 
 # Mac, Select simulation time
 msgid "Set Time…"
-msgstr ""
+msgstr "Задай време..."
 
 # Android/iOS, Set simulation time to device
 msgid "Set to Current Time"
-msgstr ""
+msgstr "Задай текущо време"
 
 # Android/iOS
 msgid "Settings"
@@ -1144,11 +1153,11 @@ msgstr "Настройки"
 
 # Android/iOS, Share a URL
 msgid "Share"
-msgstr ""
+msgstr "Сподели"
 
 # Mac, System menu item, Show all windows
 msgid "Show All"
-msgstr ""
+msgstr "Покажи всички"
 
 # Android/iOS/Mac, Reference vector
 msgid "Show Body Axes"
@@ -1156,69 +1165,69 @@ msgstr "Покажи осите на телата"
 
 # Android/iOS/Mac, Show constellation boundaries
 msgid "Show Boundaries"
-msgstr "Покажи граници"
+msgstr "Покажи очертанията"
 
 # Mac
 msgid "Show Constellation Labels"
-msgstr ""
+msgstr "Покажи наименованията на съзвездията"
 
 # Mac
 msgid "Show Constellations"
-msgstr ""
+msgstr "Покажи съзвездията"
 
 # Android/iOS/Mac, Reference vector
 msgid "Show Frame Axes"
-msgstr "Покажи осите на кадрите"
+msgstr "Покажи осите на кадъра"
 
 # Mac, Show info for an object
 msgid "Show Info"
-msgstr ""
+msgstr "Покажи информация"
 
 # Mac
 msgid "Show Locations"
-msgstr ""
+msgstr "Покажи местоположенията"
 
 # Android/iOS/Mac
 msgid "Show Markers"
-msgstr ""
+msgstr "Покажи маркерите"
 
 # Mac
 msgid "Show Orbits"
-msgstr ""
+msgstr "Покажи орбитите"
 
 # Android/iOS/Mac, Reference vector
 msgid "Show Planetographic Grid"
-msgstr "Покажи звезди"
+msgstr "Покажи планетографска мрежа"
 
 # Android/iOS/Mac, Reference vector
 msgid "Show Sun Direction"
-msgstr "Покажи посока на Слънцето"
+msgstr "Покажи посоката на Слънцето"
 
 # Android/iOS/Mac, Reference vector
 msgid "Show Terminator"
-msgstr "Покажи звезди"
+msgstr "Покажи терминатора"
 
 # Android/iOS/Mac, Reference vector
 msgid "Show Velocity Vector"
-msgstr "Покажи вектора на скоростта"
+msgstr "Покажи вектора на ускорението"
 
 # Android/iOS/Mac
 #, c-format
 msgid "Sidereal rotation period: %s"
-msgstr ""
+msgstr "Звезден ден: %s"
 
 # Android/iOS/Mac, Size of an object
 #, c-format
 msgid "Size: %s"
-msgstr ""
+msgstr "Размер: %s"
 
 # Mac, Make time go more slowly
 msgid "Slower"
-msgstr ""
+msgstr "По-бавно"
 
 # Mac, Smooth lines for rendering
 msgid "Smooth Lines"
-msgstr ""
+msgstr "Изгладени линии"
 
 # Android/iOS/Mac, Tab for solar system in Star Browser
 msgid "Solar System"
@@ -1226,15 +1235,15 @@ msgstr "Слънчева система"
 
 # Android/iOS/Mac, Plural
 msgid "Spacecraft"
-msgstr "Космически апарати"
+msgstr "Космически апарат"
 
 # Mac, Split view
 msgid "Split Horizontally"
-msgstr ""
+msgstr "Раздели хоризонтално"
 
 # Mac, Split view
 msgid "Split Vertically"
-msgstr ""
+msgstr "Раздели вертикално"
 
 # Android/iOS/Mac, Marker
 msgid "Square"
@@ -1242,11 +1251,11 @@ msgstr "Квадрат"
 
 # Android/iOS/Mac
 msgid "Star Style"
-msgstr ""
+msgstr "Стил на звездите"
 
 # Mac
 msgid "Star Style:"
-msgstr ""
+msgstr "Стил на звездите:"
 
 # Android/iOS/Mac
 msgid "Stars"
@@ -1254,55 +1263,55 @@ msgstr "Звезди"
 
 # Android/iOS/Mac
 msgid "Stars with Planets"
-msgstr ""
+msgstr "Звезди с планети"
 
 # Android/iOS, In eclipse finder, range of time to find eclipse in
 msgid "Start Time"
-msgstr ""
+msgstr "Начално време"
 
 # Mac, Interupt the process of finding eclipse
 msgid "Stop"
-msgstr ""
+msgstr "Спри"
 
 # Android/iOS, Subsystem of an object (e.g. planetarium system)
 msgid "Subsystem"
-msgstr ""
+msgstr "Подсистема"
 
 # Android/iOS
 msgid "Support Forum"
-msgstr ""
+msgstr "Форум за поддръжка"
 
 # Android/iOS, Move/zoom camera FOV
 msgid "Switched to camera mode"
-msgstr ""
+msgstr "Превключване към режим наблюдение"
 
 # Android/iOS, Move/zoom on an object
 msgid "Switched to object mode"
-msgstr ""
+msgstr "Превключване към режим обекти"
 
 # Android/iOS
 msgid "Sync Orbit"
-msgstr "Синхронизирай Орбита"
+msgstr "Синхронизирай орбитата"
 
 # Android/iOS
 msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
-msgstr ""
+msgstr "Докосни бутона в страничната лента за превключване между режимите."
 
 # Android/iOS/Mac, Location labels
 msgid "Terra"
-msgstr "Земни маси"
+msgstr "Земна маса"
 
 # Android/iOS/Mac, Terse HUD display
 msgid "Terse"
-msgstr "Ясно"
+msgstr "Сбито"
 
 # Android/iOS/Mac
 msgid "Texture Resolution"
-msgstr ""
+msgstr "Резолюция на текстурите"
 
 # Mac
 msgid "Texture Resolution:"
-msgstr ""
+msgstr "Резолюция на текстурите:"
 
 # Android/iOS, URL for Third Party Dependencies wiki
 msgid "Third Party Dependencies"
@@ -1314,43 +1323,43 @@ msgstr "Време"
 
 # Android/iOS
 msgid "Time Control"
-msgstr ""
+msgstr "Контрол на времето"
 
 # Android/iOS
 msgid "Time Zone"
-msgstr ""
+msgstr "Часова зона"
 
 # Mac
 msgid "Time Zone:"
-msgstr ""
+msgstr "Часова зона:"
 
 # Mac, Set simulation time based on Julian date
 msgid "Time:"
-msgstr ""
+msgstr "Време:"
 
 # Android/iOS, Toggle console log display on overlay
 msgid "Toggle Console Display"
-msgstr ""
+msgstr "Покажи конзолата"
 
 # Android/iOS, Toggle FPS display on overlay
 msgid "Toggle FPS Display"
-msgstr ""
+msgstr "Покажи FPS"
 
 # Mac, Track an object
 msgid "Track"
-msgstr ""
+msgstr "Последвай"
 
 # Mac, Track selected object
 msgid "Track Selection"
-msgstr ""
+msgstr "Следи селекция"
 
 # Android/iOS, Translators for Celestia
 msgid "Translators"
-msgstr ""
+msgstr "Преводачи"
 
 # Mac, Travel menu
 msgid "Travel"
-msgstr ""
+msgstr "Пътуване"
 
 # Android/iOS/Mac, Marker
 msgid "Triangle"
@@ -1358,43 +1367,43 @@ msgstr "Триъгълник"
 
 # Android/iOS
 msgid "Tutorial"
-msgstr ""
+msgstr "Урок"
 
 # Mac, Type of a star
 msgid "Type"
-msgstr "Тип"
+msgstr "Вид"
 
 # Mac
 msgid "Unable to capture video"
-msgstr ""
+msgstr "Видеото не може да се прихване"
 
 # Android/iOS/Mac
 msgid "Unknown"
-msgstr "Неизвестна грешка при отваряне на скрипта"
+msgstr "Неизвестно"
 
 # iOS
 msgid "Unknown error"
-msgstr ""
+msgstr "Неизвестна грешка"
 
 # Android/iOS/Mac, Unmark an object
 msgid "Unmark"
-msgstr ""
+msgstr "Размаркирай"
 
 # Android/iOS, Unmark all objects
 msgid "Unmark All"
-msgstr ""
+msgstr "Размаркирай всички"
 
 # Android/iOS, String not in correct format
 msgid "Unrecognized time string."
-msgstr ""
+msgstr "Неразпознат времеви формат"
 
 # Mac, Default name for a newly created folder
 msgid "Untitled"
-msgstr ""
+msgstr "Неозаглавена"
 
 # Mac, Pitch angle up
 msgid "Up"
-msgstr ""
+msgstr "Нагоре"
 
 # Android/iOS/Mac, Marker
 msgid "Up Arrow"
@@ -1410,7 +1419,7 @@ msgstr "UTC"
 
 # Android/iOS/Mac
 msgid "UTC Offset"
-msgstr "UTC"
+msgstr "UTC отклонение"
 
 # Android/iOS/Mac, Location labels
 msgid "Vallis"
@@ -1418,35 +1427,35 @@ msgstr "Долини"
 
 # Mac, Menu for velocity of traveling
 msgid "Velocity"
-msgstr ""
+msgstr "Ускорение"
 
 # Android/iOS/Mac, Verbose HUD display
 msgid "Verbose"
-msgstr "Празно"
+msgstr "Подробно"
 
 # Android/iOS
 msgid "Version"
-msgstr ""
+msgstr "Версия"
 
 # Mac, Menu for split views
 msgid "Views"
-msgstr ""
+msgstr "Изгледи"
 
 # Android/iOS/Mac, Location labels
 msgid "Volcanoes"
-msgstr ""
+msgstr "Вулкани"
 
 # Android/iOS, Web info for an object
 msgid "Web Info"
-msgstr ""
+msgstr "Уеб информация"
 
 # Android/iOS, Welcome message
 msgid "Welcome to Celestia"
-msgstr ""
+msgstr "Добре дошли в Celestia"
 
 # Mac, System menu, window management
 msgid "Window"
-msgstr ""
+msgstr "Прозорец"
 
 # Android/iOS/Mac, Marker
 msgid "X"
@@ -1454,8 +1463,8 @@ msgstr "Х"
 
 # Android/iOS/Mac, Camera control
 msgid "Yaw"
-msgstr ""
+msgstr "Отклонение"
 
 # Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
 msgid "Zoom"
-msgstr ""
+msgstr "Увеличи"

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -353,7 +353,7 @@ msgstr "Описание"
 
 # Android/iOS, URL for Development wiki
 msgid "Development"
-msgstr ""
+msgstr "Разработка"
 
 # Android/iOS/Mac, Marker
 msgid "Diamond"

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -112,7 +112,7 @@ msgstr "Фонова светлина"
 
 # iOS
 msgid "An external screen is connected, do you want to display Celestia on the external screen?"
-msgstr ""
+msgstr "Свързан е външен екран, искате ли Celestia да се покаже на външния екран?"
 
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
@@ -483,7 +483,7 @@ msgstr "Изход"
 
 # iOS
 msgid "Failed to connect to the external screen."
-msgstr ""
+msgstr "Неуспешно свързване с външния екран."
 
 # Android/iOS
 msgid "Failed to download or install this add-on."

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "За Селестия"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Абс. зв.вел."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Добави фаворит"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Астероиди"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Атмосфери"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "АЕ"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Автори"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Фаворити"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Звезди"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Откажи"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Прихвани видео"
+
+# Mac
+msgid "Celestia"
+msgstr "Селестия"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Центрирай селекция\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Гони"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Кръг"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Градове"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Сенки на облаци"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Облаци"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Опашки на комети"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Комети"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Съзвездия"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Съзвездия на латински"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Дата"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Маркирани обекти"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Изтрий"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Продължителност"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Диамант"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Диск"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Екран"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Разстояние: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Стрелка надолу"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Продължителност"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "С планети"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Търсач на затъмнения"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Санки на затъмнеия"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr ", ред "
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Покажи звезди"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Покажи детайли"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Изпълнен квадрат"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Следвай"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Скорост на кадрите:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Мъгливи точки"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Галактики"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Галактики"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Покажи звезди"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr ""
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Тур"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr ""
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Раздели изгледа хоризонтално"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Инфо"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "км"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Етикет детайли"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Места на кацане"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Лява стрелка"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Местно време"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Местоположения"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Заключи"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Ниско"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Морета"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Маркери"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Средно"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Луни"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Луни"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Луни"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Име"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Мъглявини"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Нова папка…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Нищо"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Обекти"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Обсерватории"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "ОК"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Отворени купове"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL Инфо"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Орбити"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Планети"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Плюс"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Точки"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "радиус"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Резолюция"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Дясна стрелка"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Сенки на пръстени"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Оразмерени дискове"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Скриптове"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Търси"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Задай време…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Настройки"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Покажи осите на телата"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Покажи граници"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Покажи осите на кадрите"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Покажи звезди"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Покажи посока на Слънцето"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Покажи звезди"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Покажи вектора на скоростта"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Слънчева система"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Космически апарати"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Квадрат"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Звезди"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Синхронизирай Орбита"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Земни маси"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Ясно"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Време"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Триъгълник"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Тип"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Неизвестна грешка при отваряне на скрипта"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Стрелка нагоре"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Долини"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Празно"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr ""
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "Х"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -82,6 +82,14 @@ msgstr "Добави отметка"
 msgid "Add new…"
 msgstr "Добави нова…"
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "Добави/Извади забавянето на светлината"
@@ -190,6 +198,10 @@ msgstr "Обектът не може да се добави"
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Прихвани видео"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -380,6 +392,14 @@ msgstr "Покажи забавянето на светлината"
 msgid "Distance:"
 msgstr "Разстояние:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "Кликни два пъти за да отидеш до елемента"
@@ -395,6 +415,14 @@ msgstr "Надолу"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Стрелка надолу"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -447,6 +475,18 @@ msgstr "Грешка при зареждане на данните, връщан
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -653,6 +693,14 @@ msgstr "Информационен екран:"
 msgid "Information"
 msgstr "Информация"
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "Юлианова дата:"
@@ -841,6 +889,10 @@ msgstr "Няма отговор"
 # Android/iOS/Mac, Empty HUD display
 msgid "None"
 msgstr "Нищо"
+
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
 
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
@@ -1031,6 +1083,10 @@ msgstr "Референтни вектори"
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
 msgstr "Референтните вектори са видими само за текущия обект от слънчевата система."
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
+msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
@@ -1381,6 +1437,15 @@ msgstr "Вид"
 # Mac
 msgid "Unable to capture video"
 msgstr "Видеото не може да се прихване"
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
+msgstr ""
 
 # Android/iOS/Mac
 msgid "Unknown"

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -4,6 +4,7 @@
 # Translators:
 # Georgi Georgiev <georgiev_1994@abv.bg>, 2020
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
@@ -79,7 +80,7 @@ msgstr "Добави отметка"
 
 # iOS, Add a new item (bookmark)
 msgid "Add new…"
-msgstr "Добави нова..."
+msgstr "Добави нова…"
 
 # Mac
 msgid "Add/Subtract Light Travel Delay"
@@ -172,7 +173,7 @@ msgstr "c (светлинна скорост)"
 
 # Android/iOS, Calculating for eclipses
 msgid "Calculating…"
-msgstr "Изчисляване..."
+msgstr "Изчисляване…"
 
 # Android/iOS, Observer control
 msgid "Camera Control"
@@ -280,7 +281,7 @@ msgstr "Копирай URL"
 
 # Android, Copying default data from APK
 msgid "Copying data…"
-msgstr "Копиране на данни..."
+msgstr "Копиране на данни…"
 
 # Android/iOS/Mac, Location labels
 msgid "Crater"
@@ -444,6 +445,10 @@ msgstr "Екваториален радиус: %s"
 msgid "Error loading data, fallback to original configuration."
 msgstr "Грешка при зареждане на данните, връщане към началната конфигурация."
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr "Неуспешно стартиране на OpenGL."
@@ -542,7 +547,7 @@ msgstr "Общи"
 
 # Android/iOS
 msgid "Generating sharing link…"
-msgstr "Генериране на споделяща връзка..."
+msgstr "Генериране на споделяща връзка…"
 
 # Android/iOS/Mac
 msgid "Globulars"
@@ -558,7 +563,7 @@ msgstr "Отиди до обект"
 
 # Mac
 msgid "Go to Object…"
-msgstr "Отиди до обект..."
+msgstr "Отиди до обект…"
 
 # Mac, Go to selected object
 msgid "Go to Selection"
@@ -702,7 +707,7 @@ msgstr "Зареждането на Celestia е неуспешно…"
 # Android, Loading Celestia configuration
 #, c-format
 msgid "Loading configuration…"
-msgstr "Зареждане на конфигурация..."
+msgstr "Зареждане на конфигурация…"
 
 # Android/iOS, Celestia initialization, loading file
 #, c-format
@@ -899,7 +904,7 @@ msgstr "Информация за OpenGL"
 
 # Android
 msgid "Opening external file or URL…"
-msgstr "Отваряне на външен файл или URL..."
+msgstr "Отваряне на външен файл или URL…"
 
 # iOS
 msgid "Operation not permitted."
@@ -915,7 +920,7 @@ msgstr "Орбити"
 
 # Mac
 msgid "Organize Bookmarks…"
-msgstr "Организирай отметки..."
+msgstr "Организирай отметки…"
 
 # Mac, Other location labels
 msgid "Other"
@@ -988,7 +993,7 @@ msgstr "Предпочитания"
 
 # Mac, Settings
 msgid "Preferences…"
-msgstr "Предпочитания..."
+msgstr "Предпочитания…"
 
 # Mac, Quit Celestia
 msgid "Quit"
@@ -1097,7 +1102,7 @@ msgstr "Изпълни скрипта?"
 
 # Mac
 msgid "Run Script…"
-msgstr "Изпълни скрипта..."
+msgstr "Изпълни скрипта…"
 
 # Android/iOS/Mac, Star style
 msgid "Scaled Discs"
@@ -1141,7 +1146,7 @@ msgstr "Задай време"
 
 # Mac, Select simulation time
 msgid "Set Time…"
-msgstr "Задай време..."
+msgstr "Задай време…"
 
 # Android/iOS, Set simulation time to device
 msgid "Set to Current Time"
@@ -1410,7 +1415,7 @@ msgid "Up Arrow"
 msgstr "Стрелка нагоре"
 
 # Android/iOS, URL for Use Add-ons and Scripts wiki
-msgid "Използвани добавки и скриптове"
+msgid "Use Add-ons and Scripts"
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -110,6 +110,10 @@ msgstr "Алтернативни повърхности"
 msgid "Ambient Light"
 msgstr "Фонова светлина"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "и:"
@@ -476,6 +480,10 @@ msgstr "Грешка при зареждане на данните, връщан
 # Android, Exit Celestia
 msgid "Exit"
 msgstr "Изход"
+
+# iOS
+msgid "Failed to connect to the external screen."
+msgstr ""
 
 # Android/iOS
 msgid "Failed to download or install this add-on."

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
 "POT-Creation-Date: 2020-04-15 20:22+0800\n"
-"PO-Revision-Date: 2020-08-29 22:36+0200\n"
+"PO-Revision-Date: 2020-10-24 12:45+0200\n"
 "Last-Translator: Georgi Georgiev <georgiev_1994@abv.bg>\n"
 "Language-Team: Bulgarian <georgiev_1994@abv.bg>\n"
 "Language: bg\n"
@@ -84,11 +84,11 @@ msgstr "Добави нова…"
 
 # iOS
 msgid "Add-on directory does not exist."
-msgstr ""
+msgstr "Директорията за добавки не съществува."
 
 # Android/iOS
 msgid "Add-ons"
-msgstr ""
+msgstr "Добавки"
 
 # Mac
 msgid "Add/Subtract Light Travel Delay"
@@ -201,7 +201,7 @@ msgstr "Прихвани видео"
 
 # Android/iOS, Add-on categories
 msgid "Categories"
-msgstr ""
+msgstr "Категории"
 
 # Mac
 msgid "Celestia"
@@ -394,11 +394,11 @@ msgstr "Разстояние:"
 
 # Android/iOS, Prompt to ask to cancel downloading an add-on
 msgid "Do you want to cancel this task?"
-msgstr ""
+msgstr "Искате ли да отмените тази задача?"
 
 # Android/iOS
 msgid "Do you want to uninstall this add-on?"
-msgstr ""
+msgstr "Искате ли да деинсталирате тази добавка?"
 
 # Mac, In eclipse finder
 msgid "Double click on item to go"
@@ -418,11 +418,11 @@ msgstr "Стрелка надолу"
 
 # Android/iOS, Download button when the add-on is not downloaded
 msgid "DOWNLOAD"
-msgstr ""
+msgstr "ИЗТЕГЛИ"
 
 # Android/iOS, Download button when the add-on is being downloaded
 msgid "DOWNLOADING"
-msgstr ""
+msgstr "ИЗТЕГЛЯНЕ"
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -475,19 +475,19 @@ msgstr "Грешка при зареждане на данните, връщан
 
 # Android, Exit Celestia
 msgid "Exit"
-msgstr ""
+msgstr "Изход"
 
 # Android/iOS
 msgid "Failed to download or install this add-on."
-msgstr ""
+msgstr "Неуспешно изтегляне или инсталиране на добавката."
 
 # Android/iOS
 msgid "Failed to load add-on categories."
-msgstr ""
+msgstr "Неуспешно зареждане на категориите с добавки."
 
 # Android/iOS
 msgid "Failed to load add-ons."
-msgstr ""
+msgstr "Неуспешно зареждане на добавките."
 
 # Mac
 msgid "Failed to start OpenGL."
@@ -695,11 +695,11 @@ msgstr "Информация"
 
 # Android/iOS, Title for the list of installed add-ons
 msgid "Installed"
-msgstr ""
+msgstr "Инсталирани"
 
 # Android/iOS, Download button when the add-on is installed
 msgid "INSTALLED"
-msgstr ""
+msgstr "ИНСТАЛИРАНА"
 
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
@@ -892,7 +892,7 @@ msgstr "Нищо"
 
 # Android/iOS
 msgid "Note: restarting Celestia is needed to use any new installed add-on."
-msgstr ""
+msgstr "Забележка: рестартирайте Celestia за активация на новите инсталирани добавки."
 
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
@@ -1086,7 +1086,7 @@ msgstr "Референтните вектори са видими само за 
 
 # Android/iOS, Button to refresh this list
 msgid "Refresh"
-msgstr ""
+msgstr "Опресни"
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
@@ -1441,11 +1441,11 @@ msgstr "Видеото не може да се прихване"
 # Android, Custom config/data directory path have to be under a specific path
 #, c-format
 msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
-msgstr ""
+msgstr "Пътят не е разпознат, моля, изберете път в %s."
 
 # Android/iOS
 msgid "Unable to uninstall add-on."
-msgstr ""
+msgstr "Добавката не може да се деинсталира."
 
 # Android/iOS/Mac
 msgid "Unknown"
@@ -1481,7 +1481,7 @@ msgstr "Стрелка нагоре"
 
 # Android/iOS, URL for Use Add-ons and Scripts wiki
 msgid "Use Add-ons and Scripts"
-msgstr ""
+msgstr "Използвай добавки и скриптове"
 
 # Android/iOS/Mac
 msgid "UTC"

--- a/po3/bg.po
+++ b/po3/bg.po
@@ -1113,7 +1113,7 @@ msgstr "Скриптове"
 
 # Android/iOS, URL for Scripts and URLs wiki
 msgid "Scripts and URLs"
-msgstr ""
+msgstr "Скриптове и линкове"
 
 # Android/iOS
 msgid "Search"
@@ -1315,7 +1315,7 @@ msgstr "Резолюция на текстурите:"
 
 # Android/iOS, URL for Third Party Dependencies wiki
 msgid "Third Party Dependencies"
-msgstr ""
+msgstr "Зависимости от трети страни"
 
 # Android/iOS/Mac
 msgid "Time"
@@ -1410,7 +1410,7 @@ msgid "Up Arrow"
 msgstr "Стрелка нагоре"
 
 # Android/iOS, URL for Use Add-ons and Scripts wiki
-msgid "Use Add-ons and Scripts"
+msgid "Използвани добавки и скриптове"
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/celestia_ui.pot
+++ b/po3/celestia_ui.pot
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr ""
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr ""
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr ""
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr ""
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr ""
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr ""
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr ""
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr ""
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr ""
+
+# Mac
+msgid "Celestia"
+msgstr ""
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr ""
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr ""
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr ""
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr ""
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr ""
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr ""
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr ""
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr ""
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr ""
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr ""
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr ""
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr ""
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr ""
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr ""
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr ""
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr ""
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr ""
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr ""
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr ""
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr ""
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr ""
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr ""
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr ""
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr ""
+
+# Android/iOS
+msgid "Lock"
+msgstr ""
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr ""
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr ""
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr ""
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr ""
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr ""
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr ""
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr ""
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr ""
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr ""
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr ""
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr ""
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr ""
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr ""
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr ""
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr ""
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr ""
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Settings"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr ""
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr ""
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr ""
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr ""
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr ""
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr ""
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr ""
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr ""
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr ""
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr ""
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr ""
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr ""
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Verbose"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr ""
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/celestia_ui.pot
+++ b/po3/celestia_ui.pot
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/celestia_ui.pot
+++ b/po3/celestia_ui.pot
@@ -80,6 +80,14 @@ msgstr ""
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -187,6 +195,10 @@ msgstr ""
 
 # Mac, Record a video in Celestia
 msgid "Capture Video"
+msgstr ""
+
+# Android/iOS, Add-on categories
+msgid "Categories"
 msgstr ""
 
 # Mac
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr ""
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -392,6 +412,14 @@ msgstr ""
 
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
 msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr ""
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr ""
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/celestia_ui.pot
+++ b/po3/celestia_ui.pot
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/de.po
+++ b/po3/de.po
@@ -444,6 +444,10 @@ msgstr "Äquatorradius: %s"
 msgid "Error loading data, fallback to original configuration."
 msgstr "Fehler beim Laden der Daten, lade Originalkonfiguration."
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr "OpenGL konnte nicht gestartet werden."

--- a/po3/de.po
+++ b/po3/de.po
@@ -109,6 +109,10 @@ msgstr "Alternative Oberflächen"
 msgid "Ambient Light"
 msgstr "Umgebungslicht"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "bis:"
@@ -474,6 +478,10 @@ msgstr "Fehler beim Laden der Daten, lade Originalkonfiguration."
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/de.po
+++ b/po3/de.po
@@ -1,0 +1,1470 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: 2020-06-28 13:51+0200\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Olaf Senninger <olafsenninger@googlemail.com>\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.3.1\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr "%.2f Tage"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr "%.2f Stunden"
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr "%d km"
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr "%d m"
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 AE/s"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 km/s"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 Lj/s"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 km/s"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10c"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr "Über"
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Über Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. Helligkeit"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr "Hinzufügen"
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Lesezeichen hinzufügen"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr "Hinzufügen…"
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "Lichtlaufzeitverzögerung addieren/subtrahieren"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr "Erweitert"
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "Vorwärts"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr "Alternative Oberflächen"
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr "Umgebungslicht"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "bis:"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr "Kantenglättung"
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroiden"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosphären"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "AE"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autoren"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr "Automatische Helligkeit"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr "B: %d° %d′ %.2f″"
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "Zurück"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "Anfang"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "Im Zeitraum von:"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "Lesezeichenverwaltung"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Hellste Sterne"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "Alles nach vorne bringen"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr "Browser"
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (Lichtgeschwindigkeit)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr "Wird berechnet…"
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr "Kamerasteuerung"
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Abbrechen"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr "Objekt kann nicht hinzugefügt werden"
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Video aufzeichnen"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Celestia Browser"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Celestia Hilfe"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr "Zentrieren"
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Auswahl zentrieren"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr "Ändere Konfigurationsdatei"
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Verfolgen"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr "Konfigurationsdatei wählen"
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Kreis"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Städte"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Wolkenschatten"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Wolken"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Kometenschweife"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kometen"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr "Konfigurationsdatei"
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr "Änderungen treten nach Neustart in Kraft."
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr "Bestätigen und Neustart"
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr "Beschriftung Sternbilder"
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Sternbilder"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Lateinische Sternbildnamen"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr "Koordinaten:"
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "URL kopieren"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr "Kopiere Daten…"
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr "Krater"
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "Fadenkreuz"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr "Aktuelle Zeit"
+
+# Android/iOS
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr "Datenverzeichnis"
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr "Speicherort"
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Datum"
+
+# Android/iOS
+msgid "Date Format"
+msgstr "Datumsformat"
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr "Debugger"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr "DEK: %d° %d′ %.2f″"
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Deep-Sky-Objekte"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr "Standard"
+
+# Android/iOS
+msgid "Delete"
+msgstr "Löschen"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "Aktive Ansicht entfernen"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "Weitere Ansichten entfernen"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Beschreibung"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Raute"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "Richtung"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Kreis"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Anzeige"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "Lichtlaufzeitverzögerung zeigen"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Entfernung:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "Zur Anzeige Doppelklick auf Eintrag ausführen"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "Doppelklick auf Objekt zum Öffnen oder Control-Klick für Kontextmenü. Objekte an Position ziehen um diese zu reorganisieren."
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "Runter"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Pfeil nach unten"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "DSOs"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Dauer"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Zwergplaneten"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Eklipsen-Suche"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Eklipsen-Schatten"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptik"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr "Editieren"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr "Zeitraum bis"
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "Name von Planet oder Mond eingeben"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Äquatorial"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr "Äquatorradius: %s"
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr "Fehler beim Laden der Daten, lade Originalkonfiguration."
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr "OpenGL konnte nicht gestartet werden."
+
+# Mac
+msgid "Failed to start renderer."
+msgstr "Renderer konnte nicht gestartet werden."
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr "Schwächste Sterne"
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "Schneller"
+
+# Mac
+msgid "Fatal Error"
+msgstr "Kritischer Fehler"
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr "Favoriten"
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Besonderheiten"
+
+# Mac, File menu
+msgid "File"
+msgstr "Datei"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Gefülltes Quadrat"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "Suchen"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "Finde Verfinsterung von:"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Umkreisung"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr "Format:"
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "Vorwärts"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Bildrate:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Verschwommene Punkte"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktisch"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxien"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr "Galaxien (balkenspiralförmig)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr "Galaxien (elliptisch)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr "Galaxien (unregelmässig)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr "Galaxien (spiralförmig)"
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr "Galaxie Helligkeit"
+
+# Mac, In settings
+msgid "General"
+msgstr "Allgemein"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr "Teilbaren Link erzeugen…"
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Kugelsternhaufen"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr "Los"
+
+# Mac
+msgid "Go to Object"
+msgstr "Gehe zu Objekt"
+
+# Mac
+msgid "Go to Object…"
+msgstr "Gehe zu Objekt…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "Gehe zur Auswahl"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Koordinatennetze"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Hilfslinien"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr "Atmosphäre vorhanden"
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr "Hat Ringe"
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr "Hilfe"
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "Celestia verbergen"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "Andere Verbergen"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr "HiDPI"
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Hoch"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "Verlauf"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "Home (Sol)"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+"Im Kamera Modus ziehen, um Felder oder Ansicht zu bewegen.\n"
+"\n"
+"Zwei-Finger-Pinch, um Felder und Ansichten zu vergrößern oder zu verkleinern."
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+"Im Objekt Modus ziehen, um Felder oder Ansicht zu rotieren.\n"
+"\n"
+"Zwei-Finger-Pinch, um Objekte zu vergrößern oder zu verkleinern."
+
+# Mac, HUD display
+msgid "Info"
+msgstr "Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr "Info-Anzeige"
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "Info-Anzeige:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr "Information"
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "Julianisches Datum:"
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr "L: %d° %d′ %.2f″"
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr "Beschriftungsdichte"
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Beschriftungen"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Landeplätze"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "Breitengrad"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "Links"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Pfeil nach links"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr "Länge eines Tages: %s"
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr "Laden von Celestia fehlgeschlagen…"
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr "Lade Konfiguration…"
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr "Lädt: %s"
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Lokalzeit"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "Standort"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr "Merkmale auswählen"
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Merkmale"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Verbinden"
+
+# Mac
+msgid "Lock Phase"
+msgstr "Verbinden"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr "Langes Drücken der Schritt-Buttons ändert die Ausrichtung."
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "Längengrad"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "Zurückblicken"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Gering"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "Markieren"
+
+# Mac
+msgid "Markers"
+msgstr "Markierungen"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr "Masse"
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Mittel"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "Minimieren"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr "Minimalgröße der gekennzeichnete Besonderheiten"
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Kleine Monde"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Mons"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Monde"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "Nähern"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "Entfernen"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Name"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr "Naheliegenste Sterne"
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebel"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Neuer Ordner"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr "Nachtlichter"
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr "Keine Daten"
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr "Kein Objektname eingegeben"
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr "Keine Übersicht verfügbar."
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr "Keine Rückmeldung"
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Keine Information"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"Anmerkung:\n"
+"Festlegen eines großen Zeitintervalls kann eine lange Suchzeit und eine sehr große Anzahl an Resultaten zur Folge haben."
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr "Objekt"
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr "Objektbeschriftung"
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr "Objekt nicht gefunden"
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "Objekt:"
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objekte"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorien"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr "Bedeckender Himmelskörper"
+
+# Android/iOS
+msgid "Official Website"
+msgstr "Offizielle Webseite"
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Offene Sternhaufen"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr "URL öffnen?"
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Web URL öffnen"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL-Informationen"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr "Öffnen externer Daten oder URL…"
+
+# iOS
+msgid "Operation not permitted."
+msgstr "Vorgang nicht erlaubt."
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "Synchrone Umlaufbahn"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbit-Linien"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "Lesezeichen organisieren…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "Sonstige"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr "Weitere"
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "URL einfügen"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "Pause"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr "Nicken"
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr "Planetenringe"
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planeten"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr "Bitte die Richtigkeit des Objektnamens überprüfen."
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr "Bitte Objekt auswählen."
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr "Bitte eine Beschreibung des Inhalts eingeben."
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr "Bitte einen neuen Namen eingeben."
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr "Bitte einen Objektnamen eingeben."
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr "Bitte Celestia neustarten"
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Punkte"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr "Einstellungen"
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "Einstellungen…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Beenden"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "Celestia beenden"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr "RA: %dh %dm %.2fs"
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "Radien"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr "Radius"
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "Echtzeit"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "Verdunkelter Himmelskörper"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr "Referenzvektoren"
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr "Referenzvektoren sind nur für das ausgewählte Solarsystem-Objekt sichtbar."
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr "Umbenennen"
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr "Renderinformation"
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr "Rendereinstellungen"
+
+# Mac, In settings
+msgid "Renderer"
+msgstr "Renderer"
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr "Erlaubnisabfrage abgeschlossen"
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "Script wiederholen"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr "Standardeinstellung wiederherstellen"
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Auflösung:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "Rückwärts"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr "Richtung umkehren"
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "Rechts"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Pfeil nach rechts"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Ringschatten"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr "Rollen"
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr "Demo starten"
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr "Skript starten?"
+
+# Mac
+msgid "Run Script…"
+msgstr "Starte Skript…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Skalierte Kreise"
+
+# Android/iOS
+msgid "Script Control"
+msgstr "Skriptsteuerung"
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Skripte"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Suche"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr "Auswahl"
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "Wähle nächste Ansicht"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr "Zeit einstellen"
+
+# Mac, System menu
+msgid "Services"
+msgstr "Services"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Zeit einstellen"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "Zeit einstellen…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr "Aktuelle Zeit einstellen"
+
+# Android/iOS
+msgid "Settings"
+msgstr "Einstellungen"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr "Teilen"
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "Alles zeigen"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Körperachsen anzeigen"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Sternbildgrenzen anzeigen"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "Sternbildbezeichnung anzeigen"
+
+# Mac
+msgid "Show Constellations"
+msgstr "Sternbilder anzeigen"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Koordinatenachsen anzeigen"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "Info anzeigen"
+
+# Mac
+msgid "Show Locations"
+msgstr "Merkmale anzeigen"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "Markierungen anzeigen"
+
+# Mac
+msgid "Show Orbits"
+msgstr "Umlaufbahnen anzeigen"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Koordinatennetz des Planeten anzeigen"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Richtung zur Sonne anzeigen"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Tag/Nacht-Grenze anzeigen"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Geschwindigkeitsvektor anzeigen"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr "Umlaufzeit: %s"
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr "Größe: %s"
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "Langsamer"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr "Linien glätten"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sonnensystem"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Raumfahrzeuge"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "Horizontal teilen"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "Vertikal teilen"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Quadrat"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr "Sterndarstellung"
+
+# Mac
+msgid "Star Style:"
+msgstr "Sterndarstellung:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Sterne"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr "Sterne mit Planeten"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr "Zeitraum von"
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "Stop"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr "Untersystem"
+
+# Android/iOS
+msgid "Support Forum"
+msgstr "Support-Forum"
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr "In Kameramodus umgeschaltet"
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr "In Objektmodus umgeschaltet"
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Orbit synchronisieren"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr "Modusbutton in Sidebar drücken, um zwischen Objekt- und Kameramodus umzuschalten."
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Knapp"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr "Texturauflösung"
+
+# Mac
+msgid "Texture Resolution:"
+msgstr "Texturauflösung:"
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Zeit"
+
+# Android/iOS
+msgid "Time Control"
+msgstr "Zeit-Einstellungen"
+
+# Android/iOS
+msgid "Time Zone"
+msgstr "Zeitzone"
+
+# Mac
+msgid "Time Zone:"
+msgstr "Zeitzone:"
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "Zeit:"
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr "Konsolenanzeige zu-/abschalten"
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr "FPS-Anzeige zu-/abschalten"
+
+# Mac, Track an object
+msgid "Track"
+msgstr "Folgen"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "Auswahl folgen"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr "Übersetzer"
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "Schub"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Dreieck"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr "Anleitung"
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Typ"
+
+# Mac
+msgid "Unable to capture video"
+msgstr "Videoaufnahme nicht möglich"
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Unbekannt"
+
+# iOS
+msgid "Unknown error"
+msgstr "Unbekannter Fehler"
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "Markierung aufheben"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr "Alle Markierungen aufheben"
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr "Falsches Datum-/Zeitformat."
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr "Ohne Titel"
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "Rauf"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Pfeil nach oben"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC-Versatz"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "Geschwindigkeit"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Ausführlich"
+
+# Android/iOS
+msgid "Version"
+msgstr "Version"
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "Ansichten"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkane"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr "Web-Info"
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr "Willkommen bei Celestia"
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "Fenster"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr "Gieren"
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "Zoom"

--- a/po3/de.po
+++ b/po3/de.po
@@ -81,6 +81,14 @@ msgstr "Lesezeichen hinzufügen"
 msgid "Add new…"
 msgstr "Hinzufügen…"
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "Lichtlaufzeitverzögerung addieren/subtrahieren"
@@ -189,6 +197,10 @@ msgstr "Objekt kann nicht hinzugefügt werden"
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Video aufzeichnen"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -379,6 +391,14 @@ msgstr "Lichtlaufzeitverzögerung zeigen"
 msgid "Distance:"
 msgstr "Entfernung:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "Zur Anzeige Doppelklick auf Eintrag ausführen"
@@ -394,6 +414,14 @@ msgstr "Runter"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Pfeil nach unten"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -446,6 +474,18 @@ msgstr "Fehler beim Laden der Daten, lade Originalkonfiguration."
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -652,6 +692,14 @@ msgstr "Info-Anzeige:"
 msgid "Information"
 msgstr "Information"
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "Julianisches Datum:"
@@ -840,6 +888,10 @@ msgstr "Keine Rückmeldung"
 # Android/iOS/Mac, Empty HUD display
 msgid "None"
 msgstr "Keine Information"
+
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
 
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
@@ -1030,6 +1082,10 @@ msgstr "Referenzvektoren"
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
 msgstr "Referenzvektoren sind nur für das ausgewählte Solarsystem-Objekt sichtbar."
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
+msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
@@ -1380,6 +1436,15 @@ msgstr "Typ"
 # Mac
 msgid "Unable to capture video"
 msgstr "Videoaufnahme nicht möglich"
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
+msgstr ""
 
 # Android/iOS/Mac
 msgid "Unknown"

--- a/po3/el.po
+++ b/po3/el.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Περί Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Απόλ. Μέγεθος "
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Προσθήκη Σελιδοδείκτη"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Αστεροειδείς"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Ατμόσφαιρα"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "αμ"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Συγγραφείς"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Σελιδοδείκτες "
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Άστρα"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Ακύρωση"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Σύλληψη Βίντεο"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Κεντράρισμα Επιλογής\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Καταδίωξη"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Κύκλος"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Πόλεις"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Σκιές από Σύννεφα"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Σύννεφα"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Ουρές Κομητών"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Κομήτες"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Αστερισμοί"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Λατινικοί Αστερισμοί"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Ημερομηνία"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " αντικείμενα βαθέως ουρανού"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Διαγραφή"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Διάρκεια"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Ρόμβος"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Δίσκος"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Προβολή"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Απόσταση: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Κάτω Βέλος"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Διάρκεια"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Νάνοι Πλανήτες"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Εύρεση Έκλειψης "
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Σκιές έκλειψης"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ελλειπτικά"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Ισημερινή"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Εμφάνιση Δυνατοτήτων"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Τετράγωνο με Γέμισμα"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Παρακολούθηση"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Ρυθμός καρέ:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Ασαφή Σημεία"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Γαλαξιακό"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Γαλαξίες"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Σφαιροειδή"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Πλέγματα"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Ταξιδιωτικός Οδηγός"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Υψηλό"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Οριζόντια"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Πληροφορίες"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "χμ"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Ετικέτες  Δυνατοτήτων"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Τοποθεσίες Προσγείωσης "
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Αριστερό Βέλος"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Τοπική ώρα"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Τοποθεσίες"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Κλείδωμα"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Χαμηλό"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Θάλασσες"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Δείκτες"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Μεσαίο"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Μικροί Δορυφόροι"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Όρη"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Δορυφόροι"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Όνομα"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Νεφελώματα"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Νέος Φάκελος… "
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Κανένα"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Αντικείμενα"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Αστεροσκοπεία"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "Εντάξει"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Ανοιχτά Σμήνη "
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Πληροφορίες OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Τροχιές"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Πλάνητες"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Πλεον"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Σημεία"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "ακτίνα"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Ανάλυση:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Δεξί Βέλος"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Σκιές δακτυλίων"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Κλιμακούμενοι &Δίσκοι"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Σενάρια"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Αναζήτηση"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Καθορισμός Χρόνου…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Ρυθμίσεις"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Εμφάνιση Αξόνων Σωμάτων"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Εμφάνιση Συνόρων"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Εμφάνιση Αξόνων Καρέ"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Εμφάνιση Πλέγματος Πλανητογραφίας"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Εμφάνιση Κατεύθυνσης Ήλιου"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Εμφάνιση Terminator"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Ηλιακό Σύστημα"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Διαστημόπλοια"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Τετράγωνο"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Άστρα"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Συγχρονισμός Τροχιάς"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Γη"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Περιεκτικός "
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Χρόνος "
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Τρίγωνο"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Είδος"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Πάνω Βέλος"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Αντιστάθμιση UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Κοιλάδες"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Διεξοδικός"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Ηφαίστεια"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/el.po
+++ b/po3/el.po
@@ -80,6 +80,14 @@ msgstr "Προσθήκη Σελιδοδείκτη"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Σύλληψη Βίντεο"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Απόσταση: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Κάτω Βέλος"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Κανένα"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Είδος"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/el.po
+++ b/po3/el.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/el.po
+++ b/po3/el.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/es.po
+++ b/po3/es.po
@@ -80,6 +80,14 @@ msgstr "Añadir señalador"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "Agregar/sustraer la demora-luz"
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Capturar video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr "Mostrar demora-luz"
 msgid "Distance:"
 msgstr "Distancia: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "Doble-clic sobre un eclipse para verlo"
@@ -393,6 +413,14 @@ msgstr "Abajo"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Flecha abajo"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr "Info Display:"
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "Julian Date:"
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Ninguna"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1022,6 +1074,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1372,6 +1428,15 @@ msgstr "Tipo"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/es.po
+++ b/po3/es.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "y el :"
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/es.po
+++ b/po3/es.po
@@ -1,0 +1,1463 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 AU/s"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 km/s"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 ly/s"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 km/s"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10c"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Acerca de Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag. absoluta"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Añadir señalador"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "Agregar/sustraer la demora-luz"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "Hacia adelente"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "y el :"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroides"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmósferas"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "UA"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autores:"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr " Auto Mag"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "Anterior"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "Comienzo"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "Entre el :"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "Bookmark Organizer"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Señaladores"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Estrellas"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "Todo al primer plano"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (velocidad de la luz)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Cancelar"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Capturar video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Navegador de Celestia"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Ayuda de Celestia"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Centrar selección\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Perseguir"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Círculo"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Ciudades"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Sombras de nubes"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nubes"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Colas de cometas"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Cometas"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Constelaciones"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Constelaciones en latín"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "Copiar URL"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "Crosshair"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Fecha"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " objetos de espacio profundo"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Borrar"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "Suprimir la vista activa"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "Suprimir las otras vistas"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Duración"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Diamante"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "Dirección"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disco"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Pantalla"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "Mostrar demora-luz"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distancia: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "Doble-clic sobre un eclipse para verlo"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "Abajo"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Flecha abajo"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "Objetos de cielo profundo"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Duración"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planetas enanos"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Sombras de eclipses"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Eclíptica"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "Nombre de un planeta o de una luna"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Ecuatorial"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "Acelerar"
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Mostrar items"
+
+# Mac, File menu
+msgid "File"
+msgstr "Archivo"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Cuadrado lleno"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "Buscar"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "Buscar eclipse para :"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Seguir"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "Siguiente"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Cuadros por segundo: "
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Puntos difusos"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galáctica"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxias"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr "General"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Cúmulos globulares"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr "Ir a objeto"
+
+# Mac
+msgid "Go to Object…"
+msgstr "Ir a objeto…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "Ir a la selección"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Grillas"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Guía"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "Ocultar Celestia"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "Ocultar los demás"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Alto"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "Historial"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "Origen (Sol)"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Información"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "Info Display:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "Julian Date:"
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Etiquetar"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Sitios de aterrizaje"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "Latitude"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "Izquierda"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Flecha izquierda"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Hora local"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "Navegación"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Ubicaciones"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Trabar"
+
+# Mac
+msgid "Lock Phase"
+msgstr "Fijar fase"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "Longitude"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "Mirar hacia atrás"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Baja"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mares"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "Mark"
+
+# Mac
+msgid "Markers"
+msgstr "Marcadores"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Media"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "Minimizar"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Satélites menores"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Montes"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Satélites"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "Acercarse              home"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "Apartarse                 end"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nombre"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulosas"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Nueva carpeta…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Ninguna"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"Nota:\n"
+"Especificar un lapso de tiempo demasiado grande puede generar un tiempo de búsqueda muy largo y una lista de resultados muy larga…"
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "Object:"
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objetos"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorios"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Cúmulos abiertos"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Open Web URL"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Información OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "Orbitar en sincronía"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Órbitas"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "Organize Bookmarks…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "Otros"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "Pegar URL"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "Pause"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planetas"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Suma"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Puntos"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "Preferencias…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "Salir de Celestia"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radios"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "Tiempo real"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "Receiver"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "Reejecutar script"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Resolución: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "Hacia atrás"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "Derecha"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Flecha derecha"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Sombras de anillos"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr "Ejecutar script…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Discos a escala"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Buscar"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "Seleccionar vista siguiente"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr "Servicios"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Establecer fecha y hora…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "Ajustar tiempo…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Preferencias"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "Mostrar todo"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Mostrar ejes del cuerpo"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Mostrar límites"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "Show Constellation Labels"
+
+# Mac
+msgid "Show Constellations"
+msgstr "Show Constellations"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Mostrar ejes del marco"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "Información"
+
+# Mac
+msgid "Show Locations"
+msgstr "Show Locations"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "Show Markers"
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Mostrar grilla planetaria"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Mostrar dirección al Sol"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Mostrar terminador"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Mostrar vector velocidad"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "Descelerar"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr " Smooth Lines"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sistema Solar"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Naves espaciales"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "Dividir horizontalmente"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "Dividir verticalmente"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Cuadrado"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr "Star Style:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Estrellas"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "Parar"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Órbita sincrónica"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Tierras"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Sucinta"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Tiempo"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "Time:"
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr "Mantener centrado (Traquear)"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "Mantener selección centrada (Traquear)"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "Viajar"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triángulo"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tipo"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Error desconocido abriendo script"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "Unmark"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "Arriba"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Flecha arriba"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Corrimiento UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Valles"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "Velocidad"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Completa"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "Vistas"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Volcanes"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "Ventana"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "Zoom"

--- a/po3/es.po
+++ b/po3/es.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/fr.po
+++ b/po3/fr.po
@@ -80,6 +80,14 @@ msgstr "Ajouter un signet"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "Ajouter/soustraire le délai de la vitesse de la lumière"
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Acquisition Vidéo"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr "Afficher le délai de la vitesse de la lumière"
 msgid "Distance:"
 msgstr ""
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "Double-cliquer sur une date pour voir l'éclipse"
@@ -393,6 +413,14 @@ msgstr "Bas"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Flèche vers le bas"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr "Info Display:"
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "Julian Date:"
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Aucun"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1022,6 +1074,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1372,6 +1428,15 @@ msgstr "Type"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/fr.po
+++ b/po3/fr.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/fr.po
+++ b/po3/fr.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "et le :"
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/fr.po
+++ b/po3/fr.po
@@ -1,0 +1,1463 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 AU/s"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 km/s"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 ly/s"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 km/s"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10c"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "À propos de Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag. abs."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Ajouter un signet"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "Ajouter/soustraire le délai de la vitesse de la lumière"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "En avant"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "et le :"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Astéroïdes"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosphères"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "ua"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Auteurs"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr " Auto Mag"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "En arrière"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "Début"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "Entre le :"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "Bookmark Organizer"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "&Signets"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr ""
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "Tout ramener au premier plan"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (vitesse de la lumière)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Annuler"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Acquisition Vidéo"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Navigateur de Celestia"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Aide de Celestia"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr ""
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Pourchasser"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Cercle"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Villes"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Ombres des nuages"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nuages"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Queues des comètes"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Comètes"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Constellations"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Constellations en latin"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "Copier l'URL"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "Crosshair"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Date"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr ""
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Supprimer"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "Supprimer la vue active"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "Supprimer les autres vues"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr ""
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Losange"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "Direction"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disque"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr ""
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "Afficher le délai de la vitesse de la lumière"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "Double-cliquer sur une date pour voir l'éclipse"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "Bas"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Flèche vers le bas"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "Objets de ciel profond"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Durée"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planètes naines"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Découvreur d’éclipses"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Ombres des éclipses"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Écliptique"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "Nom d'une planète ou d'une lune"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Équatoriale"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "Accélérer"
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr ""
+
+# Mac, File menu
+msgid "File"
+msgstr "Fichier"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Carré plein"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "Chercher"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "Rechercher des éclipses pour :"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Suivre"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "En avant"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Vitesse d’affichage : "
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galactique"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxies"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr "General"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Amas globulaires"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr "Aller à l'objet"
+
+# Mac
+msgid "Go to Object…"
+msgstr "Aller à l'objet…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "Aller à la sélection"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Grilles"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "Masquer Celestia"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "Masquer les autres"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Haute"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "Historique"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "Origine (Soleil)"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontale"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr ""
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "Info Display:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "Julian Date:"
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Sites d'atterrissage"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "Latitude"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "Gauche"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Flèche vers la gauche"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Heure locale"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "Navigation"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Points de repère"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Bloquer"
+
+# Mac
+msgid "Lock Phase"
+msgstr "Contraindre l'orientation"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "Longitude"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "Regarder en arrière"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Basse"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "Mark"
+
+# Mac
+msgid "Markers"
+msgstr "Marqueurs"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Moyenne"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "Minimiser"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Lunes mineures"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Mons"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Lunes"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "Se rapprocher        home"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "S'éloigner                 end"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nom"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nébuleuses"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Aucun"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"Note:\n"
+"Spécifier un intervalle de temps trop grand peut générer un temps de recherche très long et une liste de résultats très longue…"
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "Object:"
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objets"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatoires"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Amas ouverts"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Open Web URL"
+
+# Mac
+msgid "OpenGL Info"
+msgstr ""
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "Orbite synchronisé"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbites"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "Organize Bookmarks…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "Autres"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "Coller l'URL"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "Pause"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planètes"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr ""
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "Préférences…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "Quitter Celestia"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "rayons"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "Temps réel"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "Receiver"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "Re-lancer un script"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr ""
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "En arrière"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "Droite"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Flèche vers la droite"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Ombres des anneaux"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr "Lancer un script…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr ""
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr ""
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "Sélectionner la vue suivante"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr "Services"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr ""
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "Régler le temps…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Configuration"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "Tout afficher"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Afficher les axes de l’objet"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Afficher les limites"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "Show Constellation Labels"
+
+# Mac
+msgid "Show Constellations"
+msgstr "Show Constellations"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Afficher les axes du repère"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "Informations"
+
+# Mac
+msgid "Show Locations"
+msgstr "Show Locations"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "Show Markers"
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Afficher la grille planétographique"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Afficher la direction du Soleil"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Afficher le terminateur"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Afficher le vecteur vitesse"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "Ralentir"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr " Smooth Lines"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Système solaire"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Astronefs"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "Diviser horizontalement"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "Diviser verticalement "
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Carré"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr "Star Style:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Étoiles"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "Arrêter"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Orbite synchrone"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Concis"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Temps"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "Time:"
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr "Maintenir la sélection centrée (Pister)"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "Maintenir la sélection centrée (Pister)"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "Déplacement"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triangle"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Type"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr ""
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "Unmark"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "Haut"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Flèche vers le haut"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Décalage UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "Vitesse"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Complet"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "Vues"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Volcans"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "Fenêtre"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "Zoom"

--- a/po3/gl.po
+++ b/po3/gl.po
@@ -80,6 +80,14 @@ msgstr "Engadir Marcador"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Capturar Ví­deo"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Distancia: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Frecha Abaixo"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Ningún"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Tipo"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/gl.po
+++ b/po3/gl.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/gl.po
+++ b/po3/gl.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Acerca de Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag. abs."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Engadir Marcador"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroides"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosferas"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "ua"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autores"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "A máis brillante"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Cancelar"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Capturar Ví­deo"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Centrase sobre a Selección\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Perseguir"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Círculo"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Cidades"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Sombras das Nubes"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nubes"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Colas dos Cometas "
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Cometas"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Constelacións"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Constelacións en Latín"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Data"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " obxecto do espazo profundo"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Borrar"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Duración"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Diamante"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disco"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Pantalla"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distancia: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Frecha Abaixo"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Duración"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planetas Ananos"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Sombras dos Eclipses "
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Eclíptica"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Ecuatorial"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Amosa-las Características"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Cadrado Recheado"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Seguir"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Taxa de fotogramas:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Puntos Di&fusos"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galáctica"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxias"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Cúmulos Globulares"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Grella"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Guía do Tour"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Alta"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Características dos Nomes"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Lugares de Aterraxe"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Frecha Esquerda"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Hora Local"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Lugares"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Bloquear"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Baixa"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Marcadores"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Medio"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Lúas Menores"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Lúas"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Lúas"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nome"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulosas"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Novo Cartafol…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Ningún"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr " obxecto do espazo profundo"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorios"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Cúmulos Abertos"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Información OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Órbitas"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planetas"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Puntos"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radios"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Resolución:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Frecha Dereita"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Sombras dos Aneis"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "&Discos a Escala"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Criterio para a Procura de Estelar"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Escolle-la Hora…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Preferencias"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Amosa-los Eixos do Corpo"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Amosa-los Bordes das Constelacións"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Amosa-los Eixos do Marco"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Amosa-la Grella Planetaria"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Amosa-la Dirección do Sol"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Amosa-lo Terminador"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Amosa-lo Vector da Velocidade"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sistema Solar"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Sondas Espaciais"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Cadrado"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Estrelas"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Órbita Sinc"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Reducida"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "&Hora"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triángulo"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tipo"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Erro descoñecido ó abri-lo script"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Frecha Arriba"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Ver en UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Completa"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Volcáns"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/gl.po
+++ b/po3/gl.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/hu.po
+++ b/po3/hu.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Celestia névjegye"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Absz. magn."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Könyvjelző hozzáadása"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Kisbolygók"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Légkör"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "CSE"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Szerzők"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Könyvjelzők"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Legfényesebb"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Vissza"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Video felvétele"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Kijelölt égitest középre\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Követés"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Kör"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Városok"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Felhőárnyékok"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Felhők"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Üstököscsóvák"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Üstökösök"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Csillagképek"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Csillagképek neve latinul"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Dátum"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Mélyég objektumok"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Törlés"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Időtartam"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Gyémánt"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Korong"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Megjelenítés"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Távolság: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Lefelé nyíl"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Időtartam"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Törpe bolygók"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Fogyatkozás-kereső"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Fogyatkozás-árnyékok"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptikus"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Egyenlítői"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Tereptárgyak mutatása"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Teli négyzet"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Követ"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Képkocka/másodperc: "
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Elmosódott pontok"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktikus"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxisok"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Gömbhalmazok"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Rácsok"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Idegenvezetés"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Nagy"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Nézet függőleges felosztása"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Adatok"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Tereptárgyak címkéi"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Leszállóhelyek"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Balra nyíl"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Helyi idő"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Helyek"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Rögzít"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Alacsony"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Tenger"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Jelölők"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Közepes "
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Kis holdak"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Hegyek"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Holdak"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Név"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulák"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Új mappa…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Semmi"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Égitestek"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Csillagvizsgálók"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Nyílt galaxishalmazok"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL adatok"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Pályák"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Bolygók"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plusz"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Pontok"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quitó"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radii"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Felbontás:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Jobbra nyíl"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Gyűrűárnyékok"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Méretarányos korongok"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Szkriptek"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Keresés"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Idő beállítása…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Beállítások"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Objektumok tengelyének mutatása"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Határok mutatása"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Váz tegelyeinek mutatása"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Planetáris háló mutatása"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Nap irányának mutatása"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Lezáró mutatása"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Sebességvektor mutatása"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Naprendszer"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Űrhajók"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Négyzet"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Csillagok"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Pálya szinkr."
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Föld"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Tömör"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Idő"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Háromszög"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Típus"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Ismeretlen hiba a szkript megnyitásakor"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Felfelé nyíl"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC eltérés"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Völgy"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Bőséges"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkánok"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/hu.po
+++ b/po3/hu.po
@@ -80,6 +80,14 @@ msgstr "Könyvjelző hozzáadása"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Video felvétele"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Távolság: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Lefelé nyíl"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Semmi"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Típus"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/hu.po
+++ b/po3/hu.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/hu.po
+++ b/po3/hu.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/it.po
+++ b/po3/it.po
@@ -80,6 +80,14 @@ msgstr "Aggiungi segnalibro"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Cattura video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Distanza: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Freccia giù"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Nessuno"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Tipo"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/it.po
+++ b/po3/it.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/it.po
+++ b/po3/it.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/it.po
+++ b/po3/it.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "A proposito di Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag. ass."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Aggiungi segnalibro"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroidi"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfere"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "ua"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autori"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Segnalibri"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Più brillanti"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Annulla"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Cattura video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Centra la selezione (&C)\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Insegui"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Cerchio"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Città"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Ombre delle nubi"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nubi"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Code delle comete"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Comete"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Costellazioni"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Costellazioni in latino"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Data"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " oggetti dello spazio profondo"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Cancella"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Durata"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Losanga"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disco"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Display"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distanza: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Freccia giù"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Durata"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Pianeti nani"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Cercatore di eclissi"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Ombre delle eclissi"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Eclittica"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Equatoriale"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Mostra le caratteristiche"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Quadrato pieno"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Segui"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Fotogrammi/secondo:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Punti sfocati (&f)"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galattico"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galassie"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Ammassi globulari"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Griglie"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Visita guidata"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Alta"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Orizzontale"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "Informazioni (&I)"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "Km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Etichetta le caratteristiche"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Zone d'atterraggio"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Freccia sinistra"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Ora locale"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Luoghi"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Blocca"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Bassa"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mari"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Marcatori"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Media"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Lune minori"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Monti"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Lune"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nome"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulose"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Nuova cartella…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Nessuno"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Oggetti"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Osservatori"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Ammassi aperti"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Informazioni su OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbite"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Pianeti"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Più"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Punti (&P)"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "raggi"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Risoluzione:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Freccia destra"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Ombre degli anelli"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Dischi in scala (&D)"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Cerca"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Imposta l'ora…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Impostazioni"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Mostra gli assi dei Corpi"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Mostra i confini"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Mostra gli assi dei bordi"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Mostra la griglia planetografica"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Mostra la direzione del Sole"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Mostra il terminatore"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Mostra il vettore velocità"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sistema solare"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Veicoli Spaziali"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Quadrato"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Stelle"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Sincronizza l'orbita"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terre"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Conciso"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Tempo"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triangolo"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tipo"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Errore sconosciuto in apertura dello script"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Freccia su"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Differenza tempo civile"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Valli"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Dettagliato"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulcani"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/ja.po
+++ b/po3/ja.po
@@ -109,6 +109,10 @@ msgstr "テククチャ選択"
 msgid "Ambient Light"
 msgstr "周辺光"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "終了:"
@@ -474,6 +478,10 @@ msgstr "データのロードでエラーがありました。オリジナルの
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/ja.po
+++ b/po3/ja.po
@@ -81,6 +81,14 @@ msgstr "ブックマークに追加"
 msgid "Add new…"
 msgstr "新規追加…"
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "光速による遅れを考慮して表示"
@@ -189,6 +197,10 @@ msgstr "天体を追加できません"
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "動画キャプチャ"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -379,6 +391,14 @@ msgstr "光速到達時間を表示"
 msgid "Distance:"
 msgstr "距離: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "項目をダブルクリックで移動"
@@ -394,6 +414,14 @@ msgstr "伏せる"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "下矢印(↓)"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -446,6 +474,18 @@ msgstr "データのロードでエラーがありました。オリジナルの
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -652,6 +692,14 @@ msgstr "天体情報表示:"
 msgid "Information"
 msgstr "情報"
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "ユリウス日:"
@@ -840,6 +888,10 @@ msgstr "応答がありません"
 # Android/iOS/Mac, Empty HUD display
 msgid "None"
 msgstr "無し"
+
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
 
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
@@ -1030,6 +1082,10 @@ msgstr "参照ベクトル"
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
 msgstr "参照ベクトルは、現在選択されている太陽系の天体に対してのみ表示されます。"
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
+msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
@@ -1380,6 +1436,15 @@ msgstr "スペクトル型"
 # Mac
 msgid "Unable to capture video"
 msgstr "ビデオをキャプチャーできません"
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
+msgstr ""
 
 # Android/iOS/Mac
 msgid "Unknown"

--- a/po3/ja.po
+++ b/po3/ja.po
@@ -1,0 +1,1470 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: 2020-07-05 20:29+0900\n"
+"Last-Translator: Sui Ota <aqua@aqsp.net>\n"
+"Language-Team: \n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3.1\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr "%.2f 日"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr "%.2f 時間"
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr "%d km"
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr "%d m"
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 天文単位/s"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 km/s"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 光年/s"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 km/s"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "光速の10倍"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr "Celestiaについて"
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Celestiaについて"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "絶対等級"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr "追加"
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "ブックマークに追加"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr "新規追加…"
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "光速による遅れを考慮して表示"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr "高度な設定"
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "画面中央へ進行"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr "テククチャ選択"
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr "周辺光"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "終了:"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr "アンチエイリアシング"
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "小惑星"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "大気"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "天文単位"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "著者"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr "自動限界等級調整"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr "銀経: %d° %d′ %.2f″"
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "前の状態へ"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "開始時刻"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "開始:"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "ブックマークの編集"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "ブックマーク"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "明るい恒星"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "すべてを前面に表示"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr "天体ブラウザ"
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "光速"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr "計算しています…"
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr "カメラコントロール"
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "キャンセル"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr "天体を追加できません"
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "動画キャプチャ"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Celestia天体ブラウザ"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Celestiaヘルプ(Wikibooks, 英語)"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr "画面中央"
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "選択した天体を画面中央へ"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr "設定ファイルを変更…"
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "公転同期"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr "設定ファイルを選択"
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "円(○)"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "都市"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "雲の影"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "雲"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "彗星の尾"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "彗星"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr "設定ファイル"
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr "設定は再起動後に有効になります。"
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr "適用して再起動"
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr "星座名"
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "星座"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "星座名ラテン語表示"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr "座標:"
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "URLをコピー"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr "データをコピーしています…"
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr "クレーター"
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "照準"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr "現在時刻に設定"
+
+# Android/iOS
+msgid "Custom"
+msgstr "カスタム"
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr "データディレクトリ"
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr "データの場所"
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "日付"
+
+# Android/iOS
+msgid "Date Format"
+msgstr "日付フォーマット"
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr "デバッグ"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr "赤緯: %d° %d′ %.2f″"
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " 個の深宇宙天体を読み込みました。"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr "デフォルト"
+
+# Android/iOS
+msgid "Delete"
+msgstr "削除"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "アクティブなビューを削除"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "アクティブなビュー以外を削除"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "継続時間"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "菱形(◇)"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "方向"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "円(●)"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "表示"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "光速到達時間を表示"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "距離: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "項目をダブルクリックで移動"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "ブックマークを開くには項目をダブルクリックします。また、control+クリックでコンテキストメニューを表示します。ドラッグ&ドロップで順番の入れ替えが可能です。"
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "伏せる"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "下矢印(↓)"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "遠距離天体"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "継続時間"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "準惑星"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "食を検索"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "食の影"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "黄道座標"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr "編集"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr "終了日時"
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "惑星名または衛星名を入力"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "赤道座標"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr "赤道半径: %s"
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr "データのロードでエラーがありました。オリジナルの設定へフォールバックします。"
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr "OpenGLの開始に失敗しました。"
+
+# Mac
+msgid "Failed to start renderer."
+msgstr "レンダラーの開始に失敗しました。"
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr "見える恒星の調整"
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "速く"
+
+# Mac
+msgid "Fatal Error"
+msgstr "致命的なエラー"
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr "お気に入り"
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "表示設定"
+
+# Mac, File menu
+msgid "File"
+msgstr "ファイル"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "正方形(■)"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "検索"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "食が起きる天体:"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "天球同期"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr "形式:"
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "次の状態へ"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "フレームレート:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "ぼやけた点"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "銀河座標"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "銀河"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr "棒渦巻銀河"
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr "楕円銀河"
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr "不規則銀河"
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr "渦巻銀河"
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr "銀河の明るさ"
+
+# Mac, In settings
+msgid "General"
+msgstr "一般"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr "共有リンクを作成しています…"
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "球状星団"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr "移動"
+
+# Mac
+msgid "Go to Object"
+msgstr "天体へ移動"
+
+# Mac
+msgid "Go to Object…"
+msgstr "天体へ移動…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "移動"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "座標"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "ガイド"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr "大気が存在"
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr "輪が存在"
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr "ヘルプ"
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "Celestiaを隠す"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "他を隠す"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr "高DPI"
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "高"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "履歴"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "太陽を選択"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "地平座標"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+"カメラモードでは、ドラッグして視野を動かせます。\n"
+"\n"
+"ピンチイン/アウトで視野を縮小/拡大できます。"
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+"天体モードでは、ドラッグして天体の周りを移動できます。\n"
+"\n"
+"ピンチイン/アウトで天体を縮小/拡大できます。"
+
+# Mac, HUD display
+msgid "Info"
+msgstr "天体情報"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr "天体情報表示"
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "天体情報表示:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr "情報"
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "ユリウス日:"
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr "銀緯: %d° %d′ %.2f″"
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr "ラベルの密度"
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "名称表示"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "着陸地点"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "緯度"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "左"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "左矢印(←)"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr "1日の長さ: %s"
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr "Celestiaのロードに失敗しました…"
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr "設定をロードしています…"
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr "ロード中: %s"
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "ローカル時"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "位置"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr "地名タイプ"
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "地名"
+
+# Android/iOS
+msgid "Lock"
+msgstr "2天体同期"
+
+# Mac
+msgid "Lock Phase"
+msgstr "2天体同期"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr "'+'または'-'を長押しして方向を変更します。"
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "経度"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "視点を180°切替"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "低"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "海洋"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "マーカー"
+
+# Mac
+msgid "Markers"
+msgstr "マーカー"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr "質量"
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "中"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "最小化"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr "地名表示詳細度"
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "小衛星"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "山地"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "衛星"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "天体へ近づく"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "天体から遠ざかる"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "天体名"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr "近い恒星"
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "星雲"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "新規フォルダ"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr "夜側の光"
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr "データなし"
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr "天体名が入力されていません"
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr "天体の概要がありません。"
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr "応答がありません"
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "無し"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"注意:\n"
+"期間を長く設定すると、検索に時間がかかり表示されるリストも長いものとなる場合があります。"
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr "天体"
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr "天体名表示"
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr "天体が見つかりません"
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "天体:"
+
+# Android/iOS
+msgid "Objects"
+msgstr "天体"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "観測所・天文台"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr "食を起こす天体"
+
+# Android/iOS
+msgid "Official Website"
+msgstr "公式ウェブサイト"
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "散開星団"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr "URLを開きますか？"
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Web情報URLを開く(英語版Wikipedia)"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL情報"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr "外部ファイルまたはURLを開いています…"
+
+# iOS
+msgid "Operation not permitted."
+msgstr "操作は許可されていません。"
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "自転同期"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "軌道"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "ブックマークを編集…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "その他"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr "その他"
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "URLをペースト"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "停止"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr "視点を上下に振る"
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr "惑星の輪"
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "惑星"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr "天体名が正しいか確認してください。"
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr "天体を選択してください。"
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr "説明を記述してください。"
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr "新しい名前を入力してください。"
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr "天体名を入力してください。"
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr "日時を\"%s\"の形式で入力してください。"
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr "Celestiaを再起動してください"
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "十字"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "点"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr "環境設定"
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "環境設定…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "終了"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "Celestiaを終了"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr "赤経: %dh %dm %.2fs"
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "半径"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr "半径"
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "実時間の速さに"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "食が起きる天体"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr "参照ベクトル"
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr "参照ベクトルは、現在選択されている太陽系の天体に対してのみ表示されます。"
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr "名前を変更"
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr "レンダリング情報"
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr "レンダリング設定"
+
+# Mac, In settings
+msgid "Renderer"
+msgstr "レンダリング"
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr "許可のリクエストが終了しました"
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "直前のスクリプトを実行"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr "リセット"
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr "デフォルトへリセット"
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "解像度: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "進行方向を逆転"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr "視点を180°切替"
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "右"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "右矢印(→)"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "輪の影"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr "視点を左右に回転"
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr "デモを実行"
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr "スクリプトを実行しますか？"
+
+# Mac
+msgid "Run Script…"
+msgstr "スクリプトを実行…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "等級に応じた円"
+
+# Android/iOS
+msgid "Script Control"
+msgstr "スクリプト制御"
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "スクリプト"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "検索"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr "選択"
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "アクティブなビューを切替"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr "時刻を選択"
+
+# Mac, System menu
+msgid "Services"
+msgstr "サービス"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "時刻を設定"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "時刻設定…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr "現在時刻に設定"
+
+# Android/iOS
+msgid "Settings"
+msgstr "設定"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr "共有"
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "すべてを表示"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "自転座標系の軸を表示"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "星座境界線を表示"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "星座名を表示"
+
+# Mac
+msgid "Show Constellations"
+msgstr "星座線を表示"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "公転座標系の軸を表示"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "情報を表示"
+
+# Mac
+msgid "Show Locations"
+msgstr "地名を表示"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "マーカーを表示"
+
+# Mac
+msgid "Show Orbits"
+msgstr "軌道を表示"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "経緯線を表示"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "太陽の方向を表示"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "明暗境界線を表示"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "速度ベクトルを表示"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr "自転周期(恒星時): %s"
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr "大きさ: %s"
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "遅く"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr "線を滑らかに"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "太陽系"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "人工天体"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "ビューを左右に分割"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "ビューを上下に分割"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "正方形(□)"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr "恒星表示方法"
+
+# Mac
+msgid "Star Style:"
+msgstr "恒星表示方法:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "恒星"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr "惑星が存在する恒星"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr "開始日時"
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "停止"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr "周回する天体"
+
+# Android/iOS
+msgid "Support Forum"
+msgstr "サポートフォーラム"
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr "カメラモードに変更"
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr "天体モードに変更"
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "自転同期"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr "サイドバーのモードボタンをタップして、天体モードとカメラモードを切り替えます。"
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "陸地"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "普通"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr "テクスチャ解像度"
+
+# Mac
+msgid "Texture Resolution:"
+msgstr "テクスチャ解像度:"
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "時間"
+
+# Android/iOS
+msgid "Time Control"
+msgstr "時間コントロール"
+
+# Android/iOS
+msgid "Time Zone"
+msgstr "タイムゾーン"
+
+# Mac
+msgid "Time Zone:"
+msgstr "タイムゾーン:"
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "時刻:"
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr "コンソール表示切替"
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr "FPS表示切替"
+
+# Mac, Track an object
+msgid "Track"
+msgstr "画面中央に保持"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "選択した天体を画面中央に保持"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr "翻訳者"
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "フライト"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "三角形(△)"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr "チュートリアル"
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "スペクトル型"
+
+# Mac
+msgid "Unable to capture video"
+msgstr "ビデオをキャプチャーできません"
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "不明"
+
+# iOS
+msgid "Unknown error"
+msgstr "不明なエラー"
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "マーカー解除"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr "すべてのマーカーを解除"
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr "日時の形式が間違っています。"
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr "名称未設定"
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "起こす"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "上矢印(↑)"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "世界時"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "協定世界時との差"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "峡谷"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "速度"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "多い"
+
+# Android/iOS
+msgid "Version"
+msgstr "バージョン"
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "ビュー"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "火山"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr "Web情報"
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr "Celestiaへようこそ"
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "ウィンドウ"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "×字"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr "視点を左右に振る"
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "ズーム"

--- a/po3/ja.po
+++ b/po3/ja.po
@@ -444,6 +444,10 @@ msgstr "赤道半径: %s"
 msgid "Error loading data, fallback to original configuration."
 msgstr "データのロードでエラーがありました。オリジナルの設定へフォールバックします。"
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr "OpenGLの開始に失敗しました。"

--- a/po3/ko.po
+++ b/po3/ko.po
@@ -80,6 +80,14 @@ msgstr "북마크 추가"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "비디오 캡춰"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "거리: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "아랫쪽화살표(↓)"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "없음"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "분광형"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/ko.po
+++ b/po3/ko.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "셀레스티아에 대하여"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "절대 등급"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "북마크 추가"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "소행성"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "대기"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "AU"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "저자"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "북마크"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "항성"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "취소"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "비디오 캡춰"
+
+# Mac
+msgid "Celestia"
+msgstr "셀레스티아"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "선택한 천체를 가운데로(&C)\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "공전 동기"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "원(○)"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "도시"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "구름 그림자"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "구름"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "혜성꼬리"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "혜성"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "별자리"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "별자리 라틴어 표시"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "날짜"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " 먼 우주 천체(DSO)"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "삭제"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "기간"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "마름모(◇)"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "원(●)"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "표시"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "거리: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "아랫쪽화살표(↓)"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "기간"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "왜소행성"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "식 찾기"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "식 그림자"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "황도"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "적도"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "기타"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "사각형(■)"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "천체 추적"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "초당 프레임수:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "희미한 점(&F)"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "은하"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "은하"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "구상성단"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "그리드"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "길잡이"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "높음"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "수평분할"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "천체정보(&I)"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "지명 보기"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "착륙지점"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "왼쪽화살표(←)"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "현지 시간"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "지명"
+
+# Android/iOS
+msgid "Lock"
+msgstr "2천체 참조 동기"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "낮음"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "바다"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "마커"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "중간"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "소 위성"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "산지"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "위성"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "이름"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "성운"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "새폴더…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "없음"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "천체"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "관측소·천문대"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "확인"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "산개성단"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL정보"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "궤도"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "행성"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "십자"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "점(&P)"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "퀴토"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "반경"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "해상도"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "오른쪽화살표(→)"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "고리 그림자"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "등급에 따른 원(&D)"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "스크립트"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "검색"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "시간 설정…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "설정"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "천체 축 보기"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "별자리 경계선 보기"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "프레임 축 보기"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "행성그리드 보기"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "태양 방향 보기"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "밤낮 경계선 보기"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "속도 벡터 보기"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "태양계"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "인공위성"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "사각형(□)"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "항성"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "자전 동기"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "육지"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "보통"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "현재 시각"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "삼각형(△)"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "분광형"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "위쪽화살표(↑)"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "세계표준시"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC 오프셋"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "협곡"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "많이"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "행성"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X자"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/ko.po
+++ b/po3/ko.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/ko.po
+++ b/po3/ko.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/lt.po
+++ b/po3/lt.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Apie Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. ryšk"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Įtraukti žymelę"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroidai"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfera"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "av"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autoriai"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Žymelės"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Ryškiausias"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Atšaukti"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Įrašyti video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Pasirinkimą į centrą\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Surišti"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Apskritimas"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Miestai"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Debesų šešėliai"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Debesys"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Kometų uodegos"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kometos"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Žvaigždynai"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Žvaigždynai lotyniškai"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Data"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Gilaus dangaus objektai"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Trinti"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Trukmė"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Deimantas"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Diskas"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Rodyti"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Atstumas:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Rodyklę žemyn"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Trukmė"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Nykštukinės planetos"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Užtemimų paiška"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Užtemimų šešėliai"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptika"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Pusiaujo"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Rodyti savybes"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Miesto aikštė"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Sekti"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Rėmelio norma:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Išplaukę taškai"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktika"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaktikos"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Kamuoliniai spiečiai"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Tinkleliai"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Kelionių gidas"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Aukšta"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontaliai"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Pavadinimų ypatybės"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Nusileidimo vietos"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Rodyklę kairėn"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Vietinis laikas"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Vietovės"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Užrakinti"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Žema"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Vandenynai"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Žymekliai"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Vidutinė"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Mažieji palydovai"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Monsas"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Palydovai"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Pavadinimas"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Ūkai"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Naujas aplankas…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Nėra"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objektai"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorijos"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "Gerai"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Padrikieji spiečiai"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL info"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbitos"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planetos"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plius"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Taškai"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Kitas"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "spindulys"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Skyros:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Rodyklę dešinėn"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Žiedų šešėliai"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Scaled &diskai"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scenarijai"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Ieškoti"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Nustatyti laiką…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Nustatymai"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Rodyti kūno ašis"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Rodyti kontūrus"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Rodyti rėmelio ašis"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Rodyti planetografinį tinklelį"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Rodyti saulės kryptį"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Rodyti terminatorių"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Rodyti greičio vektorių"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Saulės sistema"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Kosminiai aparatai"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Aikštė"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Žvaigždės"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Sinchronizuoti orbitą"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Žemynai"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Glaustas"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Laikas"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Trikampis"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tipas"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Nežinoma klaida atidarant scenarijų"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Rodyklę aukštyn"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC kompensacija"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Slėniai"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Pilnas"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkanas"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/lt.po
+++ b/po3/lt.po
@@ -80,6 +80,14 @@ msgstr "Įtraukti žymelę"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Įrašyti video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Atstumas:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Rodyklę žemyn"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Nėra"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Tipas"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/lt.po
+++ b/po3/lt.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/lt.po
+++ b/po3/lt.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/lv.po
+++ b/po3/lv.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Par Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs.spož."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Pievienot grāmatzīmi"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroīdiem"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfēras"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "au"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autori"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Grāmatzīme"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Zvaigznes"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Atcelt"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Ierakstīt video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Iecentrēt izvēlēto\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Novērot"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Rinķis"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Pilsētas"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Mākoņu ēnas"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Mākoņus"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Komētu astes"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Komētām"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Zvaigznājus"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Zvaigznājus latīniski"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Datums"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " dziļā kosmosa objekti"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Dzēst"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Ilgums"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Rombs"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disks"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Rādīt"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distance: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Bulta uz leju"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Ilgums"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Pundurplanētas"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Aptumsumu meklētājs"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Aptumsumu ēnas"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptika"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Ekvatoriālais"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Rādīt struktūras"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Aizpildīts kvadrāts"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Sekot"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Kadru skaits:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&izplūduši punkti"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktiskās"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaktikas"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Lodveida"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Tīkli"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Ceļojumu gids"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "daudz"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Sadalīt skatu horizontāli"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Informācija"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Nosaukt struktūras"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Piezemēšanās vietas"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Kreisā bulta"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Vietējais laiks"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Vietas"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Sabloķēt"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "&nedaudz"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Jūras"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Marķierus"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "&vidēji daudz"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Pavadoņiem"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Kalni"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Pavadoņiem"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nosaukums"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Miglājus"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Jauna mape…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "nav"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objekti"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorijas"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "Labi"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Vaļējās kopas"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL informācija"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbītas"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planētām"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Pluss"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&punkti"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Čita"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radii"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Izšķirtspēja: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Labā bulta"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Rinķu ēnas"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "&mērogoti diskveida objekti"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scenāriji"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Meklēšana"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Iestādīt laiku…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Iestatījumi"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Rādīt ķermeņu asis"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Rādīt robežas"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Rādīt &rāmju asis"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Rādīt planetogrāfisko tīklu"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Rādīt Saules virzienu"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Show Terminator"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Rādīt ātruma vektoru"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Saules sistēma"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Kosmiskos aparātus"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Kvadrāts"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Zvaigznes"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Sinhronizēt orbītu"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Zemienes"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "īss"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Laiks"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Trijstūris"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tips"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Nenosakāma kļūda atverot skriptu"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Bulta uz augšu"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC nobīde"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Ielejas"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "pilnīgs"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkāni"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/lv.po
+++ b/po3/lv.po
@@ -80,6 +80,14 @@ msgstr "Pievienot grāmatzīmi"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Ierakstīt video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Distance: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Bulta uz leju"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "nav"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Tips"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/lv.po
+++ b/po3/lv.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/lv.po
+++ b/po3/lv.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/nl.po
+++ b/po3/nl.po
@@ -80,6 +80,14 @@ msgstr "Bladwijzer toevoegen"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Video opnemen"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Afstand: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Pijl omlaag"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Geen"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Type"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/nl.po
+++ b/po3/nl.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/nl.po
+++ b/po3/nl.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/nl.po
+++ b/po3/nl.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Over Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. Mag."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Bladwijzer toevoegen"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Planetoiden"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Dampkringen"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "au"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Auteurs"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Bladwijzers"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Sterren"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Annuleren"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Video opnemen"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Centreer selectie\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Opjagen"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Cirkel"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Steden"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Wolkenschaduwen"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Wolken"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Komeetstaarten"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kometen"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Sterrenbeelden"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Sterrenbeelden in Latijn"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Datum"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "diep ruimte objecten"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Verwijderen"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Duur"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Diamant"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Schijf"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Scherm"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Afstand: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Pijl omlaag"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Duur"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Dwergplaneten"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Eclips Vinder"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Eclipsschaduwen"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Zonneweg"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Equatoriaal"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Weergavefeatures"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Gevuld vierkant"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Achtervolg"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Frame snelheid:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Vage punten"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galactisch"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Sterrenstelsels"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Bolvormige sterrenhopen"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Rasters"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Rondleiding"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Hoog"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontaal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Labelfeatures"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Landingsplaatsen"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Pijl links"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Lokale tijd"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Lokaties"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Vastzetten"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Laag"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Zeeën"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Markeringen"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Middel"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Kleine manen"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Bergen"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Manen"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Naam"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nevels"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Nieuwe map…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Geen"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objecten"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Sterrewachten"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Open sterrenhoop"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL info"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Omloopbanen"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planeten"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Punten"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radius"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Resolutie:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Pijl rechts"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Ringschaduwen"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Ge&schaalde schijven"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Zoeken"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Stel tijd in…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Instellingen"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Toon lichaamsassen"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Grenzen weergeven"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Toon frame-assen"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Planetografisch raster weergeven"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Toon Zon richting"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Dag/Nacht-grens weergeven"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Toon snelheidsvector"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Zonnestelsel"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Ruimtevaartuigen"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Vierkant"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Sterren"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Synchronizeer omloopbaan"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Landmassa's"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Beknopt"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Tijd"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Driehoek"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Type"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Onbekende fout tijdens openen van script bestand."
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Pijl omhoog"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC Offset"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Valleien"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Volledig"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkanen"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/no.po
+++ b/po3/no.po
@@ -80,6 +80,14 @@ msgstr "Legg til bokmerke"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Ta opp video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Avstand: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Ned-pil"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Ingen"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Typ"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/no.po
+++ b/po3/no.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/no.po
+++ b/po3/no.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: no\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Om Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. mag"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Legg til bokmerke"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroider"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfærer"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "au"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Utviklere"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Bokmerker"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Stjerner"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Avbryt"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Ta opp video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Sentrer valgt objekt\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Gå etter"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Sirkel"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Byer"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Sky-skygger"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Skyer"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Komethaler"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kometer"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Stjernebilder"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Stjernbilder på latinsk"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Dato"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " deep space objekter"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Slett"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Varighet"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Diamant"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disk"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Vis"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Avstand: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Ned-pil"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Varighet"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Dvergplaneter"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Formørkelses-finner"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Formørkelsesskygger"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptikken"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Ekvatorial"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Vis detaljer"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Fyllt kvadrat"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Følg"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Bildefrekvens:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Uklare punkter"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktisk"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galakser"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Kulehoper"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Rutenett"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Turguide"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Høy"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horisontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Sett påskrift på detaljer"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Landingsplasser"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Venstrepil"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Lokal tid"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Steder"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Lås"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Lav"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Markører"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Middels"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Mindre måner"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Mons"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Måner"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Navn"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Stjernetåker"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Ny mappe…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Ingen"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr " deep space objekter"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorier"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Åpne stjernehoper"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL-Info"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Omløpsbaner"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planeter"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Pluss"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Punkter"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radier"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Oppløsning: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Høyrepil"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Ring-skygger"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Skalerte s&kiver"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Skript"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Stjernesøk-kriterie"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Still tid…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Innstillinger"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Vis legeme-akser"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Vis grenser"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Vis ramme-akser"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Vis planetografisk rutenett"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Vis solretning"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Vis terminator"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Vis hastighetsvektor"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Solsystemet"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Romfartøy"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Kvadrat"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Stjerner"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Synkron omløpsbane"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Knapp"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "&Tid"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triangel"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Typ"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Ukjent feil ved åpning av skript"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Opp-pil"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Avvikelse fra UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Utførlig"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkaner"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/no.po
+++ b/po3/no.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/pl.po
+++ b/po3/pl.po
@@ -80,6 +80,14 @@ msgstr "Dodaj zakładkę"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Przechwyć wideo"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr ""
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Strzałka w dół"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Brak tekstu"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Typ"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/pl.po
+++ b/po3/pl.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/pl.po
+++ b/po3/pl.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "O Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. wielk."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Dodaj zakładkę"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroidy"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfery"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "j.a."
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autorzy"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Zakładki"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr ""
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Anuluj"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Przechwyć wideo"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Wyśrodkuj zaznaczenie"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Goń"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Koło"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Miasta"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Cienie chmur"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Chmury"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Ogony komet"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Komety"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Gwiazdozbiory"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Gwiazdozbiory po łacinie"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Data"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Obiekty głębokiego nieba"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Usuń"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr ""
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Romb"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Dysk"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr ""
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Strzałka w dół"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Trwanie"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planety karłowate"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Wyszukiwarka zaćmienia"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Cienie zaćmień"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptczna"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Równikowy"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr ""
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Wypełniony kwadrat"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Śledź"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Tempo klatek:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Rozmyte punkty"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktyczna"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaktyki"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Gromady kuliste"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Siatka"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Przewodniki"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Wysoka"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Pozioma"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr ""
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Miejsca lądowania"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Strzałka w lewo"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Czas lokalny"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Miejsca"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Zablokuj"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Niska"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Morze"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Markery"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Średnia"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Drobne księżyce"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Góry"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Księżyce"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nazwa"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Mgławice"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Brak tekstu"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Obiekty"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Obserwatoria"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Gromady otwarte"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Informacje o OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbity"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planety"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Punkty"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "prom."
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Rozdzielczość:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Strzałka w prawo"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Cienie pierścieni"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Skalowane dyski"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "&Skrypty"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr ""
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr ""
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Ustawienia"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Pokaż osie ciała"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Pokaż granice"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Pokaż osie ramek"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Pokaż siatkę planetarną"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Pokaż kierunek słońca"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Pokaż terminatora"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Pokaż wektor prędkości"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Układ słoneczny"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Pojazdy kosmiczne"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Kwadrat"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Gwiazdy"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Synchronizacja orbity"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Kraina"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Krótkie"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Czas"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Trójkąt"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Typ"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr ""
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Strzałka w górę"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Przesunięcie do UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Doliny"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Szczegółowe"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Wulkany"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/pl.po
+++ b/po3/pl.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/pt.po
+++ b/po3/pt.po
@@ -80,6 +80,14 @@ msgstr "Adicionar Marcardor"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Capturar Vídeo"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Distância: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Seta para Baixo"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Nenhum"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Tipo"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/pt.po
+++ b/po3/pt.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/pt.po
+++ b/po3/pt.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Acerca do Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag abs."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Adicionar Marcardor"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteróides"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosferas"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "ua"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autores"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Mais Brilhante"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Cancelar"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Capturar Vídeo"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Centrar na Selecção\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Seguir"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Círculo"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Cidades"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Sombras das Nuvens"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nuvens"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Caudas dos Cometas"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Cometas"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Constelações"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Constelações em Latim"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Data"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " objectos de céu profundo"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Apagar"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Duração"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Diamante"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disco"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Visualização"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distância: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Seta para Baixo"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Duração"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planetas Anões"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Buscador de eclipses"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Sombras dos Eclipses"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Eclíptica"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Equatorial"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Mostrar as Feições"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Encher Quadrado"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Seguir"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Imagens por segundo:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Pontos &Indistintos"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galáctico"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galáxias"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Globulares"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Grelhas"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Guia de Excursão"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Alto"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Informação"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Legendar as Feições"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Sítios de Aterragem"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Seta Esquerda"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Tempo Local"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Localizações"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Fixar"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "&Baixa"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mares"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Marcas"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "&Média"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Luas Menores"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Montes"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Luas"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nome"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulosas"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Nova Pasta…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Nenhum"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objectos"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatórios"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Enxames Abertos"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Informação do OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Órbitas"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planetas"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Mais"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Pontos"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "raio"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Resolução: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Seta Direita"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Sombras dos Anéis"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "&Discos à Escala"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Procurar"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Definir a Hora…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Configuração"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Mostrar Eixos"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Mostrar Fronteiras"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Mostrar os Eixos das Bordas"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Mostrar a Grelha Planetográfica"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Mostrar a Direcção do Sol"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Mostrar o Terminador"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Mostrar o Vector de Velocidade"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sistema Solar"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Naves Espaciais"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Quadrado"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Estrelas"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Órbita Geoest."
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Conciso"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Hora"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triângulo"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tipo"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Erro desconhecido ao abrir o script"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Seta para Cima"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Desvio em relação ao GMT"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vales"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Completo"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulcões"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/pt.po
+++ b/po3/pt.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/pt_BR.po
+++ b/po3/pt_BR.po
@@ -81,6 +81,14 @@ msgstr "Adicionar Favorito"
 msgid "Add new…"
 msgstr "Adicionar novo…"
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "Adicionar/Subtrair Atraso de Viagem da Luz"
@@ -189,6 +197,10 @@ msgstr "Não pôde adicionar objeto"
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Capturar Vídeo"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -379,6 +391,14 @@ msgstr "Mostrar Atraso de Viagem da Luz"
 msgid "Distance:"
 msgstr "Distância:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "Duplo clique no item para ir"
@@ -394,6 +414,14 @@ msgstr "Baixo"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Seta para Baixo"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -446,6 +474,18 @@ msgstr "Erro ao carregar os dados, configurações originais retornadas."
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -652,6 +692,14 @@ msgstr "Exibição de Informações:"
 msgid "Information"
 msgstr "Informação"
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "Data Juliana:"
@@ -841,6 +889,10 @@ msgstr "Sem resposta"
 msgid "None"
 msgstr "Nenhuma"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1029,6 +1081,10 @@ msgstr "Vetores de Referência"
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1380,6 +1436,15 @@ msgstr "Tipo"
 # Mac
 msgid "Unable to capture video"
 msgstr "Não pôde capturar vídeo"
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
+msgstr ""
 
 # Android/iOS/Mac
 msgid "Unknown"

--- a/po3/pt_BR.po
+++ b/po3/pt_BR.po
@@ -444,6 +444,10 @@ msgstr "Raio equatorial: %s"
 msgid "Error loading data, fallback to original configuration."
 msgstr "Erro ao carregar os dados, configurações originais retornadas."
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr "Falha ao iniciar o OpenGL."

--- a/po3/pt_BR.po
+++ b/po3/pt_BR.po
@@ -109,6 +109,10 @@ msgstr "Superfícies Alternativas"
 msgid "Ambient Light"
 msgstr "Luz Ambiente"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "e:"
@@ -474,6 +478,10 @@ msgstr "Erro ao carregar os dados, configurações originais retornadas."
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/pt_BR.po
+++ b/po3/pt_BR.po
@@ -1,0 +1,1470 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: 2020-06-08 11:58-0300\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Pedro Garcia\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.3\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr "%.2f dias"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr "%.2f horas"
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr "%d km"
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr "%d m"
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 UA/s"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 km/s"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 ano-luz/s"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 km/s"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10c"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr "Sobre"
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Sobre o Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag. absoluta"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr "Adicionar"
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Adicionar Favorito"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr "Adicionar novo…"
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "Adicionar/Subtrair Atraso de Viagem da Luz"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr "Avançado"
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "À Frente"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr "Superfícies Alternativas"
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr "Luz Ambiente"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "e:"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroides"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosferas"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "ua"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autores"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr "Mag. Automática"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr "B: %d° %d′ %.2f″"
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "Voltar"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "Início"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "Entre:"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "Organizador de Favoritos"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Favoritos"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Estrelas Mais Brilhantes"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "Trazer Todos à Frente"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr "Navegador"
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (velocidade da luz)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr "Controle da Câmera"
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Cancelar"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr "Não pôde adicionar objeto"
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Capturar Vídeo"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Navegador do Celestia"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Ajuda do Celestia"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr "Centralizar"
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Centralizar na Seleção"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr "Alterar Arquivo de Configuração"
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Perseguir"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr "Escolher Arquivo de Configuração"
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Círculo"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Cidades"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Sombras das Nuvens"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nuvens"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Caudas de Cometa"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Cometas"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr "Arquivo de Configuração"
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr "Configuração irá tomar efeito após a reinicialização."
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr "Confirmar e Reiniciar"
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr "Nomes das Constelações"
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Constelações"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Constelações em Latim"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr "Coordenadas:"
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "Copiar URL"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr "Copiando dados…"
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr "Crateras"
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "Mira"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr "Hora Atual"
+
+# Android/iOS
+msgid "Custom"
+msgstr "Personalizado"
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr "Diretório de Dados"
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr "Localização dos Dados"
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Data"
+
+# Android/iOS
+msgid "Date Format"
+msgstr "Formato de Data"
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr "Depuração"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr "DEC: %d° %d′ %.2f″"
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Objetos do Céu Profundo"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr "Padrão"
+
+# Android/iOS
+msgid "Delete"
+msgstr "Apagar"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "Apagar Visão Ativa"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "Apagar Outras Visões"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Descrição"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Losango"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "Direção"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disco"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Exibição"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "Mostrar Atraso de Viagem da Luz"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distância:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "Duplo clique no item para ir"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "Duplo clique no item para abrir ou control-clique para menu contextual. Arraste os itens para reorganizar."
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "Baixo"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Seta para Baixo"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "Objetos do Céu Profundo"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Duração"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planetas Anões"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Buscador de Eclipses"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Sombras dos Eclipses"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Eclíptica"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr "Editar"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "Digite o nome de um planeta ou lua"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Equatorial"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr "Raio equatorial: %s"
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr "Erro ao carregar os dados, configurações originais retornadas."
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr "Falha ao iniciar o OpenGL."
+
+# Mac
+msgid "Failed to start renderer."
+msgstr "Falha ao iniciar o renderizador."
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr "Estrelas Menos Brilhantes"
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "Mais Rápido"
+
+# Mac
+msgid "Fatal Error"
+msgstr "Erro Fatal"
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr "Favoritos"
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Recursos"
+
+# Mac, File menu
+msgid "File"
+msgstr "Arquivo"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Quadrado Preenchido"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "Procurar"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "Encontrar eclipses em:"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Seguir"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr "Formato:"
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "Adiante"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Quadros por segundo:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Pontos Indistintos"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galática"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galáxias"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr "Galáxias (Espirais Barradas)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr "Galáxias (Elípticas)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr "Galáxias (Irregulares)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr "Galáxias (Espirais)"
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr "Geral"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr "Gerando link de compartilhamento…"
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Globulares"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr "Ir para"
+
+# Mac
+msgid "Go to Object"
+msgstr "Ir para Objeto"
+
+# Mac
+msgid "Go to Object…"
+msgstr "Ir para Objeto…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "Ir para Seleção"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Grades"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Guias"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr "Possui atmosfera"
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr "Possui anéis"
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr "Ajuda"
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "Esconder Celestia"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "Esconder Outros"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Alta"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "Histórico"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "Origem (Sol)"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+"No modo de câmera, deslize para mover o campo de visão.\n"
+"\n"
+"Pince os dedos para aumentar/diminuir o campo de visão."
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+"No modo de objeto, deslize para girar em torno de um objeto.\n"
+"\n"
+"Pince os dedos para aproximar/afastar-se de um objeto."
+
+# Mac, HUD display
+msgid "Info"
+msgstr "Informação"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr "Exibição de Informações"
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "Exibição de Informações:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr "Informação"
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "Data Juliana:"
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr "L: %d° %d′ %.2f″"
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr "Densidade de Nomes"
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Nomes"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Locais de Pouso"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "Latitude"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "Esquerda"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Seta Esquerda"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr "Duração do dia: %s"
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr "Falha ao carregar o Celestia…"
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr "Carregando configuração…"
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr "Carregando: %s"
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Hora Local"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "Localização"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr "Tipos de Localização"
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Localizações"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Fixar"
+
+# Mac
+msgid "Lock Phase"
+msgstr "Fixar Fase"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr "Deixe pressionado para alterar a orientação."
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "Longitude"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "Olhar para Trás"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Baixa"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mares"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "Marcar"
+
+# Mac
+msgid "Markers"
+msgstr "Marcadores"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr "Massa"
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Média"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "Minimizar"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Luas Menores"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Montes"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Luas"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "Aproximar-se"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "Afastar-se"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nome"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr "Estrelas Mais Próximas"
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulosas"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Nova Pasta"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr "Luzes Noturnas"
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr "Sem dados"
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr "Nenhum nome inserido"
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr "Resumo não disponível."
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr "Sem resposta"
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Nenhuma"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"Nota:\n"
+"Especificar um intervalo longo de tempo pode causar demora na pesquisa e um excesso de resultados."
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr "Nomes de Objetos"
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr "Objeto não encontrado"
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "Objeto:"
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objetos"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatórios"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr "Ocultador"
+
+# Android/iOS
+msgid "Official Website"
+msgstr "Website Oficial"
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Aglomerados Abertos"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr "Abrir URL?"
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Abrir URL Online"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Informações do OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr "Abrindo arquivo ou URL externo…"
+
+# iOS
+msgid "Operation not permitted."
+msgstr "Operação não permitida."
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "Orbitar Sincronicamente"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Órbitas"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "Organizar Favoritos…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "Outro"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr "Outros"
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "Colar URL"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "Pausar"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr "Levantar/Baixar"
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr "Anéis"
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planetas"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr "Favor verificar se o nome do objeto está correto."
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr "Por favor digite uma descrição do conteúdo."
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr "Por favor digite um novo nome."
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr "Por favor digite o nome de um objeto."
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr "Favor reiniciar o Celestia"
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Sinal de Mais"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Pontos"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr "Preferências"
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "Preferências…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Sair"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "Sair do Celestia"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr "AR: %dh %dm %2fs"
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "raios"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr "Raio"
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "Tempo Real"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "Receptor"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr "Vetores de Referência"
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr "Renomear"
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr "Informações de Renderização"
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr "Renderizador"
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr "Solicitação de permissão finalizada"
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "Reexecutar Script"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr "Redefinir"
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr "Redefinir para Padrão"
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Resolução:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "Reverter"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr "Reverter Direção"
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "Direita"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Seta Direita"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Sombras dos Anéis"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr "Girar"
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr "Rodar Demonstração"
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr "Rodar script?"
+
+# Mac
+msgid "Run Script…"
+msgstr "Rodar Script…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Discos em Escala"
+
+# Android/iOS
+msgid "Script Control"
+msgstr "Controle do Script"
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripts"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Pesquisar"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr "Selecionar"
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "Selecionar Próxima Visão"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr "Selecionar Hora"
+
+# Mac, System menu
+msgid "Services"
+msgstr "Serviços"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Definir Hora"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "Definir Hora…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr "Definir para Hora Atual"
+
+# Android/iOS
+msgid "Settings"
+msgstr "Configurações"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr "Compartilhar"
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "Mostrar Tudo"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Mostrar Eixos do Corpo"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Mostrar Fronteiras"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "Mostrar Nomes das Constelações"
+
+# Mac
+msgid "Show Constellations"
+msgstr "Mostrar Constelações"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Mostrar Eixos do Referencial"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "Mostrar Informações"
+
+# Mac
+msgid "Show Locations"
+msgstr "Mostrar Localizações"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "Mostrar Marcadores"
+
+# Mac
+msgid "Show Orbits"
+msgstr "Mostrar Órbitas"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Mostrar Grade Planetográfica"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Mostrar Direção do Sol"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Mostrar Terminador"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Mostrar Vetor de Velocidade"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr "Período de rotação sideral: %s"
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr "Tamanho: %s"
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "Mais Devagar"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr "Linhas Suaves"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sistema Solar"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Naves Espaciais"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "Dividir na Horizontal"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "Dividir na Vertical"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Quadrado"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr "Estilo das Estrelas"
+
+# Mac
+msgid "Star Style:"
+msgstr "Estilo das Estrelas:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Estrelas"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr "Estrelas com Planetas"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "Parar"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr "Fórum de Suporte"
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr "Alternado para modo de câmera"
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr "Alternado para modo de objeto"
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Sincronizar Órbita"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr "Toque o botão de modo na barra lateral para alternar entre os modos de objeto e de câmera."
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terras"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Concisa"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr "Resolução de Textura"
+
+# Mac
+msgid "Texture Resolution:"
+msgstr "Resolução de Textura:"
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Tempo"
+
+# Android/iOS
+msgid "Time Control"
+msgstr "Controle do Tempo"
+
+# Android/iOS
+msgid "Time Zone"
+msgstr "Fuso Horário"
+
+# Mac
+msgid "Time Zone:"
+msgstr "Fuso Horário:"
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "Tempo:"
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr "Alternar Exibição do Console"
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr "Alternar Exibição de FPS"
+
+# Mac, Track an object
+msgid "Track"
+msgstr "Rastrear"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "Rastrear Seleção"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr "Tradutores"
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "Viajar"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triângulo"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr "Tutorial"
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tipo"
+
+# Mac
+msgid "Unable to capture video"
+msgstr "Não pôde capturar vídeo"
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Desconhecido"
+
+# iOS
+msgid "Unknown error"
+msgstr "Erro desconhecido"
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "Desmarcar"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr "Sem Título"
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "Cima"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Seta para Cima"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Desvio do UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vales"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "Velocidade"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Completa"
+
+# Android/iOS
+msgid "Version"
+msgstr "Versão"
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "Visões"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulcões"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr "Info Online"
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr "Bem-vindo ao Celestia"
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "Janela"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr "Guinar"
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "Ampliação"

--- a/po3/ro.po
+++ b/po3/ro.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Despre Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Mag. abs."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Adaugă marcaj"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroizi"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfere"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "ua"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autori"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Marcaje"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Stele"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Anulare"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Captură video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Centrează selecţia\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Urmareşte"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Cerc"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Oraşe"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Umbrele norilor"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Nori"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Cozile cometelor"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Comete"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Constelaţi"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Constelaţiile în latină"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Dată"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " obiect cerestru îndepărtat"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Şterge"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Durată"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Carou"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disc"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Afişaj"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Distanţă: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Săgeată jos"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Durată"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Planete pitici"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Caută eclipse"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Umbrele eclipselor"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ecliptică"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Randarizează grila planetară"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Afişează caracteristicile"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Câmp pătrat"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Urmează"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Viteza de randarizare:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Puncte di&fuze"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galactic"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxi"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "globularii"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Caroiaje"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Tur de iniţiere…"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Complex"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Orizontal"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Nume"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Zone de aterizare"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Săgeată stânga"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Fusul orar local"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Locaţii"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Blocheaza"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Redus"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Marcaje"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Mediu"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Loni minore"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Luni"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Luni"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Nume"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebuloase"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Dosar nou…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Nimic"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Obiecte"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatoare"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Rroiuri deschise"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Informaţii OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Orbite"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planete"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Puncte"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radius"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Rezoluţie: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Săgeată dreapta"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Umbrele inelelor"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "&Discuri la scală"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Scripturi"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Caută"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Seteaza timpul"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Setări"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Afişează axele corpului"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Randarizează limitele"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Afişează axele reper"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Randarizează grila planetară"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Afişează direcţia Soarelui"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Randarizează terminatorul"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Afişează vectorul viteză"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Sistem solar"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Nave spaţiale"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Pătrat"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Stele"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Orbitare sincronă"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Pământ"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Concis"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Timp"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triunghi"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Tip"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Eroare necunoscută la deschiderea scriptului"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Săgeată sus"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "GMT"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Decalaj GMT"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Complet"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulcani"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/ro.po
+++ b/po3/ro.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/ro.po
+++ b/po3/ro.po
@@ -80,6 +80,14 @@ msgstr "Adaugă marcaj"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Captură video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Distanţă: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Săgeată jos"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Nimic"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Tip"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/ro.po
+++ b/po3/ro.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/ru.po
+++ b/po3/ru.po
@@ -443,6 +443,10 @@ msgstr "Экваториальный радиус: %s"
 msgid "Error loading data, fallback to original configuration."
 msgstr "Ошибка загрузки данных, возврат к исходной конфигурации."
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr "Ошибка подключения OpenGL."

--- a/po3/ru.po
+++ b/po3/ru.po
@@ -108,6 +108,10 @@ msgstr "Альтернативные поверхности"
 msgid "Ambient Light"
 msgstr "Подсветка"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "и:"
@@ -473,6 +477,10 @@ msgstr "Ошибка загрузки данных, возврат к исход
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/ru.po
+++ b/po3/ru.po
@@ -1,0 +1,1469 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: 2020-06-28 15:45+0300\n"
+"Last-Translator: Askaniy Anpilogov <aaskaniy@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr "%.2f сут."
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr "%.2f ч."
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr "%d км"
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr "%d м"
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 а.е./с"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 км/с"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 св. год/с"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 км/с"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10c"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr "О программе"
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "О программе"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Абс. зв. вел."
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr "Добавить"
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Добавить закладку"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr "Создать…"
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "Вкл./откл. световое запаздывание"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr "Дополнительно"
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "Вперёд"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr "Альтернативные поверхности"
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr "Подсветка"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "и:"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr "Сглаживание"
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Астероиды"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Атмосферы"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "а.е."
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "В разработке принимали участие"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr "Автонастройка зв. величины"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr "B: %d° %d′ %.2f″"
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "Назад"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "Начало"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "Между:"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "Упорядочить закладки"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Закладки"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Ярчайшие звёзды"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "Вывести всё на передний план"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr "Обозреватель"
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (скорость света)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr "Вычисление…"
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr "Управление камерой"
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Отмена"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr "Не удаётся добавить объект"
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Захват видео"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Обозреватель"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Помощь по Celestia"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr "Центрировать"
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "Центрировать выделенное"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr "Изменить файл конфигурации"
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Следовать"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr "Выбрать файл конфигурации"
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Круг"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Города"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Тени облаков"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Облака"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Хвосты комет"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Кометы"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr "Файл конфигурации"
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr "Конфигурация вступит в силу после перезагрузки."
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr "Подтвердить и перезапустить"
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr "Названия созвездий"
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Созвездия"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Латинские названия"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr "Координаты:"
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "Копировать ссылку"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr "Копирование данных…"
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr "Кратеры"
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "Перекрестие"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr "Текущий язык"
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr "Внутреннее время"
+
+# Android/iOS
+msgid "Custom"
+msgstr "Вручную"
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr "Папка с данными"
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr "Расположение данных"
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Дата"
+
+# Android/iOS
+msgid "Date Format"
+msgstr "Формат даты"
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr "Отладка"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr "Склонение: %d° %d′ %.2f″"
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "Объекты глубокого космоса"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr "По умолчанию"
+
+# Android/iOS
+msgid "Delete"
+msgstr "Удалить"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "Удалить активный экран"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "Оставить один экран"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Описание"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Ромб"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "Направление"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Диски"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Визуализация"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "Отобразить световое запаздывание"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Расстояние:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "Нажмите дважды для перехода"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "Нажмите дважды для открытия или нажмите с зажатым Control для контекстного меню. Перетащите элементы для реорганизации."
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "Вниз"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Стрелка вниз"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "Объекты глубокого космоса"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Продолжительность"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Карликовые планеты"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Поиск затмений"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Тени затмений"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Эклиптическая"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr "Редактировать"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr "Время окончания"
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "Введите название планеты или спутника"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Экваториальная"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr "Экваториальный радиус: %s"
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr "Ошибка загрузки данных, возврат к исходной конфигурации."
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr "Ошибка подключения OpenGL."
+
+# Mac
+msgid "Failed to start renderer."
+msgstr "Ошибка запуска рендера."
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr "Предел звёздной величины"
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "Быстрее"
+
+# Mac
+msgid "Fatal Error"
+msgstr "Критическая ошибка"
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr "Избранное"
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Графика"
+
+# Mac, File menu
+msgid "File"
+msgstr "Файл"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Закрашенный квадрат"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "Найти"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "Найти затмения на:"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Наблюдение"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr "Формат:"
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "Вперёд"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Частота кадров:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "Размытые точки"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Галактическая"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Галактики"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr "Галактики (с перемычкой)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr "Галактики (эллиптические)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr "Галактики (неправильные)"
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr "Галактики (спиральные)"
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr "Яркость галактик"
+
+# Mac, In settings
+msgid "General"
+msgstr "Основное"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr "Создание ссылки…"
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Шаровые скопления"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr "Перейти"
+
+# Mac
+msgid "Go to Object"
+msgstr "Перейти к объекту"
+
+# Mac
+msgid "Go to Object…"
+msgstr "Перейти к объекту…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "Перейти к выделенному"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Координатная сетка"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Вспомогательные элементы"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr "Есть атмосфера"
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr "Есть кольца"
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr "Помощь"
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "Свернуть Celestia"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "Свернуть прочее"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr "Высокая чёткость (HiDPI)"
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Высокое"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "История"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "Выбрать Солнце"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Горизонтальная"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+"В режиме работы с камерой проведите пальцем для смещения поля зрения.\n"
+"\n"
+"Щипок пальцами увеличит/уменьшит поле зрения."
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+"В режиме работы с объектом проведите пальцем для вращения.\n"
+"\n"
+"Щипок пальцами приблизит/отдалит объект."
+
+# Mac, HUD display
+msgid "Info"
+msgstr "Информация"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr "Отображение информации"
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "Отображение информации:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr "Об объекте"
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "Юлианская дата:"
+
+# Mac, Unit
+msgid "km"
+msgstr "км"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr "L: %d° %d′ %.2f″"
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr "Прозрачность названий"
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Название"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Места посадок"
+
+# Android, Display language setting
+msgid "Language"
+msgstr "Язык"
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "Широта"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "Влево"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Стрелка влево"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr "Солнечные сутки: %s"
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr "Сбой загрузки Celestia…"
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr "Загрузка конфигурации…"
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr "Загрузка: %s"
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Местное время"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "Местоположения"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr "Виды местоположений"
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Местоположения"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Блокировка фазы"
+
+# Mac
+msgid "Lock Phase"
+msgstr "Блокировка фазы"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr "Удерживайте кнопки для вращения камеры."
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "Долгота"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "Обернуться"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Низкое"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Моря"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "Поставить метку"
+
+# Mac
+msgid "Markers"
+msgstr "Метки"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr "Масса"
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Среднее"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "Свернуть"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr "Фильтр местоположений"
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Малые спутники"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Горы"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Спутники"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "Приблизиться"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "Отдалиться"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Название"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr "Ближайшие звёзды"
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Туманности"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Новая папка"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr "Свет ночной стороны"
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr "Нет данных"
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr "Нет объекта с указанным именем"
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr "Обзор недоступен."
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr "Нет ответа"
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Нет"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"Примечание:\n"
+"Указание большого интервала времени может привести к длительному времени поиска и очень большому количеству результатов."
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr "Объект"
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr "Названия объектов"
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr "Объект не найден"
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "Объект:"
+
+# Android/iOS
+msgid "Objects"
+msgstr "Объекты"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Обсерватории"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr "Затмевающий объект"
+
+# Android/iOS
+msgid "Official Website"
+msgstr "Официальный сайт"
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "Ок"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Рассеянные скопления"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr "Открыть ссылку?"
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Открыть интернет-ссылку"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Информация OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr "Открытие внешнего файла или ссылки…"
+
+# iOS
+msgid "Operation not permitted."
+msgstr "Операция не разрешена."
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "Синхронное вращение"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Орбиты"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "Упорядочить закладки…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "Прочее"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr "Прочее"
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "Вставить ссылку"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "Пауза"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr "По вертикали"
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr "Кольца"
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Планеты"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr "Проверьте название объекта на ошибки."
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr "Выберите объект."
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr "Введите описание содержимого."
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr "Введите новое название."
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr "Введите название объекта."
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr "Введите время в формате «%s»."
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr "Необходим перезапуск Celestia"
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Плюс"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "Точки"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr "Настройки"
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "Настройки…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Выйти"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "Выйти из Celestia"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr "Прямое восхождение: %dh %dm %.2fs"
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "рад."
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr "Радиус"
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "Прямой ход времени"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "Получатель"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr "Опорные векторы"
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr "Опорные векторы видны только для текущего выбранного объекта."
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr "Переименовать"
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr "О рендере"
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr "Параметры рендеринга"
+
+# Mac, In settings
+msgid "Renderer"
+msgstr "Видеокарта"
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr "Запрос необходимых разрешений завершён"
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "Перезапустить сценарий"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr "Сброс"
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr "Вернуть настройки по умолчанию"
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Разрешение:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "Назад"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr "Обернуться"
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "Вправо"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Стрелка вправо"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Тени на кольцах"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr "Вращение"
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr "Демонстрационный сценарий"
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr "Запустить сценарий?"
+
+# Mac
+msgid "Run Script…"
+msgstr "Запуск сценария…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Диски"
+
+# Android/iOS
+msgid "Script Control"
+msgstr "Управление сценариями"
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Сценарии"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Найти"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr "Выбрать"
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "Выбрать следующий экран"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr "Выбрать время"
+
+# Mac, System menu
+msgid "Services"
+msgstr "Сервисы"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Установить время"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "Установить время…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr "Установить текущее время"
+
+# Android/iOS
+msgid "Settings"
+msgstr "Настройки"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr "Поделиться"
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "Показать всё"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Показывать оси объекта"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Показывать границы"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "Показывать названия созвездий"
+
+# Mac
+msgid "Show Constellations"
+msgstr "Показывать созвездия"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Показывать оси каркаса"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "Показывать информацию"
+
+# Mac
+msgid "Show Locations"
+msgstr "Показывать местоположения"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "Показывать метки"
+
+# Mac
+msgid "Show Orbits"
+msgstr "Показывать орбиты"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Показывать планетографическую сетку"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Показывать направление к Солнцу"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Показывать линию терминатора"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Показывать направление движения"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr "Звёздные сутки: %s"
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr "Размер: %s"
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "Медленее"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr "Сгладить линии"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Солнечная система"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Космич. аппараты"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "Разделить по горизонтали"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "Разделить по вертикали"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Квадрат"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr "Отрисовка звёзд"
+
+# Mac
+msgid "Star Style:"
+msgstr "Отрисовка звёзд:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Звёзды"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr "Звёзды с планетами"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr "Время начала"
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "Стоп"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr "Компоненты системы"
+
+# Android/iOS
+msgid "Support Forum"
+msgstr "Форум"
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr "Включён режим работы с камерой"
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr "Включён режим работы с объектом"
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Синхронное вращение"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr "Переключение между режимами работы с объектом и камерой осуществляется через кнопку на боковой панели."
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Земли, области"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Кратко"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr "Разрешение текстур"
+
+# Mac
+msgid "Texture Resolution:"
+msgstr "Разрешение текстур:"
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Время"
+
+# Android/iOS
+msgid "Time Control"
+msgstr "Управление временем"
+
+# Android/iOS
+msgid "Time Zone"
+msgstr "Часовой пояс"
+
+# Mac
+msgid "Time Zone:"
+msgstr "Часовой пояс:"
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "Время:"
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr "Показать/скрыть консоль"
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr "Показать/скрыть FPS"
+
+# Mac, Track an object
+msgid "Track"
+msgstr "Следовать"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "Следовать за выделенным"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr "Переводчики"
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "Перемещение"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Треугольник"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr "Руководство"
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Тип"
+
+# Mac
+msgid "Unable to capture video"
+msgstr "Нельзя записать видео"
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Неизвестно"
+
+# iOS
+msgid "Unknown error"
+msgstr "Неизвестная ошибка"
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "Снять метку"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr "Снять все метки"
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr "Формат времени не распознан."
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr "Без названия"
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "Вверх"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Стрелка вверх"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Смещение UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Долины"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "Скорость"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Подробно"
+
+# Android/iOS
+msgid "Version"
+msgstr "Версия"
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "Экраны"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Вулканы"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr "Информация в интернете"
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr "Добро пожаловать в Celestia"
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "Окно"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr "По горизонтали"
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "Масштабирование"

--- a/po3/ru.po
+++ b/po3/ru.po
@@ -80,6 +80,14 @@ msgstr "Добавить закладку"
 msgid "Add new…"
 msgstr "Создать…"
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "Вкл./откл. световое запаздывание"
@@ -188,6 +196,10 @@ msgstr "Не удаётся добавить объект"
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Захват видео"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr "Отобразить световое запаздывание"
 msgid "Distance:"
 msgstr "Расстояние:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "Нажмите дважды для перехода"
@@ -393,6 +413,14 @@ msgstr "Вниз"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Стрелка вниз"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr "Ошибка загрузки данных, возврат к исход
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -651,6 +691,14 @@ msgstr "Отображение информации:"
 msgid "Information"
 msgstr "Об объекте"
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "Юлианская дата:"
@@ -839,6 +887,10 @@ msgstr "Нет ответа"
 # Android/iOS/Mac, Empty HUD display
 msgid "None"
 msgstr "Нет"
+
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
 
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
@@ -1029,6 +1081,10 @@ msgstr "Опорные векторы"
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
 msgstr "Опорные векторы видны только для текущего выбранного объекта."
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
+msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
@@ -1379,6 +1435,15 @@ msgstr "Тип"
 # Mac
 msgid "Unable to capture video"
 msgstr "Нельзя записать видео"
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
+msgstr ""
 
 # Android/iOS/Mac
 msgid "Unknown"

--- a/po3/sk.po
+++ b/po3/sk.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "O Celestii"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. jasnosť"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Pridať záložku"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroidy"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosféry"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "AU"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Autori"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Záložky"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Najjasnejšie"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Zrušiť"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Nahrať video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Vycentrovať na výber\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Prenasledovať"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Kruh"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Mestá"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Tiene oblakov"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Oblaky"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Chvosty komét"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kométy"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Súhvezdia"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Súhvezdia v latinčine"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Dátum"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " telesá hlbokého vesmíru"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Vymazať"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Trvanie"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Kosoštvorec"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Kotúč/disk"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Zobrazenie"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Vzdialenosť: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Šípka dole"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Trvanie"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Trpasličie planéty"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Vyhľadávač zatmení…"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Tiene zatmení"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptická"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Rovníková"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Zobraziť útvary"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Vyplnený štvorec"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Nasledovať"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Snímok za sekundu:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "N&eostré body"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktická"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxie"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Guľové hviezdokopy"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Súradnicové siete"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Sprievodca"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Vysoké"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horizontálna"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Informácie"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Pomenovať útvary"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Miesta pristátí"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Šípka doľava"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Miestny čas"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Lokality"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Zamknúť"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Nízke"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare (Moria)"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Značky"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Stredné"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Malé mesiace"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Mons (Hory)"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Mesiace"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Názov"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Hmloviny"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Nový priečinok…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Žiadny"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objekty"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatóriá"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Otvorené hviezdokopy"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Informácie o OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Obežné dráhy"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planéty"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Body"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "polomerov"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Rozlíšenie: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Šípka doprava"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Tiene prstencov"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "&Kotúče v mierke"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Skripty"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Hľadať"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Nastaviť čas…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Nastavenia"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Zobraziť osi telesa"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Zobraziť hranice súhvezdí"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Zobraziť osi pohľadu"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Zobraziť planetografickú súradnicovú sieť"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Zobraziť smer k slnku"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Zobraziť terminátor"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Zobraziť vektor rýchlosti"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Slnečná sústava"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Kozmické lode"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Štvorec"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Hviezdy"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Synchronizovať obežnú dráhu"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra (Pevniny)"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Stručný"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Čas"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Trojuholník"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Typ"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Neznáma chyba pri otváraní skriptu"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Šípka hore"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC (svetový čas)"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Posun voči svetovému času"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis (Údolia)"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Podrobný"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Sopky"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/sk.po
+++ b/po3/sk.po
@@ -80,6 +80,14 @@ msgstr "Pridať záložku"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Nahrať video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Vzdialenosť: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Šípka dole"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Žiadny"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Typ"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/sk.po
+++ b/po3/sk.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/sk.po
+++ b/po3/sk.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/sv.po
+++ b/po3/sv.po
@@ -80,6 +80,14 @@ msgstr "Lägg till bokmärke"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Fånga video"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Avstånd: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Nedåtpil"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Ingen"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Typ"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/sv.po
+++ b/po3/sv.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/sv.po
+++ b/po3/sv.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Om Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Abs. mag"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Lägg till bokmärke"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroider"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosfärer"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "au"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Upphovsmän"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Bokmärken"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Stjärnor"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Avbryt"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Fånga video"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Centrera valt objekt\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Jaga"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Cirkel"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Städer"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Molnskuggor"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Moln"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Kometsvansar"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kometer"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Stjärnbilder"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Stjärnbilder på latin"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Datum"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " rymdobjekt"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Ta bort"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Längd"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Diamant"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disk"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Visa"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Avstånd: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Nedåtpil"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Längd"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Dvärgplaneter"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Förmörkelsefinnare"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Förmörkelseskuggor"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Ekliptika"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Visa himlarutnät"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Visa funktioner"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Fylld fyrkant"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Följ"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Bildfrekvens:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Suddiga punkter"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaktisk"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaxer"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Klotformiga stjärnhopar"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Rutnät"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Turnéguide"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Hög"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Horisontell"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Info"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Etikettfunktioner"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Landningsplatser"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Vänsterpil"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Lokal tid"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Platser"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Lås"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Låg"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Mare"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Markörer"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Medel"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Mindre månar"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Mons"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Månar"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Namn"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebulosor"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Ny mapp…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Ingen"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Objekt"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Observatorier"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "OK"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Öppna stjärnhopar"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL-Info"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Omloppsbanor"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Planeter"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Plus"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Punkter"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Quito"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "radii"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Upplösning: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Högerpil"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Ringskuggor"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Nedskalade &skivor"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Skript"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Sök"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Ställ tid…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Inställningar"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Visa kroppsaxlar"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Visa gränser"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Visa ramaxlar"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Visa planetografiskt rutnät"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Visa solriktning"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Visa terminator"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Visa hastighetsvektor"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Solsystemet"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Rymdfarkoster"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Kvadrat"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Stjärnor"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Synkronisera omloppsbana"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Terra"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Fåordig"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Tid"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Triangel"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Typ"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Okänt fel vid öppning av skript"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Uppåtpil"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Avvikelse från UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Vallis"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Informativ"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Vulkaner"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/sv.po
+++ b/po3/sv.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/tr.po
+++ b/po3/tr.po
@@ -80,6 +80,14 @@ msgstr "Yerimi Ekle"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -187,6 +195,10 @@ msgstr ""
 
 # Mac, Record a video in Celestia
 msgid "Capture Video"
+msgstr ""
+
+# Android/iOS, Add-on categories
+msgid "Categories"
 msgstr ""
 
 # Mac
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Mesafe:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Aşağı Ok"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "&Hiçbiri"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Türü"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/tr.po
+++ b/po3/tr.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/tr.po
+++ b/po3/tr.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/tr.po
+++ b/po3/tr.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Celestia Hakkında"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr ""
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Yerimi Ekle"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Asteroitler"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Atmosferler"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "Bakü"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Yazarlar"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Yer imleri"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Yıldızları Göster"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "İptal"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr ""
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Merkez Seçin\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr ""
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Daire"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Şehirler"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Bulutlar"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Kuyruklu yıldız kuyrukları"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Kuyruklu yıldızlar"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr ""
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Tarih"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " derin uzay nesneleri"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Sil"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Süre"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr ""
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Disk"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr ""
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Mesafe:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Aşağı Ok"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Süre"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Cüce gezegenler"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr ""
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Diğer özellikler"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr ""
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "İzle"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Zaman oranı"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Bulanık Noktalar"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Galaksiler"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Galaksiler"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr ""
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Tur Rehberi"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Yüksek"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Seçenekleri Göster…"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Bilgi"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "km"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Etiket Özellikleri"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Yükleniyor"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Sol Ok"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "Yerel Zaman"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Konumlar"
+
+# Android/iOS
+msgid "Lock"
+msgstr ""
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Düşük"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr ""
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Yıldızları Göster"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Orta"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Uydular"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Uydular"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "İsim"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Nebula"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Yeni Klasör…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "&Hiçbiri"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr " derin uzay nesneleri"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Krater Konumunu Göster"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "TAMAM"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL Bilgi"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Yörüngeler"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Gezegenler"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Noktalar"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr ""
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr ""
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Çözünürlük:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Sağ Ok"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "Yıldız stili: ölçekli diskler"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr ""
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr ""
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Zaman Ayarları…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Ayarlar"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr ""
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Yıldızları Göster"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Yıldızları Göster"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Güneş Sistemi"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Asteroit yörüngelerini göster"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Yıldızlar"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Yörüngeleri göster"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr ""
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "&Zaman"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr ""
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Türü"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr ""
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Yukarı Ok"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC "
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC "
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr ""
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr ""
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr ""
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/uk.po
+++ b/po3/uk.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr ""
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr ""
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/uk.po
+++ b/po3/uk.po
@@ -1,0 +1,1461 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr ""
+
+# Mac, Speed unit
+msgid "10c"
+msgstr ""
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "Про Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "Абс. величина"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "Додати закладку"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr ""
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr ""
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "Астероїди"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "Атмосфери"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "а. о."
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "Автори"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr ""
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr ""
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr ""
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr ""
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "Закладки"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "Найяскравіша"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr ""
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr ""
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "Скасувати"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "Захоплення відео"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr ""
+
+# Mac
+msgid "Celestia Help"
+msgstr ""
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "&Розташувати по центру\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "Гонитва"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "Коло"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "Міста"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "Тіні хмар"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "Хмари"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "Хвости комет"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "Комети"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr ""
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "Сузір'я"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "Сузір'я латиною"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr ""
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr ""
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr ""
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "Дата"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr " віддалені об’єкти"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "Вилучити"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr ""
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr ""
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "Тривалість"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "Ромб"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "Диск"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "Показ"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr ""
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "Відстань: "
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr ""
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr ""
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "Стрілка вниз"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr ""
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "Тривалість"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "Карликові планети"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "Пошук затемнень"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "Тіні затемнення"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "Екліптика"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "Екваторіальна"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr ""
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr ""
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "Показувати об’єкти"
+
+# Mac, File menu
+msgid "File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "Заповнений квадрат"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr ""
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "Стеження"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr ""
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr ""
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "Частота кадрів:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "&Розмиті точки"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "Галактика"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "Галактики"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr ""
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "Сферичні скупчення"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr ""
+
+# Mac
+msgid "Go to Object…"
+msgstr ""
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "Сітки"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "Путівник"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr ""
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr ""
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "Висока"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr ""
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr ""
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "Горизонтальна"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "&Інформація"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr ""
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr ""
+
+# Mac, Unit
+msgid "km"
+msgstr "км"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr ""
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "Назва об'єктiв"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "Місця посадок"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr ""
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "Стрілка ліворуч"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "За місцевим часом"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr ""
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr ""
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "Місця"
+
+# Android/iOS
+msgid "Lock"
+msgstr "Заблокувати"
+
+# Mac
+msgid "Lock Phase"
+msgstr ""
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr ""
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr ""
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "Низька"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "Моря"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr ""
+
+# Mac
+msgid "Markers"
+msgstr "Позначки"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "Помірна"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr ""
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "Малі планети"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "Гори"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "Місяці"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr ""
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr ""
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "Назва"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "Туманності"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "Створити теку…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "Немає"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr ""
+
+# Android/iOS
+msgid "Objects"
+msgstr "Об'єкти"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "Обсерваторії"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "Гаразд"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "Розсіяні скупчення"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr ""
+
+# Mac
+msgid "OpenGL Info"
+msgstr "Інформація щодо OpenGL"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "Орбіти"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr ""
+
+# Mac, Other location labels
+msgid "Other"
+msgstr ""
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr ""
+
+# Mac, Pause time
+msgid "Pause"
+msgstr ""
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "Планети"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "Плюс"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "&Точки"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr ""
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr ""
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "Кіто"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "радіуси"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr ""
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr ""
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr ""
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr ""
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr ""
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "Роздільна здатність: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr ""
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "Стрілка праворуч"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "Тіні від кілець"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr ""
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "&Диски"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "Скрипти"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "Пошук"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr ""
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr ""
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "Встановити час…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr ""
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "Налаштування"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "Показувати осі тіла"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "Показувати межі"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr ""
+
+# Mac
+msgid "Show Constellations"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "Показувати осі вікна"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr ""
+
+# Mac
+msgid "Show Locations"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr ""
+
+# Mac
+msgid "Show Orbits"
+msgstr ""
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "Показувати планетографічну сітку"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "Показувати напрямок на сонце"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "Показувати термінатор"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "Показувати вектор швидкості"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr ""
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr ""
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "Сонячна система"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "Космічні кораблі"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr ""
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "Квадрат"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr ""
+
+# Mac
+msgid "Star Style:"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "Зірки"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr ""
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "Синхронна орбіта"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "Континенти"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "Коротко"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr ""
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "Час"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr ""
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr ""
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr ""
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "Трикутник"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "Тип"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "Невідома помилка під час відкриття скрипту"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr ""
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "Стрілка вгору"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "Відступ від UTC"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "Долини"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr ""
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "Докладно"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "Вулкани"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr ""

--- a/po3/uk.po
+++ b/po3/uk.po
@@ -80,6 +80,14 @@ msgstr "Додати закладку"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr ""
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "Захоплення відео"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr ""
 msgid "Distance:"
 msgstr "Відстань: "
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr ""
@@ -393,6 +413,14 @@ msgstr ""
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "Стрілка вниз"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr ""
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "Немає"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1020,6 +1072,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1370,6 +1426,15 @@ msgstr "Тип"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/uk.po
+++ b/po3/uk.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""

--- a/po3/zh_CN.po
+++ b/po3/zh_CN.po
@@ -81,6 +81,14 @@ msgstr "添加书签"
 msgid "Add new…"
 msgstr "添加…"
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr "插件文件夹不存在。"
+
+# Android/iOS
+msgid "Add-ons"
+msgstr "插件"
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "增加/减少光速延迟"
@@ -189,6 +197,10 @@ msgstr "无法添加对象"
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "录制视频"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr "分类"
 
 # Mac
 msgid "Celestia"
@@ -379,6 +391,14 @@ msgstr "显示光速延迟"
 msgid "Distance:"
 msgstr "距离:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr "您是否希望取消该任务？"
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr "您是否希望卸载该插件？"
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "双击条目前往"
@@ -394,6 +414,14 @@ msgstr "下"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "下箭头"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr "下载"
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr "下载中"
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -447,6 +475,18 @@ msgstr "加载数据失败，尝试加载默认配置。"
 # Android, Exit Celestia
 msgid "Exit"
 msgstr "退出"
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr "下载或安装插件失败。"
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr "无法加载插件目录。"
+
+# Android/iOS
+msgid "Failed to load add-ons."
+msgstr "无法加载插件列表。"
 
 # Mac
 msgid "Failed to start OpenGL."
@@ -652,6 +692,14 @@ msgstr "信息显示 :"
 msgid "Information"
 msgstr "信息"
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr "已安装"
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr "已安装"
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "儒略日："
@@ -840,6 +888,10 @@ msgstr "无响应"
 # Android/iOS/Mac, Empty HUD display
 msgid "None"
 msgstr "无"
+
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr "注意：需要重新启动 Celestia 以使用新插件。"
 
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
@@ -1030,6 +1082,10 @@ msgstr "参考向量"
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
 msgstr "参考向量只对当前选中的太阳系天体有效。"
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
+msgstr "刷新"
 
 # Android, Rename a favorite item (currently bookmark)
 msgid "Rename"
@@ -1380,6 +1436,15 @@ msgstr "类型"
 # Mac
 msgid "Unable to capture video"
 msgstr "无法录制视频"
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr "无法获取路径，请确保您选择的路径在%s下。"
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
+msgstr "无法卸载插件。"
 
 # Android/iOS/Mac
 msgid "Unknown"

--- a/po3/zh_CN.po
+++ b/po3/zh_CN.po
@@ -444,6 +444,10 @@ msgstr "赤道半径：%s"
 msgid "Error loading data, fallback to original configuration."
 msgstr "加载数据失败，尝试加载默认配置。"
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr "退出"
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr "无法启用OpenGL。"

--- a/po3/zh_CN.po
+++ b/po3/zh_CN.po
@@ -109,6 +109,10 @@ msgstr "替换表面"
 msgid "Ambient Light"
 msgstr "环境光"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr "检测到已连接新的屏幕，您是否想在外接屏幕上显示 Celestia ？"
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "到"
@@ -475,6 +479,10 @@ msgstr "加载数据失败，尝试加载默认配置。"
 # Android, Exit Celestia
 msgid "Exit"
 msgstr "退出"
+
+# iOS
+msgid "Failed to connect to the external screen."
+msgstr "连接到外接屏幕失败。"
 
 # Android/iOS
 msgid "Failed to download or install this add-on."

--- a/po3/zh_CN.po
+++ b/po3/zh_CN.po
@@ -1,0 +1,1470 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: 2020-05-08 22:42+0800\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.3\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr "%.2f 天"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr "%.2f 小时"
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr "%d 千米"
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr "%d 米"
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 天文单位/秒"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 千米/秒"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 光年/秒"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 千米/秒"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10倍光速"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr "关于"
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "关于 Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "绝对星等"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr "添加"
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "添加书签"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr "添加…"
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "增加/减少光速延迟"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr "高级"
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "向前"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr "替换表面"
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr "环境光"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "到"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr "抗锯齿"
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "小行星"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "大气"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "天文单位"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "软件作者"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr "自动增强"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr "B: %d° %d′ %.2f″"
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "后退"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "开始"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "从"
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "管理书签"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "书签"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "最亮的恒星"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "前置全部窗口"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr "星体浏览器"
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (光速)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr "计算中…"
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr "镜头控制"
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "取消"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr "无法添加对象"
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "录制视频"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "星体浏览器"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Celestia 帮助"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr "居中"
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "居中所选天体"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr "修改配置文件"
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "追赶"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr "选择配置文件"
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "圆"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "城市"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "云层投影"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "云层"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "彗尾"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "彗星"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr "配置文件"
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr "配置会在重启后生效。"
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr "确认并重启"
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr "星座标签"
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "星座"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "拉丁名星座标签"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr "坐标："
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "拷贝URL"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr "复制数据…"
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr "陨石坑"
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "瞄准线"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr "当前语言"
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr "当前时间"
+
+# Android/iOS
+msgid "Custom"
+msgstr "自定义"
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr "数据目录"
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr "数据位置"
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "日期"
+
+# Android/iOS
+msgid "Date Format"
+msgstr "日期格式"
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr "调试操作"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr "DEC: %d° %d′ %.2f″"
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "深空天体"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr "默认"
+
+# Android/iOS
+msgid "Delete"
+msgstr "删除"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "删除当前视图"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "删除其他视图"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "描述"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr "开发"
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "菱形"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "方向"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "填充的圆"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "显示"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "显示光速延迟"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "距离:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "双击条目前往"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "双击项目前往，右键点击项目打开菜单。拖拽项目进行管理。"
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "下"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "下箭头"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "深空天体"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "持续时间"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "矮行星"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "日月食查找"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "日月食投影"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "黄道座标系"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr "编辑"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr "结束时间"
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "输入行星或卫星名称"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "赤道坐标系"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr "赤道半径：%s"
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr "加载数据失败，尝试加载默认配置。"
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr "无法启用OpenGL。"
+
+# Mac
+msgid "Failed to start renderer."
+msgstr "无法启用渲染器。"
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr "最暗的星"
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "加快"
+
+# Mac
+msgid "Fatal Error"
+msgstr "致命错误"
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr "收藏"
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "特征"
+
+# Mac, File menu
+msgid "File"
+msgstr "文件"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "填充的正方形"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "查找"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "查找日月食发生在"
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "跟随"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr "格式："
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "前进"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "帧率："
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "模糊点"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "银道座标系"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "星系"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr "棒旋星系"
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr "椭圆星系"
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr "不规则星系"
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr "漩涡星系"
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr "星系亮度"
+
+# Mac, In settings
+msgid "General"
+msgstr "通用"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr "生成分享链接…"
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "球状星团"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr "前往"
+
+# Mac
+msgid "Go to Object"
+msgstr "转到目标"
+
+# Mac
+msgid "Go to Object…"
+msgstr "转到目标…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "转到所选"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "坐标系"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "向导"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr "存在大气"
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr "存在星环"
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr "帮助"
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "隐藏 Celestia"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "隐藏其他"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr "高分屏显示"
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "高"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "历史"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "主地点 (太阳)"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "地平座标系"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+"在相机模式，拖拽以移动视野。\n"
+"\n"
+"双指捏合以缩放视野。"
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+"在相对天体模式，拖拽以绕天体旋转。\n"
+"\n"
+"双指捏合以缩放天体。"
+
+# Mac, HUD display
+msgid "Info"
+msgstr "信息"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr "信息显示"
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "信息显示 :"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr "信息"
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "儒略日："
+
+# Mac, Unit
+msgid "km"
+msgstr "千米"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr "L: %d° %d′ %.2f″"
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr "标签密度"
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "标签"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "着陆点"
+
+# Android, Display language setting
+msgid "Language"
+msgstr "语言"
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "纬度"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "左"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "左箭头"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr "日长：%s"
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr "Celestia加载失败"
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr "加载配置…"
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr "加载中：%s"
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "本地时间"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "位置"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr "位置类型"
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "位置"
+
+# Android/iOS
+msgid "Lock"
+msgstr "锁定"
+
+# Mac
+msgid "Lock Phase"
+msgstr "锁定相位"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr "长按来控制方向。"
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "经度"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "转向"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "低"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "海洋"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "标记"
+
+# Mac
+msgid "Markers"
+msgstr "标记"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr "质量"
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "中"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "最小化窗口"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr "最小带标签纹理尺寸"
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "子卫星"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "山脉"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "卫星"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "拉近"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "推远"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "名称"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr "最近的恒星"
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "星云"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "新建文件夹…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr "夜间照明"
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr "无数据"
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr "没有输入天体名称"
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr "无描述。"
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr "无响应"
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "无"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"注意：\n"
+"计算较长的时间范围会需要更多的时间，且可能会产生过多的数据结果。"
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr "天体"
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr "天体标签"
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr "找不到对象"
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "目标："
+
+# Android/iOS
+msgid "Objects"
+msgstr "天体"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "观测站"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr "遮光体"
+
+# Android/iOS
+msgid "Official Website"
+msgstr "官方网站"
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "确定"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "疏散星团"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr "打开URL？"
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "打开网页"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL 信息"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr "打开外部文件或URL…"
+
+# iOS
+msgid "Operation not permitted."
+msgstr "操作不被允许。"
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "同步轨道"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "轨道"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "管理书签…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "其他"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr "其他"
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "粘贴URL"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "暂停"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr "Pitch"
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr "行星环"
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "行星"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr "请检查输入的天体名是否正确。"
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr "请选择一个天体。"
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr "请输入内容介绍。"
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr "请输入新名称。"
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr "请输入天体名称。"
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr "请以“%s”格式输入时间"
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr "请重启Celestia"
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "加号"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "点"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr "偏好设置"
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "偏好设置…"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "退出"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "退出 Celestia"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr "RA: %dh %dm %.2fs"
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "倍半径"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr "半径"
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "实时"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "观测地"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr "参考向量"
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr "参考向量只对当前选中的太阳系天体有效。"
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr "重命名"
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr "渲染信息"
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr "渲染参数"
+
+# Mac, In settings
+msgid "Renderer"
+msgstr "渲染器"
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr "完成请求权限"
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "重新运行脚本"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr "重置"
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr "恢复默认"
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "分辨率:"
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "反向"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr "反转朝向"
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "右"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "右箭头"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "星环投影"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr "Roll"
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr "运行演示"
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr "运行脚本？"
+
+# Mac
+msgid "Run Script…"
+msgstr "运行脚本…"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "缩放点"
+
+# Android/iOS
+msgid "Script Control"
+msgstr "脚本控制"
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "脚本"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr "脚本和URL"
+
+# Android/iOS
+msgid "Search"
+msgstr "查找"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr "选择"
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "选择下一个视图"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr "选择时间"
+
+# Mac, System menu
+msgid "Services"
+msgstr "服务"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "设置时间…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "设置时间…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr "设置为当前时间"
+
+# Android/iOS
+msgid "Settings"
+msgstr "设置"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr "分享"
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "显示全部"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "显示赤道轴"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "显示星座边界"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "显示星座标签"
+
+# Mac
+msgid "Show Constellations"
+msgstr "显示星座"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "显示黄道轴"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "显示简介"
+
+# Mac
+msgid "Show Locations"
+msgstr "显示位置"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "显示标记器"
+
+# Mac
+msgid "Show Orbits"
+msgstr "显示轨道"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "显示经纬网格"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "显示太阳方向"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "显示明暗边界线"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "显示速度向量"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr "自转周期：%s"
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr "尺寸: %s"
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "减慢"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr "线性平滑"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "太阳系"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "航天器"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "水平分割"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "垂直分割"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "正方形"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr "恒星样式"
+
+# Mac
+msgid "Star Style:"
+msgstr "恒星样式 :"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "恒星"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr "有行星的恒星"
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr "开始时间"
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "停止"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr "子系统"
+
+# Android/iOS
+msgid "Support Forum"
+msgstr "论坛"
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr "已切换至相机模式"
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr "已切换至相对天体模式"
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "同步轨道"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr "轻按边栏的模式按钮以在相对天体模式和相机模式之间切换。"
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "陆地"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "简单"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr "纹理分辨率"
+
+# Mac
+msgid "Texture Resolution:"
+msgstr "纹理分辨率："
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr "第三方依赖"
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "时间"
+
+# Android/iOS
+msgid "Time Control"
+msgstr "时间控制"
+
+# Android/iOS
+msgid "Time Zone"
+msgstr "时区"
+
+# Mac
+msgid "Time Zone:"
+msgstr "时区："
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "时间："
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr "切换控制台输出显示"
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr "切换FPS显示"
+
+# Mac, Track an object
+msgid "Track"
+msgstr "保持居中"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "保持居中"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr "翻译"
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "移动"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "三角形"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr "教程"
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "类型"
+
+# Mac
+msgid "Unable to capture video"
+msgstr "无法录制视频"
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "未知"
+
+# iOS
+msgid "Unknown error"
+msgstr "未知错误"
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "取消标记"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr "取消所有标记"
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr "无法识别字符串。"
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr "未命名"
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "上"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "上箭头"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr "使用插件和脚本"
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "UTC"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "UTC偏移"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "峡谷"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "速度"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "详细"
+
+# Android/iOS
+msgid "Version"
+msgstr "版本"
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "视图"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "火山"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr "在线信息"
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr "欢迎使用Celestia"
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "窗口"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr "Yaw"
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "缩放"

--- a/po3/zh_TW.po
+++ b/po3/zh_TW.po
@@ -1,0 +1,1463 @@
+#
+# Copyright (C) 2001-2020 Celestia Development Team
+# This file is distributed under the same license as the celestia package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: celestia 1.7.0\n"
+"Report-Msgid-Bugs-To: team@celestia.space\n"
+"POT-Creation-Date: 2020-04-15 20:22+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f days"
+msgstr ""
+
+# Android/iOS/Mac
+#, c-format
+msgid "%.2f hours"
+msgstr ""
+
+# Android/iOS/Mac, Unit kilometer
+#, c-format
+msgid "%d km"
+msgstr ""
+
+# Android/iOS/Mac, Unit meter
+#, c-format
+msgid "%d m"
+msgstr ""
+
+# Mac, Speed unit
+msgid "1 AU/s"
+msgstr "1 天文單位/秒"
+
+# Mac, Speed unit
+msgid "1 km/s"
+msgstr "1 千米/秒"
+
+# Mac, Speed unit
+msgid "1 ly/s"
+msgstr "1 光年/秒"
+
+# Mac, Speed unit
+msgid "1000 km/s"
+msgstr "1000 千米/秒"
+
+# Mac, Speed unit
+msgid "10c"
+msgstr "10倍光速"
+
+# Android/iOS, About Celstia...
+msgid "About"
+msgstr ""
+
+# Mac, System menu item
+msgid "About Celestia"
+msgstr "關於 Celestia"
+
+# Mac, Absolute magnitude
+msgid "Abs. mag"
+msgstr "絕對星等"
+
+# Android, Add a new item (bookmark)
+msgid "Add"
+msgstr ""
+
+# Mac, Add a new bookmark
+msgid "Add Bookmark"
+msgstr "新增書籤"
+
+# iOS, Add a new item (bookmark)
+msgid "Add new…"
+msgstr ""
+
+# Mac
+msgid "Add/Subtract Light Travel Delay"
+msgstr "增加/減少光速延遲"
+
+# Android/iOS, Advanced setting items
+msgid "Advanced"
+msgstr ""
+
+# Mac, Traveling forward
+msgid "Ahead"
+msgstr "向前"
+
+# Android/iOS/Mac, Alternative textures to display
+msgid "Alternate Surfaces"
+msgstr ""
+
+# Android/iOS/Mac, In setting
+msgid "Ambient Light"
+msgstr "環境光"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "and:"
+msgstr "和:"
+
+# Android/iOS/Mac
+msgid "Anti-aliasing"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Asteroids"
+msgstr "小行星"
+
+# Android/iOS/Mac
+msgid "Atmospheres"
+msgstr "大氣壓"
+
+# Mac, Astronomical unit
+msgid "au"
+msgstr "天文單位"
+
+# Android/iOS, Authors for Celestia
+msgid "Authors"
+msgstr "作者群"
+
+# Mac, Auto mag for star display
+msgid "Auto Mag"
+msgstr " 自動調節星等極限"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "B: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Undo an operation
+msgid "Back"
+msgstr "返回"
+
+# Mac, Beginning time (for eclipse)
+msgid "Beginning"
+msgstr "開始"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Between:"
+msgstr "介於："
+
+# Mac
+msgid "Bookmark Organizer"
+msgstr "Bookmark Organizer"
+
+# Android/iOS/Mac, URL bookmarks
+msgid "Bookmarks"
+msgstr "書籤"
+
+# Android/iOS/Mac
+msgid "Brightest Stars"
+msgstr "星體"
+
+# Mac, System menu item, bring all windows to front
+msgid "Bring All to Front"
+msgstr "將此程式所有視窗移至最前"
+
+# Android/iOS/Mac, Object browser
+msgid "Browser"
+msgstr ""
+
+# Mac
+msgid "c (lightspeed)"
+msgstr "c (光速)"
+
+# Android/iOS, Calculating for eclipses
+msgid "Calculating…"
+msgstr ""
+
+# Android/iOS, Observer control
+msgid "Camera Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Cancel"
+msgstr "取消"
+
+# Android/iOS, Failed to add a favorite item (currently a bookmark)
+msgid "Cannot add object"
+msgstr ""
+
+# Mac, Record a video in Celestia
+msgid "Capture Video"
+msgstr "抓取影像"
+
+# Mac
+msgid "Celestia"
+msgstr "Celestia"
+
+# Mac, Object browser
+msgid "Celestia Browser"
+msgstr "Celestia 流覽器"
+
+# Mac
+msgid "Celestia Help"
+msgstr "Celestia 輔助說明"
+
+# Android/iOS/Mac, Center an object
+msgid "Center"
+msgstr ""
+
+# Mac, Center selected object
+msgid "Center Selection"
+msgstr "選取星體置中(&C)\tC"
+
+# Mac, Choose another location for celestia.cfg and data to load
+msgid "Change Config File"
+msgstr "Change Configuration File"
+
+# Android/iOS/Mac
+msgid "Chase"
+msgstr "追逐"
+
+# Mac, Choose location for celestia.cfg
+msgid "Choose Config File"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Circle"
+msgstr "圓形"
+
+# Android/iOS/Mac
+msgid "Cities"
+msgstr "城市"
+
+# Android/iOS/Mac
+msgid "Cloud Shadows"
+msgstr "雲層陰影"
+
+# Android/iOS/Mac
+msgid "Clouds"
+msgstr "雲層"
+
+# Android/iOS/Mac
+msgid "Comet Tails"
+msgstr "彗尾"
+
+# Android/iOS/Mac
+msgid "Comets"
+msgstr "彗星"
+
+# Android/iOS/Mac, celestia.cfg
+msgid "Config File"
+msgstr ""
+
+# Android/iOS, Change requires a restart
+msgid "Configuration will take effect after a restart."
+msgstr ""
+
+# Mac, Confirm and relaunch Celestia
+msgid "Confirm and Relaunch"
+msgstr "Confirm and Relaunch"
+
+# Android/iOS
+msgid "Constellation Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Constellations"
+msgstr "星座"
+
+# Android/iOS/Mac, display constellation labels in latin
+msgid "Constellations in Latin"
+msgstr "以拉丁文顯示星座"
+
+# Mac, Longitude and latitude (in Go to)
+msgid "Coordinate:"
+msgstr "Coordinate:"
+
+# Mac, Copy current URL to pasteboard
+msgid "Copy URL"
+msgstr "拷貝網址"
+
+# Android, Copying default data from APK
+msgid "Copying data…"
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Crater"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Crosshair"
+msgstr "Crosshair"
+
+# Android, Current display language
+msgid "Current Language"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Custom"
+msgstr ""
+
+# Android/iOS/Mac, Directory to load data from
+msgid "Data Directory"
+msgstr ""
+
+# Android/iOS, Title for celestia.cfg, data location setting
+msgid "Data Location"
+msgstr ""
+
+# Mac, The date that a specifc eclipse takes place
+msgid "Date"
+msgstr "日期"
+
+# Android/iOS
+msgid "Date Format"
+msgstr ""
+
+# Android/iOS, Debug menu
+msgid "Debug"
+msgstr ""
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "DEC: %d° %d′ %.2f″"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Deep Sky Objects"
+msgstr "深太空天體"
+
+# Androd/iOS/Mac
+msgid "Default"
+msgstr ""
+
+# Android/iOS
+msgid "Delete"
+msgstr "刪除"
+
+# Mac, Delete current view (in split view mode)
+msgid "Delete Active View"
+msgstr "刪除活動視窗"
+
+# Mac, Delete views other than current view (in split view mode)
+msgid "Delete Other Views"
+msgstr "刪除其他視窗"
+
+# iOS, Title for share link
+msgid "Description"
+msgstr "歷時"
+
+# Android/iOS, URL for Development wiki
+msgid "Development"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Diamond"
+msgstr "鑽石"
+
+# Mac, Camera direction
+msgid "Direction"
+msgstr "方向"
+
+# Android/iOS/Mac, Marker
+msgid "Disk"
+msgstr "碟形"
+
+# Android/iOS/Mac, Display settings
+msgid "Display"
+msgstr "顯示"
+
+# Mac
+msgid "Display Light Travel Delay"
+msgstr "顯示光速延遲"
+
+# Mac, Distance to the object (in Go to)
+msgid "Distance:"
+msgstr "距離:"
+
+# Mac, In eclipse finder
+msgid "Double click on item to go"
+msgstr "雙擊項目前往"
+
+# Mac, In bookmark organizer
+msgid "Double-click item to open or control-click for contextual menu. Drag items to reorganize."
+msgstr "雙擊項目打開或者按住 Control 鍵并點按項目可以打開上下文菜單。拖拽項目以重新組織。"
+
+# Mac, Pitch angle down
+msgid "Down"
+msgstr "下"
+
+# Android/iOS/Mac, Marker
+msgid "Down Arrow"
+msgstr "下箭號"
+
+# Android/iOS/Mac, Tab for deep sky objects in Star Browser
+msgid "DSOs"
+msgstr "深太空星體"
+
+# Mac, Duration for an eclipse
+msgid "Duration"
+msgstr "歷時"
+
+# Android/iOS/Mac
+msgid "Dwarf Planets"
+msgstr "矮行星"
+
+# Android/iOS/Mac
+msgid "Eclipse Finder"
+msgstr "食相尋找器"
+
+# Android/iOS/Mac
+msgid "Eclipse Shadows"
+msgstr "日月食陰影"
+
+# Android/iOS/Mac, Grids
+msgid "Ecliptic"
+msgstr "黃道"
+
+# iOS, Enter edit mode for favorite items
+msgid "Edit"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "End Time"
+msgstr ""
+
+# Mac, In eclipse finder
+msgid "Enter name of planet or moon"
+msgstr "鍵入行星名或衛星名"
+
+# Android/iOS/Mac, Grids
+msgid "Equatorial"
+msgstr "赤道"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Equatorial radius: %s"
+msgstr ""
+
+# Android/iOS
+msgid "Error loading data, fallback to original configuration."
+msgstr ""
+
+# Mac
+msgid "Failed to start OpenGL."
+msgstr ""
+
+# Mac
+msgid "Failed to start renderer."
+msgstr ""
+
+# Android/iOS/Mac, Control the faintest star that Celestia should display
+msgid "Faintest Stars"
+msgstr "Faintest Stars"
+
+# Mac, Make time go faster
+msgid "Faster"
+msgstr "較快"
+
+# Mac
+msgid "Fatal Error"
+msgstr ""
+
+# Android/iOS, Favorites (currently bookmarks and scripts)
+msgid "Favorites"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Features"
+msgstr "顯示特徵"
+
+# Mac, File menu
+msgid "File"
+msgstr "檔案"
+
+# Android/iOS/Mac, Marker
+msgid "Filled Square"
+msgstr "填滿的方形"
+
+# Android/iOS/Mac, Find (eclipses)
+msgid "Find"
+msgstr "尋找"
+
+# Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
+msgid "Find Eclipses cast on:"
+msgstr "搜尋日月食發生在："
+
+# Android/iOS/Mac
+msgid "Follow"
+msgstr "跟隨天體"
+
+# Mac, Format for time
+msgid "Format:"
+msgstr "格式："
+
+# Mac, Redo an operation
+msgid "Forward"
+msgstr "往前"
+
+# Mac, Frame rate for capturing video
+msgid "Frame rate:"
+msgstr "影像速率:"
+
+# Android/iOS/Mac, Star style
+msgid "Fuzzy Points"
+msgstr "模糊點(&U)"
+
+# Android/iOS/Mac, Grids
+msgid "Galactic"
+msgstr "銀河"
+
+# Android/iOS/Mac
+msgid "Galaxies"
+msgstr "星系"
+
+# Android/iOS/Mac
+msgid "Galaxies (Barred Spiral)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Elliptical)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Irregular)"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Galaxies (Spiral)"
+msgstr ""
+
+# Android/iOS, Render parameter
+msgid "Galaxy Brightness"
+msgstr ""
+
+# Mac, In settings
+msgid "General"
+msgstr "General"
+
+# Android/iOS
+msgid "Generating sharing link…"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Globulars"
+msgstr "球狀星團"
+
+# Android/iOS/Mac, Go to an object
+msgid "Go"
+msgstr ""
+
+# Mac
+msgid "Go to Object"
+msgstr "前往星體"
+
+# Mac
+msgid "Go to Object…"
+msgstr "前往星體…"
+
+# Mac, Go to selected object
+msgid "Go to Selection"
+msgstr "前往選定"
+
+# Android/iOS/Mac
+msgid "Grids"
+msgstr "格子"
+
+# Mac, Grids, labels, orbits, markers
+msgid "Guides"
+msgstr "遊歷指導"
+
+# Android/iOS/Mac, Indicate that an object has atmosphere
+msgid "Has atmosphere"
+msgstr ""
+
+# Android/iOS/Mac, Indicate that an object has rings
+msgid "Has rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Help"
+msgstr ""
+
+# Mac, System menu item, hide Celestia window
+msgid "Hide Celestia"
+msgstr "隱藏 Celestia"
+
+# Mac, System menu item, hide windows other than Celestia
+msgid "Hide Others"
+msgstr "隱藏其他"
+
+# Android/iOS/Mac, HiDPI support in display
+msgid "HiDPI"
+msgstr ""
+
+# Android/iOS/Mac, High resolution
+msgid "High"
+msgstr "高"
+
+# Mac, Operation history menu
+msgid "History"
+msgstr "瀏覽記錄"
+
+# Android/iOS/Mac, Home object, sun.
+msgid "Home (Sol)"
+msgstr "主地點 (太陽)"
+
+# Android/iOS/Mac, Grids
+msgid "Horizontal"
+msgstr "水平分割檢視"
+
+# Android/iOS
+msgid ""
+"In camera mode, drag to move field of view.\n"
+"\n"
+"Pinch to zoom in/out field of view."
+msgstr ""
+
+# Android/iOS
+msgid ""
+"In object mode, drag to rotate around an object.\n"
+"\n"
+"Pinch to zoom in/out on an object."
+msgstr ""
+
+# Mac, HUD display
+msgid "Info"
+msgstr "資訊(&I)"
+
+# Android/iOS, HUD display
+msgid "Info Display"
+msgstr ""
+
+# Mac, HUD display
+msgid "Info Display:"
+msgstr "Info Display:"
+
+# Android/iOS, Information of an object
+msgid "Information"
+msgstr ""
+
+# Mac, Set simulation time based on Julian date
+msgid "Julian Date:"
+msgstr "儒略曆："
+
+# Mac, Unit
+msgid "km"
+msgstr "公里"
+
+# Android/iOS/Mac, Galactic coordinates
+#, c-format
+msgid "L: %d° %d′ %.2f″"
+msgstr ""
+
+# Mac, Density of labels to display
+msgid "Label Density"
+msgstr "Label Density"
+
+# Mac, Labels to display
+msgid "Labels"
+msgstr "標記特徵"
+
+# Android/iOS/Mac, Location labels
+msgid "Landing Sites"
+msgstr "著陸點(Landing Sites)"
+
+# Android, Display language setting
+msgid "Language"
+msgstr ""
+
+# Mac, Coordinates
+msgid "Latitude"
+msgstr "Latitude"
+
+# Mac, Yaw angle left
+msgid "Left"
+msgstr "左"
+
+# Android/iOS/Mac, Marker
+msgid "Left Arrow"
+msgstr "左箭號"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Length of day: %s"
+msgstr ""
+
+# Android/iOS, Celestia loading failed
+#, c-format
+msgid "Loading Celestia failed…"
+msgstr ""
+
+# Android, Loading Celestia configuration
+#, c-format
+msgid "Loading configuration…"
+msgstr ""
+
+# Android/iOS, Celestia initialization, loading file
+#, c-format
+msgid "Loading: %s"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Local Time"
+msgstr "本地時間"
+
+# Mac, Menu, location for observation
+msgid "Location"
+msgstr "位置"
+
+# Mac, Type of locations to display
+msgid "Location Types"
+msgstr "Location Types"
+
+# Android/iOS/Mac, Location labels to display
+msgid "Locations"
+msgstr "位置"
+
+# Android/iOS
+msgid "Lock"
+msgstr "鎖定"
+
+# Mac
+msgid "Lock Phase"
+msgstr "鎖定"
+
+# Android/iOS
+msgid "Long press on stepper to change orientation."
+msgstr ""
+
+# Mac, Coordinates
+msgid "Longitude"
+msgstr "Longitude"
+
+# Mac, Reverse camera direction
+msgid "Look Back"
+msgstr "回顧"
+
+# Android/iOS/Mac, Low resolution
+msgid "Low"
+msgstr "低"
+
+# Android/iOS/Mac, Location labels
+msgid "Mare"
+msgstr "海(Mare)"
+
+# Android/iOS/Mac, Mark an object
+msgid "Mark"
+msgstr "Mark"
+
+# Mac
+msgid "Markers"
+msgstr "標記"
+
+# Mac, Mass of an object
+msgid "Mass"
+msgstr ""
+
+# Android/iOS/Mac, Medium resolution
+msgid "Medium"
+msgstr "中"
+
+# Mac, System menu item, minimize window
+msgid "Minimize"
+msgstr "縮到最小"
+
+# Android/iOS, Minimum feature size that we should display a label for
+msgid "Minimum Labelled Feature Size"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Minor Moons"
+msgstr "小行星衛星 (二重小行星)"
+
+# Android/iOS/Mac, Location labels
+msgid "Mons"
+msgstr "山(Mons)"
+
+# Android/iOS/Mac
+msgid "Moons"
+msgstr "衛星"
+
+# Mac, Move closer to the object
+msgid "Move Closer"
+msgstr "Move Closer"
+
+# Mac, Move farther away from the object
+msgid "Move Farther"
+msgstr "Move Farther"
+
+# Mac, Name of an object
+msgid "Name"
+msgstr "名稱"
+
+# Android/iOS/Mac
+msgid "Nearest Stars"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Nebulae"
+msgstr "星雲"
+
+# Mac, Create a folder in bookmark organizer
+msgid "New Folder"
+msgstr "新資料夾…"
+
+# Android/iOS/Mac
+msgid "Night Lights"
+msgstr ""
+
+# iOS, No data received for a request
+msgid "No data"
+msgstr ""
+
+# Mac, In Go to
+msgid "No object name entered"
+msgstr ""
+
+# Android/iOS/Mac, No overview for an object
+msgid "No overview available."
+msgstr ""
+
+# iOS, No response received for a request
+msgid "No response"
+msgstr ""
+
+# Android/iOS/Mac, Empty HUD display
+msgid "None"
+msgstr "無"
+
+# Mac, Hint for specifying time in eclipse finder
+msgid ""
+"Note:\n"
+"Specifying a large time interval may cause long search times and a very large number of results."
+msgstr ""
+"注意：\n"
+"分析較長時間內將會嚴懲分析的時間并產生大量結果。"
+
+# Android/iOS, In eclipse finder, object to find eclipse with
+msgid "Object"
+msgstr ""
+
+# Android/iOS, Labels
+msgid "Object Labels"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Object not found"
+msgstr ""
+
+# Mac, In Go to
+msgid "Object:"
+msgstr "星體："
+
+# Android/iOS
+msgid "Objects"
+msgstr "天體"
+
+# Android/iOS/Mac, Location labels
+msgid "Observatories"
+msgstr "天文臺"
+
+# Mac, In eclipse finder
+msgid "Occulter"
+msgstr ""
+
+# Android/iOS
+msgid "Official Website"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "OK"
+msgstr "確定"
+
+# Android/iOS/Mac
+msgid "Open Clusters"
+msgstr "疏散星團"
+
+# Android/iOS/Mac, Request user consent to open a URL
+msgid "Open URL?"
+msgstr ""
+
+# Mac, Open web URL for an object
+msgid "Open Web URL"
+msgstr "Open Web URL"
+
+# Mac
+msgid "OpenGL Info"
+msgstr "OpenGL 資訊"
+
+# Android
+msgid "Opening external file or URL…"
+msgstr ""
+
+# iOS
+msgid "Operation not permitted."
+msgstr ""
+
+# Mac
+msgid "Orbit Synchronously"
+msgstr "同步軌道"
+
+# Android/iOS/Mac
+msgid "Orbits"
+msgstr "軌道"
+
+# Mac
+msgid "Organize Bookmarks…"
+msgstr "Organize Bookmarks…"
+
+# Mac, Other location labels
+msgid "Other"
+msgstr "其他"
+
+# Android/iOS, Other settings
+msgid "Others"
+msgstr ""
+
+# Mac, Paste URL from pasteboard
+msgid "Paste URL"
+msgstr "貼上網址"
+
+# Mac, Pause time
+msgid "Pause"
+msgstr "Pause"
+
+# Android/iOS/Mac, Camera control
+msgid "Pitch"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planet Rings"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Planets"
+msgstr "行星"
+
+# Mac, In Go to/Eclipse Finder
+msgid "Please check that the object name is correct."
+msgstr ""
+
+# Android/iOS, In eclipse finder, choose an object to find eclipse wth
+msgid "Please choose an object."
+msgstr ""
+
+# iOS, Message for sharing a URL
+msgid "Please enter a description of the content."
+msgstr ""
+
+# iOS, Message for renaming a favorite item (currently bookmark)
+msgid "Please enter a new name."
+msgstr ""
+
+# Mac, In Go to
+msgid "Please enter an object name."
+msgstr ""
+
+# Android/iOS
+#, c-format
+msgid "Please enter the time in \"%s\" format."
+msgstr ""
+
+# Android, Possibly due to memory issue, Celestia needs to be restarted
+msgid "Please restart Celestia"
+msgstr ""
+
+# Android/iOS/Mac, Marker
+msgid "Plus"
+msgstr "加號"
+
+# Android/iOS/Mac, Star style
+msgid "Points"
+msgstr "點(&P)"
+
+# Mac, Settings window title
+msgid "Preferences"
+msgstr "Preference"
+
+# Mac, Settings
+msgid "Preferences…"
+msgstr "偏好設定⋯"
+
+# Mac, Quit Celestia
+msgid "Quit"
+msgstr "基多"
+
+# Mac, System menu item
+msgid "Quit Celestia"
+msgstr "結束 Celestia"
+
+# Android/iOS/Mac, Equatorial coordinate
+#, c-format
+msgid "RA: %dh %dm %.2fs"
+msgstr ""
+
+# Mac, In Go to, specify the distance based on the object radius
+msgid "radii"
+msgstr "半徑"
+
+# Mac, Radius of an object
+msgid "Radius"
+msgstr ""
+
+# Mac, Reset time speed to 1x
+msgid "Real Time"
+msgstr "實時"
+
+# Mac, In Eclipse Finder
+msgid "Receiver"
+msgstr "Receiver"
+
+# Android/iOS/Mac, Reference vectors for an object
+msgid "Reference Vectors"
+msgstr ""
+
+# Android/iOS
+msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android, Rename a favorite item (currently bookmark)
+msgid "Rename"
+msgstr ""
+
+# Android/iOS, Information about renderer
+msgid "Render Info"
+msgstr ""
+
+# Android/iOS, Render parameters in setting
+msgid "Render Parameters"
+msgstr ""
+
+# Mac, In settings
+msgid "Renderer"
+msgstr "Renderer"
+
+# Android, Finished requesting permission needed for Celestia
+msgid "Requesting permission finished"
+msgstr ""
+
+# Mac, Run the previous script again
+msgid "Rerun Script"
+msgstr "重新執行工序指令"
+
+# Mac, Reset celestia.cfg, data directory location
+msgid "Reset"
+msgstr "Reset"
+
+# Android/iOS, Reset celestia.cfg, data directory location
+msgid "Reset to Default"
+msgstr ""
+
+# Mac, Resolution for capturing video
+msgid "Resolution:"
+msgstr "解析度: "
+
+# Mac, Traveling backward
+msgid "Reverse"
+msgstr "向後"
+
+# Android/iOS, Reverse camera direction
+msgid "Reverse Direction"
+msgstr ""
+
+# Mac, Yaw angle right
+msgid "Right"
+msgstr "右"
+
+# Android/iOS/Mac, Marker
+msgid "Right Arrow"
+msgstr "右箭號"
+
+# Android/iOS/Mac
+msgid "Ring Shadows"
+msgstr "環狀陰影"
+
+# Android/iOS/Mac, Camera control
+msgid "Roll"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Run Demo"
+msgstr ""
+
+# Android/iOS/Mac, Request user consent to run a script
+msgid "Run script?"
+msgstr ""
+
+# Mac
+msgid "Run Script…"
+msgstr "執行工序指令"
+
+# Android/iOS/Mac, Star style
+msgid "Scaled Discs"
+msgstr "按比例的盤面(&D)"
+
+# Android/iOS
+msgid "Script Control"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Scripts"
+msgstr "腳本"
+
+# Android/iOS, URL for Scripts and URLs wiki
+msgid "Scripts and URLs"
+msgstr ""
+
+# Android/iOS
+msgid "Search"
+msgstr "搜尋"
+
+# Android/iOS/Mac, Select an object
+msgid "Select"
+msgstr ""
+
+# Mac, Select next view (in split view)
+msgid "Select Next View"
+msgstr "選擇下個視窗"
+
+# Android, Select simulation time
+msgid "Select Time"
+msgstr ""
+
+# Mac, System menu
+msgid "Services"
+msgstr "服務"
+
+# Mac, Button to confirm selected simulation time
+msgid "Set Time"
+msgstr "設定時間…"
+
+# Mac, Select simulation time
+msgid "Set Time…"
+msgstr "設定時間…"
+
+# Android/iOS, Set simulation time to device
+msgid "Set to Current Time"
+msgstr ""
+
+# Android/iOS
+msgid "Settings"
+msgstr "設定"
+
+# Android/iOS, Share a URL
+msgid "Share"
+msgstr ""
+
+# Mac, System menu item, Show all windows
+msgid "Show All"
+msgstr "顯示全部"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Body Axes"
+msgstr "顯示天體轉軸"
+
+# Android/iOS/Mac, Show constellation boundaries
+msgid "Show Boundaries"
+msgstr "顯示界限"
+
+# Mac
+msgid "Show Constellation Labels"
+msgstr "顯示星座標記"
+
+# Mac
+msgid "Show Constellations"
+msgstr "顯示星座"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Frame Axes"
+msgstr "顯示系統轉軸"
+
+# Mac, Show info for an object
+msgid "Show Info"
+msgstr "顯示簡介"
+
+# Mac
+msgid "Show Locations"
+msgstr "顯示位置"
+
+# Android/iOS/Mac
+msgid "Show Markers"
+msgstr "標記"
+
+# Mac
+msgid "Show Orbits"
+msgstr "Show Orbits"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Planetographic Grid"
+msgstr "顯示行星格線"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Sun Direction"
+msgstr "顯示太陽方向"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Terminator"
+msgstr "顯示晝夜界線"
+
+# Android/iOS/Mac, Reference vector
+msgid "Show Velocity Vector"
+msgstr "顯示速度向量"
+
+# Android/iOS/Mac
+#, c-format
+msgid "Sidereal rotation period: %s"
+msgstr ""
+
+# Android/iOS/Mac, Size of an object
+#, c-format
+msgid "Size: %s"
+msgstr ""
+
+# Mac, Make time go more slowly
+msgid "Slower"
+msgstr "較慢"
+
+# Mac, Smooth lines for rendering
+msgid "Smooth Lines"
+msgstr " 線性平滑"
+
+# Android/iOS/Mac, Tab for solar system in Star Browser
+msgid "Solar System"
+msgstr "太陽系"
+
+# Android/iOS/Mac, Plural
+msgid "Spacecraft"
+msgstr "太空船"
+
+# Mac, Split view
+msgid "Split Horizontally"
+msgstr "水平分割"
+
+# Mac, Split view
+msgid "Split Vertically"
+msgstr "垂直分割"
+
+# Android/iOS/Mac, Marker
+msgid "Square"
+msgstr "方形"
+
+# Android/iOS/Mac
+msgid "Star Style"
+msgstr "恆星樣式"
+
+# Mac
+msgid "Star Style:"
+msgstr "Star Style:"
+
+# Android/iOS/Mac
+msgid "Stars"
+msgstr "星體"
+
+# Android/iOS/Mac
+msgid "Stars with Planets"
+msgstr ""
+
+# Android/iOS, In eclipse finder, range of time to find eclipse in
+msgid "Start Time"
+msgstr ""
+
+# Mac, Interupt the process of finding eclipse
+msgid "Stop"
+msgstr "停止"
+
+# Android/iOS, Subsystem of an object (e.g. planetarium system)
+msgid "Subsystem"
+msgstr ""
+
+# Android/iOS
+msgid "Support Forum"
+msgstr ""
+
+# Android/iOS, Move/zoom camera FOV
+msgid "Switched to camera mode"
+msgstr ""
+
+# Android/iOS, Move/zoom on an object
+msgid "Switched to object mode"
+msgstr ""
+
+# Android/iOS
+msgid "Sync Orbit"
+msgstr "同步軌道"
+
+# Android/iOS
+msgid "Tap the mode button on the sidebar to switch between object mode and camera mode."
+msgstr ""
+
+# Android/iOS/Mac, Location labels
+msgid "Terra"
+msgstr "台地(Terra)"
+
+# Android/iOS/Mac, Terse HUD display
+msgid "Terse"
+msgstr "精簡"
+
+# Android/iOS/Mac
+msgid "Texture Resolution"
+msgstr ""
+
+# Mac
+msgid "Texture Resolution:"
+msgstr "Texture Resolution:"
+
+# Android/iOS, URL for Third Party Dependencies wiki
+msgid "Third Party Dependencies"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Time"
+msgstr "時間"
+
+# Android/iOS
+msgid "Time Control"
+msgstr ""
+
+# Android/iOS
+msgid "Time Zone"
+msgstr ""
+
+# Mac
+msgid "Time Zone:"
+msgstr "時區："
+
+# Mac, Set simulation time based on Julian date
+msgid "Time:"
+msgstr "時間："
+
+# Android/iOS, Toggle console log display on overlay
+msgid "Toggle Console Display"
+msgstr ""
+
+# Android/iOS, Toggle FPS display on overlay
+msgid "Toggle FPS Display"
+msgstr ""
+
+# Mac, Track an object
+msgid "Track"
+msgstr "追蹤"
+
+# Mac, Track selected object
+msgid "Track Selection"
+msgstr "跟隨所選"
+
+# Android/iOS, Translators for Celestia
+msgid "Translators"
+msgstr ""
+
+# Mac, Travel menu
+msgid "Travel"
+msgstr "旅行"
+
+# Android/iOS/Mac, Marker
+msgid "Triangle"
+msgstr "三角形"
+
+# Android/iOS
+msgid "Tutorial"
+msgstr ""
+
+# Mac, Type of a star
+msgid "Type"
+msgstr "類型"
+
+# Mac
+msgid "Unable to capture video"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "Unknown"
+msgstr "開啟腳本時發生未知的錯誤"
+
+# iOS
+msgid "Unknown error"
+msgstr ""
+
+# Android/iOS/Mac, Unmark an object
+msgid "Unmark"
+msgstr "Unmark"
+
+# Android/iOS, Unmark all objects
+msgid "Unmark All"
+msgstr ""
+
+# Android/iOS, String not in correct format
+msgid "Unrecognized time string."
+msgstr ""
+
+# Mac, Default name for a newly created folder
+msgid "Untitled"
+msgstr ""
+
+# Mac, Pitch angle up
+msgid "Up"
+msgstr "上"
+
+# Android/iOS/Mac, Marker
+msgid "Up Arrow"
+msgstr "上箭號"
+
+# Android/iOS, URL for Use Add-ons and Scripts wiki
+msgid "Use Add-ons and Scripts"
+msgstr ""
+
+# Android/iOS/Mac
+msgid "UTC"
+msgstr "世界協調時間(UTC)"
+
+# Android/iOS/Mac
+msgid "UTC Offset"
+msgstr "與世界協調時間的差異"
+
+# Android/iOS/Mac, Location labels
+msgid "Vallis"
+msgstr "峽谷(Vallis)"
+
+# Mac, Menu for velocity of traveling
+msgid "Velocity"
+msgstr "速度"
+
+# Android/iOS/Mac, Verbose HUD display
+msgid "Verbose"
+msgstr "詳細"
+
+# Android/iOS
+msgid "Version"
+msgstr ""
+
+# Mac, Menu for split views
+msgid "Views"
+msgstr "視角"
+
+# Android/iOS/Mac, Location labels
+msgid "Volcanoes"
+msgstr "火山"
+
+# Android/iOS, Web info for an object
+msgid "Web Info"
+msgstr ""
+
+# Android/iOS, Welcome message
+msgid "Welcome to Celestia"
+msgstr ""
+
+# Mac, System menu, window management
+msgid "Window"
+msgstr "視窗"
+
+# Android/iOS/Mac, Marker
+msgid "X"
+msgstr "X"
+
+# Android/iOS/Mac, Camera control
+msgid "Yaw"
+msgstr ""
+
+# Android/iOS, Zoom in/out on FOV/object  Mac, System menu item, Zoom a window
+msgid "Zoom"
+msgstr "Zoom"

--- a/po3/zh_TW.po
+++ b/po3/zh_TW.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Ambient Light"
 msgstr "環境光"
 
+# iOS
+msgid "An external screen is connected, do you want to display Celestia on the external screen?"
+msgstr ""
+
 # Mac, Used in "Find Eclipses cast on: ... Between: ... and:"
 msgid "and:"
 msgstr "和:"
@@ -473,6 +477,10 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# iOS
+msgid "Failed to connect to the external screen."
 msgstr ""
 
 # Android/iOS

--- a/po3/zh_TW.po
+++ b/po3/zh_TW.po
@@ -80,6 +80,14 @@ msgstr "新增書籤"
 msgid "Add new…"
 msgstr ""
 
+# iOS
+msgid "Add-on directory does not exist."
+msgstr ""
+
+# Android/iOS
+msgid "Add-ons"
+msgstr ""
+
 # Mac
 msgid "Add/Subtract Light Travel Delay"
 msgstr "增加/減少光速延遲"
@@ -188,6 +196,10 @@ msgstr ""
 # Mac, Record a video in Celestia
 msgid "Capture Video"
 msgstr "抓取影像"
+
+# Android/iOS, Add-on categories
+msgid "Categories"
+msgstr ""
 
 # Mac
 msgid "Celestia"
@@ -378,6 +390,14 @@ msgstr "顯示光速延遲"
 msgid "Distance:"
 msgstr "距離:"
 
+# Android/iOS, Prompt to ask to cancel downloading an add-on
+msgid "Do you want to cancel this task?"
+msgstr ""
+
+# Android/iOS
+msgid "Do you want to uninstall this add-on?"
+msgstr ""
+
 # Mac, In eclipse finder
 msgid "Double click on item to go"
 msgstr "雙擊項目前往"
@@ -393,6 +413,14 @@ msgstr "下"
 # Android/iOS/Mac, Marker
 msgid "Down Arrow"
 msgstr "下箭號"
+
+# Android/iOS, Download button when the add-on is not downloaded
+msgid "DOWNLOAD"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is being downloaded
+msgid "DOWNLOADING"
+msgstr ""
 
 # Android/iOS/Mac, Tab for deep sky objects in Star Browser
 msgid "DSOs"
@@ -445,6 +473,18 @@ msgstr ""
 
 # Android, Exit Celestia
 msgid "Exit"
+msgstr ""
+
+# Android/iOS
+msgid "Failed to download or install this add-on."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-on categories."
+msgstr ""
+
+# Android/iOS
+msgid "Failed to load add-ons."
 msgstr ""
 
 # Mac
@@ -645,6 +685,14 @@ msgstr "Info Display:"
 msgid "Information"
 msgstr ""
 
+# Android/iOS, Title for the list of installed add-ons
+msgid "Installed"
+msgstr ""
+
+# Android/iOS, Download button when the add-on is installed
+msgid "INSTALLED"
+msgstr ""
+
 # Mac, Set simulation time based on Julian date
 msgid "Julian Date:"
 msgstr "儒略曆："
@@ -834,6 +882,10 @@ msgstr ""
 msgid "None"
 msgstr "無"
 
+# Android/iOS
+msgid "Note: restarting Celestia is needed to use any new installed add-on."
+msgstr ""
+
 # Mac, Hint for specifying time in eclipse finder
 msgid ""
 "Note:\n"
@@ -1022,6 +1074,10 @@ msgstr ""
 
 # Android/iOS
 msgid "Reference vectors are only visible for the current selected solar system object."
+msgstr ""
+
+# Android/iOS, Button to refresh this list
+msgid "Refresh"
 msgstr ""
 
 # Android, Rename a favorite item (currently bookmark)
@@ -1372,6 +1428,15 @@ msgstr "類型"
 
 # Mac
 msgid "Unable to capture video"
+msgstr ""
+
+# Android, Custom config/data directory path have to be under a specific path
+#, c-format
+msgid "Unable to resolve path, please ensure that you have selected a path inside %s."
+msgstr ""
+
+# Android/iOS
+msgid "Unable to uninstall add-on."
 msgstr ""
 
 # Android/iOS/Mac

--- a/po3/zh_TW.po
+++ b/po3/zh_TW.po
@@ -443,6 +443,10 @@ msgstr ""
 msgid "Error loading data, fallback to original configuration."
 msgstr ""
 
+# Android, Exit Celestia
+msgid "Exit"
+msgstr ""
+
 # Mac
 msgid "Failed to start OpenGL."
 msgstr ""


### PR DESCRIPTION
This change is specific for the Mobile version of Celestia and this PR makes the subtitles (hopefully) better suited for devices with smaller screens. This PR makes the subtitles on multiple rows.

@levinli303 This changes are only for the Mobile version (iOS and Android) and they are for the Bulgarian version of the demo only. The desktop version is fine as it is. I had not tested it but I believe it should be fine now.

Regards,
Georgi